### PR TITLE
Remove debug logs from Message component

### DIFF
--- a/frontend/src/Modules/Core/components/Message.tsx
+++ b/frontend/src/Modules/Core/components/Message.tsx
@@ -29,14 +29,6 @@ export class Message {
         try {
             const message = data.message;
             if (message) {
-                console.log('@@@@@@@@@@@@@@@@@@@@@@@')
-                console.log('@@@@@@@@@@@@@@@@@@@@@@@')
-                console.log('@@@@@@@@@@@@@@@@@@@@@@@')
-                console.log('@@@@@@@@@@@@@@@@@@@@@@@')
-                console.log('@@@@@@@@@@@@@@@@@@@@@@@')
-                console.log('@@@@@@@@@@@@@@@@@@@@@@@')
-                console.log('@@@@@@@@@@@@@@@@@@@@@@@')
-                console.log('@@@@@@@@@@@@@@@@@@@@@@@')
                 this.error(message);
                 const fields_errors = data.fields_errors;
                 if (fields_errors && fields_errors.length) {


### PR DESCRIPTION
## Summary
- clean up stray `console.log` calls in Message.errorsByData

## Testing
- `npm test --silent` *(fails: craco not found)*
- `pytest -q` *(fails: ModuleNotFoundError: 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6842e7f73680833095594b064f89a73f