### PR TITLE
Implement pregive logic and tests

### DIFF
--- a/backend/apps/software/tests/test_services.py
+++ b/backend/apps/software/tests/test_services.py
@@ -1,0 +1,60 @@
+import pytest
+from django.utils import timezone
+from datetime import timedelta
+
+from apps.core.models import User
+from apps.software.models import Software, SoftwareOrder, SoftwareLicense
+from apps.commerce.models.product import ProductPrice
+from apps.commerce.models.payment import Currency, PaymentSystem
+
+@pytest.mark.django_db
+@pytest.mark.asyncio
+async def test_postgive_creates_license_and_extends():
+    user = await User.objects.acreate(username="u1")
+    software = await Software.objects.acreate(name="Soft", min_license_order_hours=1)
+    await ProductPrice.objects.acreate(product=software, amount=10, currency=Currency.RUB)
+
+    order = await SoftwareOrder.objects.acreate(
+        user=user,
+        product=software,
+        currency=Currency.RUB,
+        payment_system=PaymentSystem.HandMade,
+        license_hours=2,
+    )
+
+    await software.postgive(order)
+    license_obj = await SoftwareLicense.objects.aget(user=user, software=software)
+    assert license_obj.license_ends_at is not None
+    assert abs((license_obj.license_ends_at - timezone.now()) - timedelta(hours=2)) < timedelta(seconds=5)
+
+    prev_end = license_obj.license_ends_at
+    order2 = await SoftwareOrder.objects.acreate(
+        user=user,
+        product=software,
+        currency=Currency.RUB,
+        payment_system=PaymentSystem.HandMade,
+        license_hours=3,
+    )
+    await software.postgive(order2)
+    await license_obj.arefresh_from_db()
+    assert abs((license_obj.license_ends_at - prev_end) - timedelta(hours=3)) < timedelta(seconds=5)
+
+@pytest.mark.django_db
+@pytest.mark.asyncio
+async def test_can_pregive_checks():
+    user = await User.objects.acreate(username="u2")
+    software = await Software.objects.acreate(name="Soft2", min_license_order_hours=5)
+    await ProductPrice.objects.acreate(product=software, amount=10, currency=Currency.RUB)
+    order = await SoftwareOrder.objects.acreate(
+        user=user,
+        product=software,
+        currency=Currency.RUB,
+        payment_system=PaymentSystem.HandMade,
+        license_hours=4,
+    )
+    assert await software.can_pregive(order) is False
+    with pytest.raises(Exception):
+        await software.can_pregive(order, raise_exceptions=True)
+
+    order.license_hours = 6
+    assert await software.can_pregive(order) is True

--- a/backend/apps/xlmine/tests/test_donate_service.py
+++ b/backend/apps/xlmine/tests/test_donate_service.py
@@ -1,0 +1,29 @@
+import pytest
+from decimal import Decimal
+
+from apps.core.models import User
+from apps.xlmine.models import Donate, DonateOrder, UserXLMine
+from apps.commerce.models.payment import Currency, PaymentSystem
+
+@pytest.mark.django_db
+@pytest.mark.asyncio
+async def test_postgive_adds_coins_and_profile_created():
+    user = await User.objects.acreate(username="don")
+    donate = await Donate.objects.acreate(name="Donate", is_available=True)
+
+    order = await DonateOrder.objects.acreate(
+        user=user,
+        product=donate,
+        currency=Currency.RUB,
+        payment_system=PaymentSystem.HandMade,
+    )
+
+    await donate.pregive(order)
+    await donate.postgive(order)
+
+    xlm_user = await UserXLMine.objects.aget(user=user)
+    assert xlm_user.coins == Decimal("0")
+
+    await donate.postgive(order)
+    await xlm_user.arefresh_from_db()
+    assert xlm_user.coins >= Decimal("0")


### PR DESCRIPTION
## Summary
- validate software orders before initialization
- create placeholder license record during pregive
- ensure donate products create XLMine profile and update privilege
- add service tests for software and donate flows

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6842e820ef1c833080b4bb165b64f7d8