### PR TITLE
Fix quoting and refine software string

### DIFF
--- a/backend/apps/core/confirmations/actions.py
+++ b/backend/apps/core/confirmations/actions.py
@@ -26,26 +26,26 @@ actions = {
     CoreConfirmationActionType.AUTH: ConfirmationAction(
         subject=f'xlartas | {_('Confirm auth')}',
         text=f'{_('Код подтверждения для входа в вашу учетную запись')}',
-        func=auth_by_confirmation_code
+        func=auth_by_confirmation_code,
     ),
     CoreConfirmationActionType.SIGNUP: ConfirmationAction(
         subject=f'xlartas | {_('Confirm Registration')}',
         text=f'{_('Код подтверждения для регистрации')}',
-        func=signup_by_confirmation_code
+        func=signup_by_confirmation_code,
     ),
     CoreConfirmationActionType.NEW_PASSWORD: ConfirmationAction(
         subject=f'xlartas | {_('Set new password')}',
         text=f'{_('Код подтверждения для нового пароля')}',
-        func=set_new_password_by_confirmation_code
+        func=set_new_password_by_confirmation_code,
     ),
     CoreConfirmationActionType.NEW_EMAIL: ConfirmationAction(
         subject=f'xlartas | {_('Add new email address')}',
         text=f'{_('Код подтверждения для добавления почты')}',
-        func=confirm_email_action
+        func=confirm_email_action,
     ),
     CoreConfirmationActionType.NEW_PHONE: ConfirmationAction(
         subject=f'xlartas | {_('Add new phone number')}',
         text=f'{_('Код подтверждения для добавления телефона')} {settings.MAIN_DOMAIN}',
-        func=confirm_phone_action
+        func=confirm_phone_action,
     ),
 }

--- a/backend/apps/notify/managers/notify.py
+++ b/backend/apps/notify/managers/notify.py
@@ -32,9 +32,9 @@ class NotifyManager(AManager):
             context=context,
         )
         log.info(
-            f'Создано{' отложенное' if not send_immediately else ''} '
-            f'уведомление id={notify.id} для пользователя {recipient.id} '
-            f'| {context=}'
+            f"Создано{' отложенное' if not send_immediately else ''} "
+            f"уведомление id={notify.id} для пользователя {recipient.id} "
+            f"| {context=}"
         )
 
         if send_immediately or scheduled_time <= timezone.now():

--- a/backend/apps/notify/services/notify.py
+++ b/backend/apps/notify/services/notify.py
@@ -43,10 +43,14 @@ class NotifyService:
                 if not settings.DEBUG and not self.recipient.is_test:
                     provider.send(self.recipient, context, self.notify_type)
                 else:
-                    log.info(f'Notify {provider.name} for {self.recipient} {context} sent \n'
-                             f'Rendered text:{render_to_string(
-                                 f'notify/{provider.name}/{self.notify_type}.html', context
-                             )}')
+                    rendered = render_to_string(
+                        f"notify/{provider.name}/{self.notify_type}.html",
+                        context,
+                    )
+                    log.info(
+                        f"Notify {provider.name} for {self.recipient} {context} sent \n"
+                        f"Rendered text:{rendered}"
+                    )
 
             self.status = self.Status.SENT
             self.sent_time = timezone.now()  # noqa

--- a/backend/apps/software/models/software.py
+++ b/backend/apps/software/models/software.py
@@ -48,7 +48,7 @@ class Software(Product, SoftwareService, SoftwareException):
         verbose_name_plural = _('Softwares')
 
     def __str__(self):
-        return f'{self.name} {f'(v{self.file.version})' if self.file else ''}'
+        return f'{self.name} (v{self.file.version})' if self.file else self.name
 
 
 class SoftwareOrder(Order, SoftwareOrderService):


### PR DESCRIPTION
## Summary
- address review comments in confirmation actions
- refine `Software.__str__` formatting

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'adjango')*

------
https://chatgpt.com/codex/tasks/task_e_68425cdc15cc8330a20144824d2ffd41