### PR TITLE
Add minecraft profile tab and payment ui tweaks

### DIFF
--- a/frontend/src/Modules/Order/BalanceTopUpDialog.tsx
+++ b/frontend/src/Modules/Order/BalanceTopUpDialog.tsx
@@ -1,7 +1,7 @@
 import React, {useContext, useEffect, useState} from 'react';
-import {Button, Dialog, DialogContent, DialogTitle, TextField} from '@mui/material';
+import {Button, Dialog, DialogContent, DialogTitle, TextField, Collapse} from '@mui/material';
 import CircularProgress from 'Core/components/elements/CircularProgress';
-import {FC} from 'wide-containers';
+import {FC, FR} from 'wide-containers';
 import {useApi} from '../Api/useApi';
 import PaymentTypePicker from 'Order/PaymentTypePicker';
 import {ICurrencyWithPrice, IPaymentSystem, IProduct} from 'types/commerce/shop';
@@ -31,6 +31,14 @@ const BalanceTopUpDialog: React.FC<BalanceTopUpDialogProps> = ({open, onClose}) 
         }
     }, [open, api]);
 
+    useEffect(() => {
+        if (open) {
+            setCurrency(null);
+            setSystem(null);
+            setAmount(100);
+        }
+    }, [open]);
+
     const handleCreate = async () => {
         if (!isAuthenticated) {
             notAuthentication();
@@ -55,7 +63,10 @@ const BalanceTopUpDialog: React.FC<BalanceTopUpDialogProps> = ({open, onClose}) 
     };
 
     return (
-        <Dialog open={open} onClose={() => !loading && onClose()}>
+        <Dialog
+            open={open}
+            onClose={() => !loading && onClose()}
+        >
             <DialogTitle sx={{pb: 1.5}}>Пополнить баланс</DialogTitle>
             <DialogContent>
                 {!product ? (
@@ -77,6 +88,11 @@ const BalanceTopUpDialog: React.FC<BalanceTopUpDialogProps> = ({open, onClose}) 
                             setPaymentSystem={setSystem}
                             excluded_payment_systems={["balance"]}
                         />
+                        <Collapse in={system === 'freekassa'}>
+                            <FR>
+                                При оплате через FreeKassa менее 1001 RUB нужно иметь/зарегистрировать кошелек FK Wallet и пополнить его, либо оплачивать криптой. Более 1000 RUB вы можете оплатить через СБП / Картой и всеми удобными способами. Это ограничения FreeKassa.
+                            </FR>
+                        </Collapse>
                         <Button onClick={handleCreate} disabled={loading} sx={{fontWeight: 'bold'}}>
                             {loading ? <CircularProgress size="20px"/> : 'Далее'}
                         </Button>

--- a/frontend/src/Modules/Software/SoftwareOrder.tsx
+++ b/frontend/src/Modules/Software/SoftwareOrder.tsx
@@ -1,6 +1,6 @@
 // Modules/Software/SoftwareOrder.tsx
 import React, {useContext, useEffect, useState} from 'react';
-import {Button, Dialog, DialogContent, DialogTitle, IconButton, Slider, useMediaQuery,} from '@mui/material';
+import {Button, Dialog, DialogContent, DialogTitle, IconButton, Slider, useMediaQuery, Collapse} from '@mui/material';
 import {Message} from 'Core/components/Message';
 import CircularProgress from 'Core/components/elements/CircularProgress';
 import {FC, FCC, FR, FRC, FRSC} from 'wide-containers';
@@ -193,7 +193,10 @@ const SoftwareOrder: React.FC<SoftwareOrderProps> = ({software, onSuccess}) => {
 
             {creatingOrder && <CircularProgress size="60px"/>}
 
-            <Dialog open={payModal} onClose={() => setPayModal(false)}>
+            <Dialog
+                open={payModal}
+                onClose={() => setPayModal(false)}
+            >
                 <DialogTitle><FR opacity={70}>Payment of the order</FR></DialogTitle>
                 <DialogContent>
                     <FC g={2} maxW={400}>
@@ -202,7 +205,11 @@ const SoftwareOrder: React.FC<SoftwareOrderProps> = ({software, onSuccess}) => {
                             setPaymentCurrency={setCurrency}
                             setPaymentSystem={setSystem}
                         />
-                        {system === 'freekassa' && <FR>При оплате через FreeKassa менее 1001 RUB нужно иметь/зарегистрировать кошелек FK Wallet и пополнить его, либо оплачивать криптой. Более 1000 RUB вы можете оплатить через СБП / Картой и всеми удобными способами. Это ограничения FreeKassa.</FR>}
+                        <Collapse in={system === 'freekassa'}>
+                            <FR>
+                                При оплате через FreeKassa менее 1001 RUB нужно иметь/зарегистрировать кошелек FK Wallet и пополнить его, либо оплачивать криптой. Более 1000 RUB вы можете оплатить через СБП / Картой и всеми удобными способами. Это ограничения FreeKassa.
+                            </FR>
+                        </Collapse>
                         <FRC g={1}>
                             {/*<Button onClick={() => setPayModal(false)}>*/}
                             {/*    Cancel*/}

--- a/frontend/src/Modules/Theme/themeConfig.ts
+++ b/frontend/src/Modules/Theme/themeConfig.ts
@@ -176,6 +176,7 @@ export const darkTheme = createTheme({
                     borderRadius: '1.2rem',
                     margin: '0.5rem',
                     padding: 0,
+                    transition: 'width .3s, height .3s',
                 },
             },
             defaultProps: {

--- a/frontend/src/Modules/User/Profile.tsx
+++ b/frontend/src/Modules/User/Profile.tsx
@@ -4,6 +4,7 @@ import {Route, Routes, useLocation, useNavigate} from 'react-router-dom';
 import {useTheme} from 'Theme/ThemeContext';
 import {FC, FRS} from 'wide-containers';
 import UserPersonalInfoForm from 'User/UserPersonalInfoForm';
+import XLMineProfileInfoForm from '../xLMine/xLMineProfileInfoForm';
 import {Tab, Tabs} from '@mui/material';
 import {useDispatch} from "react-redux";
 import {AuthContext, AuthContextType} from "Auth/AuthContext";
@@ -27,10 +28,11 @@ const Profile: React.FC<ProfileProps> = ({selectedProfile}) => {
             selectedProfile === 'client'
                 ? [
                     {label: 'Пользователь', path: `${basePath}/user`},
-                    // { label: 'Клиент', path: `${basePath}/client` }, // будет видео-профиль клиента
+                    {label: 'Minecraft', path: `${basePath}/minecraft`},
                 ]
                 : [
                     {label: 'Пользователь', path: `${basePath}/user`},
+                    {label: 'Minecraft', path: `${basePath}/minecraft`},
                     {label: 'Сотрудник', path: `${basePath}/employee`},
                 ],
         [selectedProfile],
@@ -79,6 +81,7 @@ const Profile: React.FC<ProfileProps> = ({selectedProfile}) => {
             <FC flexGrow={1} scroll="y-auto" px={2} py={1}>
                 <Routes>
                     <Route path="user" element={<UserPersonalInfoForm/>}/>
+                    <Route path="minecraft" element={<XLMineProfileInfoForm/>}/>
                     {/* <Route path="client" element={<ClientProfile />} /> */}
                     {/* <Route path="employee" element={<EmployeeProfile />} /> */}
                 </Routes>

--- a/frontend/src/Modules/xLMine/xLMineProfileInfoForm.tsx
+++ b/frontend/src/Modules/xLMine/xLMineProfileInfoForm.tsx
@@ -1,0 +1,45 @@
+import React, {useContext} from 'react';
+import {FR, FRSC, FC} from 'wide-containers';
+import SkinCapeSetter from './SkinCape/SkinCapeSetter';
+import UserPrivilege from './Privilege/UserPrivilege';
+import {AuthContext, AuthContextType} from 'Auth/AuthContext';
+import {useMediaQuery} from '@mui/material';
+import {useTheme} from 'Theme/ThemeContext';
+import UserBalance from 'Order/UserBalance';
+
+const XLMineProfileInfoForm: React.FC = () => {
+    const {user} = useContext(AuthContext) as AuthContextType;
+    const isGtSm = useMediaQuery('(min-width: 576px)');
+    const {plt} = useTheme();
+
+    if (!user) return null;
+
+    return (
+        <FR wrap g={1} mb={2}>
+            <FR minW={160}><SkinCapeSetter/></FR>
+            <FC g={1}>
+                <FRSC wrap g={1}>
+                    <FR
+                        color={plt.text.primary}
+                        fontWeight={'bold'}
+                        fontSize={isGtSm ? '2.2rem' : '1.7rem'}
+                        lineHeight={'1.8rem'}
+                        sx={{userSelect: 'all'}}>
+                        {user.username}
+                    </FR>
+                    <FR
+                        mt={.57}
+                        lineHeight={'1.5rem'}
+                        fontSize={isGtSm ? '1.7rem' : '1.5rem'}
+                        fontWeight={'bold'}>
+                        <UserPrivilege/>
+                    </FR>
+                </FRSC>
+                <UserBalance/>
+                <FR>{user.coins} монет</FR>
+            </FC>
+        </FR>
+    );
+};
+
+export default XLMineProfileInfoForm;


### PR DESCRIPTION
## Summary
- add Minecraft profile tab with skin/cape settings, coins, nickname and privilege
- smooth height changes on payment dialogs and collapse FreeKassa notes
- show FreeKassa notice in balance dialog
- remove deprecated `PaperProps` and move dialog size transitions to theme
- reset currency and payment system when balance dialog opens

## Testing
- `npm test --silent` *(fails: craco not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_686311adec4c8330b54a6528ab4648a1