### PR TITLE
Improve logging for dynamic form and payment picker

### DIFF
--- a/frontend/src/Modules/Core/components/elements/DynamicForm.tsx
+++ b/frontend/src/Modules/Core/components/elements/DynamicForm.tsx
@@ -1,6 +1,8 @@
 // Modules/Core/components/elements/DynamicForm.tsx
 
 import React, {ReactNode, useState} from 'react';
+import pprint from 'Utils/pprint';
+import {Message} from "Core/components/Message";
 import {FormControl, TextField} from '@mui/material';
 import Button from "Core/components/elements/Button/Button";
 
@@ -32,8 +34,9 @@ const DynamicForm: React.FC<DynamicFormProps> = (
         try {
             await requestFunc();
         } catch (error) {
-            console.log('Ошибка обработки динамической формы');
-            console.log(error);
+            pprint('Ошибка обработки динамической формы');
+            pprint(error);
+            Message.error('Ошибка обработки формы');
         } finally {
             setLoading(false);
         }

--- a/frontend/src/Modules/Order/PaymentTypePicker.tsx
+++ b/frontend/src/Modules/Order/PaymentTypePicker.tsx
@@ -10,6 +10,7 @@ import {FC, FR, FRCC} from "WideLayout/Layouts";
 import {useTheme} from "Theme/ThemeContext";
 import {useApi} from "../Api/useApi";
 import CircularProgress from "Core/components/elements/CircularProgress";
+import pprint from 'Utils/pprint';
 
 interface PaymentTypePickerProps {
     prices: IProductPrice[];
@@ -85,7 +86,7 @@ const PaymentTypePicker: React.FC<PaymentTypePickerProps> = (
         ) || [];
 
     useEffect(() => {
-        console.log(filteredPaymentTypes)
+        pprint(filteredPaymentTypes)
         if (filteredPaymentTypes.length > 0) {
             // либо ничего не выбрано, либо выбранной уже нет в списке
             if (!selectedPaymentType || !filteredPaymentTypes.includes(selectedPaymentType)) {


### PR DESCRIPTION
## Summary
- log payment type changes with `pprint` and env guard
- replace console logs in `DynamicForm` with `pprint`
- show toast error when dynamic form submission fails

## Testing
- `CI=true npm test` *(fails: craco not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842e7f5cce88330ac9c60431f3f256e