### PR TITLE
Fix error logging and keep traceback

### DIFF
--- a/backend/apps/core/middleware/__init__.py
+++ b/backend/apps/core/middleware/__init__.py
@@ -4,15 +4,19 @@ from channels.middleware import BaseMiddleware
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AnonymousUser
 from rest_framework_simplejwt.tokens import AccessToken
+import logging
 
 User = get_user_model()
+
+log = logging.getLogger('global')
 
 
 async def get_user_from_token(token):
     try:
         return await User.objects.aget(id=AccessToken(token)['user_id'])
-    except Exception as e:
-        raise e
+    except Exception:
+        log.exception('Error retrieving user from token')
+        raise
 
 
 class JWTAuthMiddleware(BaseMiddleware):

--- a/backend/apps/filehost/controllers/base.py
+++ b/backend/apps/filehost/controllers/base.py
@@ -1,6 +1,7 @@
 # filehost/controllers/base.py
 import os
 import shutil
+import logging
 
 from adjango.adecorators import acontroller
 from adrf.decorators import api_view
@@ -16,6 +17,8 @@ from apps.filehost.exceptions.base import IdWasNotProvided
 from apps.filehost.models import Folder, File
 from apps.filehost.serializers import FileSerializer, FolderSerializer
 from apps.filehost.services.base import create_archive, get_tags, get_folders, get_files
+
+log = logging.getLogger('global')
 
 
 @acontroller('Download File')
@@ -56,8 +59,9 @@ async def download_archive(request):
         with open(archive_path, 'rb') as archive:
             response = HttpResponse(archive.read(), content_type='application/octet-stream')
             response['Content-Disposition'] = f'attachment; filename="{os.path.basename(archive_path)}"'
-    except Exception as e:
-        raise e
+    except Exception:
+        log.exception('Error while creating archive')
+        raise
         # return Response({'error': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
     finally:
         if temp_dir:


### PR DESCRIPTION
## Summary
- log errors in auth middleware and file downloads
- rethrow exceptions without losing traceback

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6842e8330ac08330ad6267ce7d053140