### PR TITLE
Improve date parsing error handling

### DIFF
--- a/backend/apps/analytics/controllers/graphics.py
+++ b/backend/apps/analytics/controllers/graphics.py
@@ -1,6 +1,11 @@
 # analytics/controllers/graphics.py
 import json
+import logging
 from datetime import datetime
+
+from django.http import HttpResponseBadRequest
+
+logger = logging.getLogger(__name__)
 
 from django.contrib.admin.views.decorators import staff_member_required
 from django.db.models import Count, Q
@@ -24,14 +29,16 @@ def visits_chart(request):
         try:
             start_date = datetime.strptime(start_date_str, date_format)
             filters['created_at__gte'] = start_date
-        except Exception:  # noqa
-            pass
+        except ValueError as exc:
+            logger.warning("Invalid start_date %s: %s", start_date_str, exc)
+            return HttpResponseBadRequest("Invalid start_date")
     if end_date_str:
         try:
             end_date = datetime.strptime(end_date_str, date_format)
             filters['created_at__lte'] = end_date
-        except Exception:  # noqa
-            pass
+        except ValueError as exc:
+            logger.warning("Invalid end_date %s: %s", end_date_str, exc)
+            return HttpResponseBadRequest("Invalid end_date")
 
     # Определяем функцию группировки и формат метки
     if group_by == 'hour':
@@ -90,14 +97,16 @@ def orders_chart(request):
         try:
             start_date = datetime.strptime(start_date_str, date_format)
             filters['created_at__gte'] = start_date
-        except Exception:  # noqa
-            pass
+        except ValueError as exc:
+            logger.warning("Invalid start_date %s: %s", start_date_str, exc)
+            return HttpResponseBadRequest("Invalid start_date")
     if end_date_str:
         try:
             end_date = datetime.strptime(end_date_str, date_format)
             filters['created_at__lte'] = end_date
-        except Exception:  # noqa
-            pass
+        except ValueError as exc:
+            logger.warning("Invalid end_date %s: %s", end_date_str, exc)
+            return HttpResponseBadRequest("Invalid end_date")
 
     # Определяем функцию группировки и формат метки для заказов
     if group_by == 'hour':

--- a/backend/apps/xlmine/models.py
+++ b/backend/apps/xlmine/models.py
@@ -1,5 +1,6 @@
 # xlmine/models.py
 import hashlib
+import logging
 
 from adjango.models import AModel
 from adjango.models.mixins import ACreatedUpdatedAtMixin
@@ -15,7 +16,8 @@ def increment_version(version_str: str) -> str:
         major, minor, patch = map(int, parts[:3])
         minor += 1
         return f"{major}.{minor}.{patch}"
-    except Exception:
+    except Exception as exc:
+        logging.getLogger(__name__).warning("Failed to increment version %s: %s", version_str, exc)
         return "1.0.0"
 
 

--- a/backend/utils/timezone.py
+++ b/backend/utils/timezone.py
@@ -72,5 +72,6 @@ def parse_and_convert(date_str, user_timezone):
     try:
         dt = dt.astimezone(user_tz)
         return dt
-    except Exception:  # noqa
+    except Exception as exc:  # noqa
+        logger.warning("Failed to convert timezone: %s", exc)
         return None


### PR DESCRIPTION
## Summary
- validate analytics date parameters and return `HttpResponseBadRequest`
- log timezone conversion errors
- log version increment errors

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6842e82a7e5c83309ab2f024f326ca3d