### PR TITLE
Add missing translations

### DIFF
--- a/backend/apps/filehost/controllers/base.py
+++ b/backend/apps/filehost/controllers/base.py
@@ -125,22 +125,22 @@ async def bulk_delete_items(request) -> Response:
     folder_ids = request.data.get('folder_ids', [])
 
     if not file_ids and not folder_ids:
-        return Response({'error': 'No item ids provided'},
+        return Response({'error': _('No item ids provided')},
                         status=status.HTTP_400_BAD_REQUEST)
     files = File.objects.filter(id__in=file_ids, user=request.user).select_related('user')
     async for file in files:
         if file.user != request.user:
-            return Response({'error': 'Permission denied'}, status=status.HTTP_403_FORBIDDEN)
+            return Response({'error': _('Permission denied')}, status=status.HTTP_403_FORBIDDEN)
     folders = Folder.objects.filter(id__in=folder_ids, user=request.user).select_related('user')
     async for folder in folders:
         if folder.user != request.user:
-            return Response({'error': 'Permission denied'}, status=status.HTTP_403_FORBIDDEN)
+            return Response({'error': _('Permission denied')}, status=status.HTTP_403_FORBIDDEN)
 
     # Удаляем файлы и папки
     await File.objects.filter(id__in=[file.id for file in files]).adelete()
     await Folder.objects.filter(id__in=[folder.id for folder in folders]).adelete()
 
-    return Response({'status': 'Items deleted successfully'}, status=status.HTTP_204_NO_CONTENT)
+    return Response({'status': _('Items deleted successfully')}, status=status.HTTP_204_NO_CONTENT)
 
 
 @acontroller('Bulk Update Items')
@@ -150,7 +150,7 @@ async def bulk_update_items(request) -> Response:
     items_data = request.data.get('items_data', {})
 
     if not items_data:
-        return Response({'error': 'No update data provided'}, status=status.HTTP_400_BAD_REQUEST)
+        return Response({'error': _('No update data provided')}, status=status.HTTP_400_BAD_REQUEST)
 
     file_ids = [key for key in items_data.keys() if items_data[key].get('type') == 'file']
     folder_ids = [key for key in items_data.keys() if items_data[key].get('type') == 'folder']
@@ -172,7 +172,7 @@ async def bulk_update_items(request) -> Response:
                 setattr(folder, key, value)
         await folder.asave()
 
-    return Response({'status': 'Items updated successfully'}, status=status.HTTP_200_OK)
+    return Response({'status': _('Items updated successfully')}, status=status.HTTP_200_OK)
 
 
 @acontroller('Make Public Access')

--- a/backend/apps/filehost/exceptions/base.py
+++ b/backend/apps/filehost/exceptions/base.py
@@ -1,15 +1,16 @@
 # filehost/exceptions/base.py
 from rest_framework import status
 from rest_framework.exceptions import APIException
+from django.utils.translation import gettext_lazy as _
 
 
 class StorageLimitExceeded(APIException):
     status_code = status.HTTP_400_BAD_REQUEST
-    default_detail = {'message': 'Storage limit exceeded.'}
+    default_detail = {'message': _('Storage limit exceeded.')}
     default_code = 'storage_limit_exceeded'
 
 
 class IdWasNotProvided(APIException):
     status_code = status.HTTP_400_BAD_REQUEST
-    default_detail = {'message': 'Id was not provided.'}
+    default_detail = {'message': _('Id was not provided.')}
     default_code = 'id_was_not_provided'

--- a/backend/apps/redisui/controllers/views.py
+++ b/backend/apps/redisui/controllers/views.py
@@ -5,6 +5,7 @@ import redis
 from adjango.decorators import controller
 from django.conf import settings
 from django.http import JsonResponse
+from django.utils.translation import gettext_lazy as _
 from django.shortcuts import render
 
 # Подключение к Redis без автоматического декодирования
@@ -81,15 +82,15 @@ def delete_redis_key(request):
         client_type = request.POST.get('client_type')
 
         if not key or not client_type:
-            return JsonResponse({'status': 'error', 'message': 'Key or client_type is missing'}, status=400)
+            return JsonResponse({'status': 'error', 'message': _('Key or client_type is missing')}, status=400)
 
         if client_type == 'cache' and redis_cache:
             redis_cache.delete(key)
         elif client_type == 'broker' and redis_broker:
             redis_broker.delete(key)
         else:
-            return JsonResponse({'status': 'error', 'message': 'Invalid client type'}, status=400)
+            return JsonResponse({'status': 'error', 'message': _('Invalid client type')}, status=400)
 
         return JsonResponse({'status': 'success'})
 
-    return JsonResponse({'status': 'error', 'message': 'Invalid request method'}, status=400)
+    return JsonResponse({'status': 'error', 'message': _('Invalid request method')}, status=400)

--- a/backend/apps/surveys/exceptions/base.py
+++ b/backend/apps/surveys/exceptions/base.py
@@ -1,27 +1,28 @@
 # surveys/exceptions/base.py
 from rest_framework import status
 from rest_framework.exceptions import APIException
+from django.utils.translation import gettext_lazy as _
 
 
 class CurrentUserNotSurveyAuthor(APIException):
     status_code = status.HTTP_403_FORBIDDEN
-    default_detail = {'message': 'You are not the author of the survey.'}
+    default_detail = {'message': _('You are not the author of the survey.')}
     default_code = 'current_user_not_survey_author'
 
 
 class SurveyIdWasNotProvided(APIException):
     status_code = status.HTTP_400_BAD_REQUEST
-    default_detail = {'message': 'Survey id was not provided.'}
+    default_detail = {'message': _('Survey id was not provided.')}
     default_code = 'survey_id_was_not_provided'
 
 
 class ChangeCompletedSurveyAttemptForbidden(APIException):
     status_code = status.HTTP_423_LOCKED
-    default_detail = {'message': 'Нельзя изменять уже законченную попытку.'}
+    default_detail = {'message': _('Нельзя изменять уже законченную попытку.')}
     default_code = 'change_completed_survey_attempt_forbidden'
 
 
 class HaveNoMoreAttemptsLeftToPass(APIException):
     status_code = status.HTTP_403_FORBIDDEN
-    default_detail = {'message': 'У вас не осталось попыток для прохождения.'}
+    default_detail = {'message': _('У вас не осталось попыток для прохождения.')}
     default_code = 'have_no_more_attempts_left_to_pass'

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -101,6 +101,7 @@
   ,"no_chats": "No chats"
   ,"choose_file": "Choose file"
   ,"you_colon": "You: "
+  ,"notes": "Notes"
   ,"product_not_for_sale": "This product is currently not for sale."
   ,"min_hours_message": "Minimum hours: {{hours}}"
   ,"buy_hours_for_price": "Buy {{hours}} hours for {{price}} RUB"

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -101,6 +101,7 @@
   ,"no_chats": "Ни одного чата"
   ,"choose_file": "Выбрать файл"
   ,"you_colon": "Вы: "
+  ,"notes": "Заметки"
   ,"product_not_for_sale": "Товар сейчас не продается."
   ,"min_hours_message": "Минимальное количество часов: {{hours}}"
   ,"buy_hours_for_price": "Купить {{hours}} ч. за {{price}} RUB"


### PR DESCRIPTION
## Summary
- translate 'notes' label
- mark filehost and surveys messages for translation
- add translations in redis UI views

## Testing
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6863c147ff188330b5ed99a20d3e6cac