### PR TITLE
Fix missing gettext wrappers

### DIFF
--- a/backend/apps/commerce/models/payment.py
+++ b/backend/apps/commerce/models/payment.py
@@ -8,18 +8,18 @@ from django.utils.translation import gettext_lazy as _
 
 
 class Currency(TextChoices):
-    USD = 'USD', 'US Dollar'
-    RUB = 'RUB', 'Russian Ruble'
-    EUR = 'EUR', 'Euro'
+    USD = 'USD', _('US Dollar')
+    RUB = 'RUB', _('Russian Ruble')
+    EUR = 'EUR', _('Euro')
 
 
 class PaymentSystem(TextChoices):
-    HandMade = 'handmade', 'HandMade'
-    TBank = 'tbank', 'TBank'
-    TBankInstallment = 'tbank_installment', 'Tinkoff (Installment)'
-    CloudPayment = 'cloud_payment', 'CloudPayments'
-    FreeKassa = 'freekassa', 'FreeKassa'
-    Balance = 'balance', 'Balance'
+    HandMade = 'handmade', _('HandMade')
+    TBank = 'tbank', _('TBank')
+    TBankInstallment = 'tbank_installment', _('Tinkoff (Installment)')
+    CloudPayment = 'cloud_payment', _('CloudPayments')
+    FreeKassa = 'freekassa', _('FreeKassa')
+    Balance = 'balance', _('Balance')
 
 
 class ACurrencyMixin(AModel):

--- a/backend/apps/core/models/choices.py
+++ b/backend/apps/core/models/choices.py
@@ -50,5 +50,5 @@ class Timezone(IntegerChoices):
 
 
 class Gender(TextChoices):
-    MALE = 'male', 'Male'
-    FEMALE = 'female', 'Female'
+    MALE = 'male', _('Male')
+    FEMALE = 'female', _('Female')

--- a/backend/apps/surveys/models.py
+++ b/backend/apps/surveys/models.py
@@ -6,6 +6,7 @@ from django.db.models import (
     CASCADE, TextChoices, ImageField, DateTimeField,
     ManyToManyField, SmallIntegerField
 )
+from django.utils.translation import gettext_lazy as _
 
 from apps.core.models.user import User
 from apps.theme.models import Theme
@@ -14,7 +15,7 @@ from apps.theme.models import Theme
 class Survey(AModel):
     title = CharField(max_length=255)
     slug = SlugField(max_length=255, unique=True, blank=True, null=True)
-    description = TextField(help_text='Use Markdown for formatting', blank=True, null=True)
+    description = TextField(help_text=_('Use Markdown for formatting'), blank=True, null=True)
     is_test = BooleanField(default=False)
     is_public = BooleanField(default=False)
     author = ForeignKey(User, related_name='surveys', on_delete=CASCADE)
@@ -38,13 +39,13 @@ class Survey(AModel):
 
 class Question(AModel):
     class QuestionType(TextChoices):
-        CHOICES = 'choices', 'Multiple Choice'
-        TEXT = 'text', 'Text'
+        CHOICES = 'choices', _('Multiple Choice')
+        TEXT = 'text', _('Text')
 
     survey = ForeignKey(Survey, related_name='questions', on_delete=CASCADE)
     title = CharField(max_length=255, null=True, blank=True)
     order = PositiveSmallIntegerField()
-    text = TextField(help_text='Use Markdown for formatting')
+    text = TextField(help_text=_('Use Markdown for formatting'))
     points_for_text = PositiveSmallIntegerField(default=1)
     time_limit_minutes = PositiveSmallIntegerField(null=True, blank=True)
     question_type = CharField(max_length=20, choices=QuestionType.choices)
@@ -59,7 +60,7 @@ class Choice(AModel):
     title = CharField(max_length=255, null=True, blank=True)
     points = SmallIntegerField(default=0)
     question = ForeignKey(Question, related_name='choices', on_delete=CASCADE)
-    text = TextField(help_text='Use Markdown for formatting')
+    text = TextField(help_text=_('Use Markdown for formatting'))
     is_correct = BooleanField(default=False)
 
     def __str__(self):


### PR DESCRIPTION
## Summary
- add gettext wrappers for gender choices
- translate survey help_texts and labels
- translate currency and payment system choices

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*
- `npm test --silent` *(fails: craco: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863ba770d5c83308014170f2933bc45