### PR TITLE
Implement folder navigation and uploads

### DIFF
--- a/backend/apps/filehost/controllers/folders.py
+++ b/backend/apps/filehost/controllers/folders.py
@@ -47,7 +47,9 @@ async def get_folder_content(request) -> Response:
     files = await File.objects.afilter(folder=folder)
     subfolders_serializer = AFolderSerializer(subfolders, many=True)
     files_serializer = FileSerializer(files, many=True)
+    folder_serializer = AFolderSerializer(folder)
     return Response({
+        'folder': folder_serializer.data,
         'folders': subfolders_serializer.data,
         'files': files_serializer.data
     }, status=status.HTTP_200_OK)

--- a/frontend/src/Modules/FileHost/AllFiles.tsx
+++ b/frontend/src/Modules/FileHost/AllFiles.tsx
@@ -3,16 +3,22 @@ import PaginatedList from 'Core/components/elements/PaginatedList';
 import {useApi} from '../Api/useApi';
 import FileItem from './FileItem';
 import {IFile} from './types';
+import useFileUpload from './useFileUpload';
+import UploadProgressWindow from './UploadProgressWindow';
 
 const AllFiles: React.FC = () => {
     const {api} = useApi();
+    const {handleUpload, uploads} = useFileUpload(null);
 
     const load = async (page: number): Promise<IFile[]> => {
         return api.get(`/api/v1/filehost/files/?page=${page}&page_size=20`);
     };
 
     return (
-        <PaginatedList loadData={load} renderItem={(item) => <FileItem key={item.id} file={item}/>} />
+        <div onDragOver={e=>e.preventDefault()} onDrop={e=>{e.preventDefault(); if(e.dataTransfer.files.length) handleUpload(e.dataTransfer.files[0]);}}>
+            <PaginatedList loadData={load} renderItem={(item) => <FileItem key={item.id} file={item}/>} />
+            {uploads.length>0 && <UploadProgressWindow items={uploads}/>}    
+        </div>
     );
 };
 

--- a/frontend/src/Modules/FileHost/FavoriteFiles.tsx
+++ b/frontend/src/Modules/FileHost/FavoriteFiles.tsx
@@ -3,15 +3,23 @@ import PaginatedList from 'Core/components/elements/PaginatedList';
 import {useApi} from '../Api/useApi';
 import FileItem from './FileItem';
 import {IFile} from './types';
+import useFileUpload from './useFileUpload';
+import UploadProgressWindow from './UploadProgressWindow';
 
 const FavoriteFiles: React.FC = () => {
     const {api} = useApi();
+    const {handleUpload, uploads} = useFileUpload(null);
 
     const load = async (page: number): Promise<IFile[]> => {
         return api.get(`/api/v1/filehost/files/favorite/?page=${page}&page_size=20`);
     };
 
-    return <PaginatedList loadData={load} renderItem={(item) => <FileItem key={item.id} file={item}/>} />;
+    return (
+        <div onDragOver={e=>e.preventDefault()} onDrop={e=>{e.preventDefault(); if(e.dataTransfer.files.length) handleUpload(e.dataTransfer.files[0]);}}>
+            <PaginatedList loadData={load} renderItem={(item) => <FileItem key={item.id} file={item}/>} />
+            {uploads.length>0 && <UploadProgressWindow items={uploads}/>}
+        </div>
+    );
 };
 
 export default FavoriteFiles;

--- a/frontend/src/Modules/FileHost/FolderItem.tsx
+++ b/frontend/src/Modules/FileHost/FolderItem.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import {useNavigate} from 'react-router-dom';
+import {FRSE} from 'wide-containers';
+
+interface Props {
+    id: number;
+    name: string;
+}
+
+const FolderItem: React.FC<Props> = ({id, name}) => {
+    const navigate = useNavigate();
+    const open = () => navigate(`/storage/master/${id}/`);
+    return (
+        <FRSE p={0.5} borderBottom={'1px solid #ccc'} onClick={open} style={{cursor:'pointer'}}>
+            <strong>{name}</strong>
+        </FRSE>
+    );
+};
+
+export default FolderItem;

--- a/frontend/src/Modules/FileHost/Storage.tsx
+++ b/frontend/src/Modules/FileHost/Storage.tsx
@@ -30,6 +30,7 @@ const Storage: React.FC = () => {
             </Tabs>
             <Routes>
                 <Route path="master/" element={<Master/>}/>
+                <Route path="master/:id/" element={<Master/>}/>
                 <Route path="files/all/" element={<AllFiles/>}/>
                 <Route path="files/favorite/" element={<FavoriteFiles/>}/>
                 <Route path="files/:id/" element={<FileDetail/>}/>

--- a/frontend/src/Modules/FileHost/index.ts
+++ b/frontend/src/Modules/FileHost/index.ts
@@ -1,2 +1,4 @@
 export {default as Storage} from './Storage';
 export {default as FileDetail} from './FileDetail';
+export {default as FolderItem} from './FolderItem';
+export {default as useFileUpload} from './useFileUpload';

--- a/frontend/src/Modules/FileHost/useFileUpload.ts
+++ b/frontend/src/Modules/FileHost/useFileUpload.ts
@@ -1,0 +1,29 @@
+import {useApi} from '../Api/useApi';
+import {useState} from 'react';
+import {UploadItem} from './UploadProgressWindow';
+
+const useFileUpload = (parentId: number | null) => {
+    const {api} = useApi();
+    const [uploads, setUploads] = useState<UploadItem[]>([]);
+
+    const handleUpload = async (file: File | null) => {
+        if (!file) return;
+        const item: UploadItem = {name: file.name, progress: 0};
+        setUploads(prev => [...prev, item]);
+        const formData = new FormData();
+        formData.append('files', file);
+        if (parentId) formData.append('parent_id', String(parentId));
+        await api.post('/api/v1/filehost/files/upload/', formData, {
+            headers: {'Content-Type': 'multipart/form-data'},
+            onUploadProgress: e => {
+                item.progress = Math.round((e.loaded / e.total) * 100);
+                setUploads(u => [...u]);
+            }
+        });
+        setUploads(u => u.filter(i => i !== item));
+    };
+
+    return {handleUpload, uploads};
+};
+
+export default useFileUpload;

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -112,6 +112,7 @@
   "create_folder": "Create folder",
   "folder_name": "Folder name",
   "upload_file": "Upload file",
+  "back": "Back",
   "you_colon": "You: ",
   "notes": "Notes",
   "product_not_for_sale": "This product is currently not for sale.",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -112,6 +112,7 @@
   "create_folder": "Создать папку",
   "folder_name": "Имя папки",
   "upload_file": "Загрузить файл",
+  "back": "Назад",
   "you_colon": "Вы: ",
   "notes": "Заметки",
   "product_not_for_sale": "Товар сейчас не продается.",


### PR DESCRIPTION
## Summary
- include folder details in `get_folder_content` response
- add FolderItem and useFileUpload utilities
- support folder navigation and context actions on Master page
- enable drag & drop uploads on file listing pages
- expose new components
- add `back` translations

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68644edba3388330b146bc73415637ee