### PR TITLE
Add user manager credentials test

### DIFF
--- a/backend/apps/core/tests/managers/user_manager.py
+++ b/backend/apps/core/tests/managers/user_manager.py
@@ -1,13 +1,20 @@
 # core/tests/managers/user_manager.py
 import pytest
 
+from apps.core.models import User
+
 
 @pytest.mark.django_db
 @pytest.mark.asyncio
 async def test_user_by_creds():
-    # user = await UserFactory.acreate()
-    # email_user = await User.objects.by_creds(credential=user.email)
-    # phone_user = await User.objects.by_creds(credential=str(user.phone))
-    # assert email_user == user
-    # assert phone_user == user
-    pass  # TODO не верно
+    user = await User.objects.acreate(
+        username="testuser",
+        email="test@example.com",
+        phone="+71234567890",
+    )
+
+    email_user = await User.objects.by_creds(credential=user.email)
+    phone_user = await User.objects.by_creds(credential=str(user.phone))
+
+    assert email_user == user
+    assert phone_user == user


### PR DESCRIPTION
## Summary
- implement test for `User.objects.by_creds`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'adjango', ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68425f5374d483309a293140c1c074b0