### PR TITLE
Return success response on ID change

### DIFF
--- a/backend/apps/core/controllers/health.py
+++ b/backend/apps/core/controllers/health.py
@@ -182,6 +182,7 @@ def change_user_id(request, new_id):
     if not request.user or not request.user.is_authenticated or not request.user.is_staff:
         return JsonResponse({'error': 'Access denied'}, status=HTTP_403_FORBIDDEN)
     request.user.change_id(new_id)
+    return JsonResponse({'status': 'id changed'}, status=HTTP_200_OK)
 
 
 async def run_collectstatic(request):

--- a/backend/apps/core/tests/test_health.py
+++ b/backend/apps/core/tests/test_health.py
@@ -1,0 +1,17 @@
+from django.test import TestCase
+
+from apps.core.models import User
+
+
+class ChangeUserIdViewTest(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username='staff', password='pass', is_staff=True
+        )
+        self.client.force_login(self.user)
+
+    def test_change_user_id_returns_200(self):
+        url = f'/change_user_id/{self.user.id}/'
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+


### PR DESCRIPTION
## Summary
- return HTTP 200 JsonResponse from `change_user_id`
- test that the view works for staff users

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68425f313d948330ac87ee7c6488ba2e