### PR TITLE
Improve useApi logging and token refresh

### DIFF
--- a/frontend/src/Modules/Api/useApi.ts
+++ b/frontend/src/Modules/Api/useApi.ts
@@ -1,98 +1,162 @@
 // Modules/Api/useApi.ts
-import {useCallback, useMemo} from "react";
-import pprint from "Utils/pprint";
-import {useErrorProcessing} from "Core/components/ErrorProvider";
-import {axios} from "./axiosConfig";
+import axios, {
+    AxiosInstance,
+    AxiosRequestConfig,
+    AxiosResponse,
+    InternalAxiosRequestConfig,
+} from 'axios';
+import {useContext, useEffect, useMemo, useRef} from 'react';
+import {useErrorProcessing} from 'Core/components/ErrorProvider';
+import {AuthContext, AuthContextType} from 'Auth/AuthContext';
+import {DOMAIN_URL} from './axiosConfig';
 
-type AxiosConfig = Parameters<typeof axios.get>[1] | undefined;
+type AxiosConfig = AxiosRequestConfig | undefined;
+
+/* -------- localStorage helpers -------- */
+const LS_ACCESS = 'access';
+const LS_REFRESH = 'refresh';
+
+const saveTokens = (a: string, r: string) => {
+    localStorage.setItem(LS_ACCESS, a);
+    localStorage.setItem(LS_REFRESH, r);
+};
+
+const clearTokens = () => {
+    localStorage.removeItem(LS_ACCESS);
+    localStorage.removeItem(LS_REFRESH);
+};
+
+const getAccess = () => localStorage.getItem(LS_ACCESS);
+const getRefresh = () => localStorage.getItem(LS_REFRESH);
+
+/* -------- stringify helper (for logs) -------- */
+const fmt = (x: any) => {
+    try {
+        const s = JSON.stringify(x);
+        return s.length > 500 ? s.slice(0, 497) + '...' : s;
+    } catch {
+        return '<unstringifiable>';
+    }
+};
 
 export const useApi = () => {
     const {byResponse} = useErrorProcessing();
-
-    const get = useCallback(async <T = any>(
-        url: string,
-        config?: AxiosConfig,
-        errorPopuping: boolean = true
-    ): Promise<T> => {
-        try {
-            const response = await axios.get<T>(url, config);
-            pprint('API:' + url);
-            pprint(response.data);
-            return response.data;
-        } catch (error) {
-            if (errorPopuping) byResponse(error);
-            throw error;
-        }
+    const byRespRef = useRef(byResponse);
+    useEffect(() => {
+        byRespRef.current = byResponse;
     }, [byResponse]);
 
-    const post = useCallback(async <T = any>(
-        url: string,
-        data?: any,
-        config?: AxiosConfig,
-        errorPopuping: boolean = true
-    ): Promise<T> => {
-        try {
-            const response = await axios.post<T>(url, data, config);
-            pprint('API:' + url);
-            pprint(response.data);
-            return response.data;
-        } catch (error) {
-            if (errorPopuping) byResponse(error);
-            throw error;
-        }
-    }, [byResponse]);
+    const authCtx = useContext(AuthContext) as AuthContextType | undefined;
+    const frontendLogoutRef = useRef<() => void>(() => {});
+    useEffect(() => {
+        frontendLogoutRef.current = authCtx?.frontendLogout ?? (() => {});
+    }, [authCtx]);
 
-    const put = useCallback(async <T = any>(
-        url: string,
-        data?: any,
-        config?: AxiosConfig,
-        errorPopuping: boolean = true
-    ): Promise<T> => {
-        try {
-            const response = await axios.put<T>(url, data, config);
-            pprint('API:' + url);
-            pprint(response.data);
-            return response.data;
-        } catch (error) {
-            if (errorPopuping) byResponse(error);
-            throw error;
-        }
-    }, [byResponse]);
+    const axiosRef = useRef<AxiosInstance>();
 
-    const patch = useCallback(async <T = any>(
-        url: string,
-        data?: any,
-        config?: AxiosConfig,
-        errorPopuping: boolean = true
-    ): Promise<T> => {
-        try {
-            const response = await axios.patch<T>(url, data, config);
-            pprint('API:' + url);
-            pprint(response.data);
-            return response.data;
-        } catch (error) {
-            if (errorPopuping) byResponse(error);
-            throw error;
-        }
-    }, [byResponse]);
+    if (!axiosRef.current) {
+        const inst = axios.create({baseURL: `${DOMAIN_URL}/`});
 
-    const del = useCallback(async <T = any>(
-        url: string,
-        config?: AxiosConfig,
-        errorPopuping: boolean = true
-    ): Promise<T> => {
-        try {
-            const response = await axios.delete<T>(url, config);
-            pprint('API:' + url);
-            pprint(response.data);
-            return response.data;
-        } catch (error) {
-            if (errorPopuping) byResponse(error);
-            throw error;
-        }
-    }, [byResponse]);
+        const getCookie = (name: string): string | null => {
+            if (!document.cookie) return null;
+            const xsrfCookies = document.cookie
+                .split(';')
+                .map(c => c.trim())
+                .filter(c => c.startsWith(`${name}=`));
+            if (xsrfCookies.length === 0) return null;
+            return decodeURIComponent(xsrfCookies[0].split('=')[1]);
+        };
 
-    const api = useMemo(() => ({get, post, put, patch, delete: del}), [get, post, put, patch, del]);
+        /* ---- helpers: log ---- */
+        const logReq = (m?: string, u?: string, d?: unknown) =>
+            console.info(`API ${m?.toUpperCase()} ➜ ${u}`, fmt(d));
+        const logRes = (m?: string, u?: string, s?: number, ms?: number, d?: unknown) =>
+            console.info(`API ${m?.toUpperCase()} ⇠ ${u} [${s}] ${ms?.toFixed(0)} ms`, fmt(d));
 
-    return {api};
+        inst.interceptors.request.use((cfg: InternalAxiosRequestConfig) => {
+            const token = getAccess();
+            if (token) {
+                (cfg.headers as any).Authorization = 'Bearer ' + token;
+            }
+            const csrfToken = getCookie('csrftoken');
+            if (csrfToken) {
+                (cfg.headers as any)['X-CSRFToken'] = csrfToken;
+            }
+            (cfg as any)._ts = performance.now();
+            logReq(cfg.method, cfg.url, cfg.data);
+            return cfg;
+        });
+
+        let refreshPromise: Promise<void> | null = null;
+
+        inst.interceptors.response.use(
+            (resp) => {
+                const {method, url} = resp.config;
+                const t0 = (resp.config as any)._ts;
+                logRes(method, url, resp.status, t0 ? performance.now() - t0 : undefined, resp.data);
+                return resp;
+            },
+            async (error) => {
+                const {method, url} = error.config || {};
+                const t0 = (error.config as any)?._ts;
+                logRes(method, url, error?.response?.status, t0 ? performance.now() - t0 : undefined, error?.response?.data);
+
+                const original = error.config as AxiosRequestConfig & { _retry?: boolean };
+                if (error?.response?.status !== 401 || original?._retry) {
+                    return Promise.reject(error);
+                }
+                original._retry = true;
+
+                if (!refreshPromise) {
+                    const refresh = getRefresh();
+                    if (!refresh) {
+                        frontendLogoutRef.current();
+                        return Promise.reject(error);
+                    }
+
+                    refreshPromise = inst
+                        .post('/api/v1/token/refresh/', { refresh })
+                        .then((r: AxiosResponse<{ access: string; refresh?: string }>) =>
+                            saveTokens(r.data.access, r.data.refresh ?? refresh))
+                        .catch((e) => {
+                            clearTokens();
+                            frontendLogoutRef.current();
+                            throw e;
+                        })
+                        .finally(() => {
+                            refreshPromise = null;
+                        });
+                }
+                await refreshPromise;
+
+                const token = getAccess();
+                if (token && original.headers)
+                    (original.headers as any).Authorization = 'Bearer ' + token;
+                return inst(original);
+            },
+        );
+
+        axiosRef.current = inst;
+    }
+
+    const runner = <T = any>(p: Promise<AxiosResponse<any>>, silent = false): Promise<T> =>
+        p.then(r => r.data as T).catch(err => {
+            if (!silent) byRespRef.current(err);
+            throw err;
+        });
+
+    const apiRef = useRef({
+        get: <T = any>(u: string, c?: AxiosConfig) => runner<T>(axiosRef.current!.get(u, c)),
+        post: <T = any, D = any>(u: string, d?: D, c?: AxiosConfig, s = false) =>
+            runner<T>(axiosRef.current!.post(u, d, c), s),
+        put: <T = any, D = any>(u: string, d?: D, c?: AxiosConfig, s = false) =>
+            runner<T>(axiosRef.current!.put(u, d, c), s),
+        patch: <T = any, D = any>(u: string, d?: D, c?: AxiosConfig, s = false) =>
+            runner<T>(axiosRef.current!.patch(u, d, c), s),
+        delete: <T = any>(u: string, c?: AxiosConfig) =>
+            runner<T>(axiosRef.current!.delete(u, c)),
+    });
+
+    return { api: apiRef.current };
 };
+


### PR DESCRIPTION
## Summary
- enhance `useApi` with built in axios instance
- add request/response logging
- implement automatic token refresh using the refresh endpoint

## Testing
- `npm test -- --watchAll=false` *(fails: craco not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863036d870c833099c9122a9d9f2320