### PR TITLE
Add card view and renaming for FileHost

### DIFF
--- a/backend/apps/filehost/controllers/base.py
+++ b/backend/apps/filehost/controllers/base.py
@@ -222,3 +222,24 @@ async def move_item(request) -> Response:
         item.parent = new_folder
     await item.asave()
     return Response(status=status.HTTP_200_OK)
+
+
+@acontroller('Rename Item')
+@api_view(('POST',))
+@permission_classes((IsAuthenticated,))
+async def rename_item(request) -> Response:
+    item_id = request.data.get('item_id')
+    new_name = request.data.get('new_name')
+    if not item_id or not new_name:
+        raise IdWasNotProvided()
+    try:
+        item = await File.objects.aget(id=item_id, user=request.user)
+        item.name = new_name
+        await item.asave()
+        data = await FileSerializer(item).adata
+    except File.DoesNotExist:
+        item = await aget_object_or_404(Folder, id=item_id, user=request.user)
+        item.name = new_name
+        await item.asave()
+        data = await FolderSerializer(item).adata
+    return Response(data, status=status.HTTP_200_OK)

--- a/backend/apps/filehost/urls.py
+++ b/backend/apps/filehost/urls.py
@@ -5,7 +5,7 @@ from apps.filehost.controllers.accesses import (
     grant_access, revoke_access, list_accesses, set_public
 )
 from apps.filehost.controllers.base import (
-    move_item, get_full_tree, bulk_delete_items,
+    move_item, rename_item, get_full_tree, bulk_delete_items,
     bulk_update_items, upload_files, download_file,
     download_archive,
 )
@@ -43,6 +43,7 @@ urlpatterns = [
     path('download/archive/', download_archive, name='download_archive'),
 
     path('item/move/', move_item, name='move_item'),
+    path('item/rename/', rename_item, name='rename_item'),
     path('item/delete/', delete_item, name='delete_item'),
     path('items/bulk_delete/', bulk_delete_items, name='bulk_delete_items'),
     path('items/bulk_update/', bulk_update_items, name='bulk_update_items'),

--- a/frontend/src/Modules/FileHost/FileCard.tsx
+++ b/frontend/src/Modules/FileHost/FileCard.tsx
@@ -1,0 +1,78 @@
+import React, {useState} from 'react';
+import {Checkbox, IconButton, Menu, MenuItem, Paper} from '@mui/material';
+import MoreVertIcon from '@mui/icons-material/MoreVert';
+import StarIcon from '@mui/icons-material/Star';
+import StarBorderIcon from '@mui/icons-material/StarBorder';
+import {useNavigate} from 'react-router-dom';
+import {useApi} from '../Api/useApi';
+import {IFile} from './types';
+import formatFileSize from 'Utils/formatFileSize';
+import {useTranslation} from 'react-i18next';
+
+interface Props {
+    file: IFile;
+    selectMode?: boolean;
+    selected?: boolean;
+    onToggleSelect?: (f: IFile) => void;
+    onFavorite?: (f: IFile) => void;
+    onDelete?: (f: IFile) => void;
+    onDownload?: (f: IFile) => void;
+    onShare?: (f: IFile) => void;
+    onSelectMode?: (f: IFile) => void;
+}
+
+const FileCard: React.FC<Props> = ({file, selectMode, selected, onToggleSelect, onFavorite, onDelete, onDownload, onShare, onSelectMode}) => {
+    const {api} = useApi();
+    const navigate = useNavigate();
+    const {t} = useTranslation();
+    const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+
+    const toggleFav = () => {
+        api.post('/api/v1/filehost/files/toggle_favorite/', {file_id: file.id}).then(d => {
+            onFavorite && onFavorite({...file, is_favorite: d.is_favorite});
+        });
+    };
+
+    const handleDelete = () => { onDelete && onDelete(file); setAnchorEl(null); };
+    const handleDownload = () => { onDownload && onDownload(file); setAnchorEl(null); };
+    const handleShare = () => { onShare && onShare(file); setAnchorEl(null); };
+    const handleSelectMode = () => { onSelectMode && onSelectMode(file); setAnchorEl(null); };
+    const handleToggleSelect = () => { onToggleSelect && onToggleSelect(file); setAnchorEl(null); };
+
+    const handleClick = () => {
+        if (selectMode) {
+            onToggleSelect && onToggleSelect(file);
+        } else {
+            navigate(`/storage/files/${file.id}/`);
+        }
+    };
+
+    return (
+        <Paper sx={{p:1,width:150}} onClick={handleClick} onContextMenu={e=>{e.preventDefault();setAnchorEl(e.currentTarget);}}>
+            <div style={{display:'flex',justifyContent:'space-between',alignItems:'center'}}>
+                {selectMode && <Checkbox size="small" checked={selected} onChange={handleToggleSelect}/>} 
+                <IconButton size="small" onClick={e=>{e.stopPropagation();toggleFav();}} sx={{color:file.is_favorite? '#fbc02d':'inherit'}}>
+                    {file.is_favorite ? <StarIcon fontSize="small"/> : <StarBorderIcon fontSize="small"/>}
+                </IconButton>
+                <IconButton size="small" onClick={e=>{e.stopPropagation();setAnchorEl(e.currentTarget);}}>
+                    <MoreVertIcon fontSize="small"/>
+                </IconButton>
+            </div>
+            <div style={{wordBreak:'break-all',fontSize:'0.9rem'}}>{file.name}</div>
+            <div style={{fontSize:'0.75rem',color:'#666'}}>{new Date(file.created_at).toLocaleDateString()} · {formatFileSize(file.size)}</div>
+            <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={()=>setAnchorEl(null)}>
+                <MenuItem onClick={handleDownload}>{t('download')}</MenuItem>
+                <MenuItem onClick={handleShare}>{t('share')}</MenuItem>
+                {selectMode ? (
+                    <MenuItem onClick={handleToggleSelect}>{t('select')}</MenuItem>
+                ) : (
+                    <MenuItem onClick={handleSelectMode}>{t('select')}</MenuItem>
+                )}
+                <MenuItem onClick={toggleFav}>{file.is_favorite ? 'Unfavorite' : 'Favorite'}</MenuItem>
+                <MenuItem onClick={handleDelete}>{t('delete')}</MenuItem>
+            </Menu>
+        </Paper>
+    );
+};
+
+export default FileCard;

--- a/frontend/src/Modules/FileHost/FolderCard.tsx
+++ b/frontend/src/Modules/FileHost/FolderCard.tsx
@@ -1,0 +1,48 @@
+import React, {useState} from 'react';
+import {IconButton, Menu, MenuItem, Paper} from '@mui/material';
+import MoreVertIcon from '@mui/icons-material/MoreVert';
+import {useNavigate} from 'react-router-dom';
+import {useTranslation} from 'react-i18next';
+import RenameDialog from './RenameDialog';
+import {useApi} from '../Api/useApi';
+
+interface Props {
+    id: number;
+    name: string;
+    onDelete?: (id: number) => void;
+    onRenamed?: () => void;
+}
+
+const FolderCard: React.FC<Props> = ({id, name, onDelete, onRenamed}) => {
+    const navigate = useNavigate();
+    const {t} = useTranslation();
+    const {api} = useApi();
+    const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+    const [showRename, setShowRename] = useState(false);
+
+    const open = () => navigate(`/storage/master/${id}/`);
+    const handleDelete = async () => {
+        onDelete && onDelete(id);
+        setAnchorEl(null);
+    };
+
+    return (
+        <>
+            <Paper sx={{p:1,width:150,cursor:'pointer'}} onDoubleClick={open} onContextMenu={e=>{e.preventDefault();setAnchorEl(e.currentTarget);}}>
+                <div style={{display:'flex',justifyContent:'space-between',alignItems:'center'}}>
+                    <strong style={{wordBreak:'break-all'}}>{name}</strong>
+                    <IconButton size="small" onClick={e=>{e.stopPropagation();setAnchorEl(e.currentTarget);}}>
+                        <MoreVertIcon fontSize="small"/>
+                    </IconButton>
+                </div>
+            </Paper>
+            <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={()=>setAnchorEl(null)}>
+                <MenuItem onClick={()=>{setShowRename(true); setAnchorEl(null);}}>{t('rename')}</MenuItem>
+                <MenuItem onClick={handleDelete}>{t('delete')}</MenuItem>
+            </Menu>
+            <RenameDialog open={showRename} id={id} name={name} onClose={()=>setShowRename(false)} onRenamed={onRenamed}/>
+        </>
+    );
+};
+
+export default FolderCard;

--- a/frontend/src/Modules/FileHost/Master.tsx
+++ b/frontend/src/Modules/FileHost/Master.tsx
@@ -1,8 +1,8 @@
 import React, {useEffect, useRef, useState} from 'react';
 import {useApi} from '../Api/useApi';
 import {IFile, IFolder} from './types';
-import FileItem from './FileItem';
-import FolderItem from './FolderItem';
+import FileCard from './FileCard';
+import FolderCard from './FolderCard';
 import {FC, FRSE} from 'wide-containers';
 import MoveDialog from './MoveDialog';
 import ShareDialog from './ShareDialog';
@@ -69,6 +69,11 @@ const Master: React.FC = () => {
         setShowCreate(false); setNewFolderName(''); load();
     };
 
+    const handleDeleteFolder = async (id: number) => {
+        await api.delete('/api/v1/filehost/item/delete/', {data:{folder_id:id}});
+        load();
+    };
+
     return (
         <FC g={0.5}
             ref={containerRef}
@@ -86,15 +91,21 @@ const Master: React.FC = () => {
                 <Button onClick={()=>setShowCreate(true)}>{t('create_folder')}</Button>
                 <FileUpload onFileSelect={handleUpload}/>
             </FRSE>
-            {folders.map(f => <FolderItem key={f.id} id={f.id} name={f.name}/>) }
-            {files.sort((a,b)=>new Date(b.created_at).getTime()-new Date(a.created_at).getTime()).map(f => (
-                <FileItem key={f.id} file={f} selectMode={selectMode} selected={!!selected.find(s=>s.id===f.id)}
-                          onToggleSelect={toggleSelect}
-                          onSelectMode={()=>{setSelectMode(true); toggleSelect(f);}}
-                          onDelete={()=>{setSelected([f]); setConfirmOpen(true);}}
-                          onShare={()=>setShowShare(f)}
-                          onDownload={file=>window.open(file.file)}/>
-            ))}
+            <div style={{display:'flex',flexWrap:'wrap',gap:8}}>
+                {folders.map(f => (
+                    <FolderCard key={f.id} id={f.id} name={f.name} onDelete={handleDeleteFolder} onRenamed={load}/>
+                ))}
+                {files
+                    .sort((a,b)=>new Date(b.created_at).getTime()-new Date(a.created_at).getTime())
+                    .map(f => (
+                        <FileCard key={f.id} file={f} selectMode={selectMode} selected={!!selected.find(s=>s.id===f.id)}
+                                 onToggleSelect={toggleSelect}
+                                 onSelectMode={()=>{setSelectMode(true); toggleSelect(f);}}
+                                 onDelete={()=>{setSelected([f]); setConfirmOpen(true);}}
+                                 onShare={()=>setShowShare(f)}
+                                 onDownload={file=>window.open(file.file)}/>
+                    ))}
+            </div>
 
             <Menu open={!!context} onClose={()=>setContext(null)} anchorReference="anchorPosition"
                   anchorPosition={context ? {top: context.y, left: context.x} : undefined}>

--- a/frontend/src/Modules/FileHost/RenameDialog.tsx
+++ b/frontend/src/Modules/FileHost/RenameDialog.tsx
@@ -1,0 +1,42 @@
+import React, {useEffect, useState} from 'react';
+import {Dialog, DialogTitle, DialogContent, DialogActions, Button, TextField} from '@mui/material';
+import {useApi} from '../Api/useApi';
+import {useTranslation} from 'react-i18next';
+
+interface Props {
+    id: number | null;
+    name: string;
+    open: boolean;
+    onClose: () => void;
+    onRenamed?: () => void;
+}
+
+const RenameDialog: React.FC<Props> = ({id, name, open, onClose, onRenamed}) => {
+    const {api} = useApi();
+    const {t} = useTranslation();
+    const [value, setValue] = useState(name);
+
+    useEffect(() => { setValue(name); }, [name]);
+
+    const handleRename = async () => {
+        if (!id) return;
+        await api.post('/api/v1/filehost/item/rename/', {item_id: id, new_name: value});
+        onClose();
+        onRenamed && onRenamed();
+    };
+
+    return (
+        <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+            <DialogTitle>{t('rename')}</DialogTitle>
+            <DialogContent>
+                <TextField fullWidth value={value} onChange={e=>setValue(e.target.value)}/>
+            </DialogContent>
+            <DialogActions>
+                <Button onClick={onClose}>{t('cancel')}</Button>
+                <Button onClick={handleRename}>{t('save')}</Button>
+            </DialogActions>
+        </Dialog>
+    );
+};
+
+export default RenameDialog;

--- a/frontend/src/Modules/FileHost/index.ts
+++ b/frontend/src/Modules/FileHost/index.ts
@@ -1,5 +1,7 @@
 export {default as Storage} from './Storage';
 export {default as FileDetail} from './FileDetail';
 export {default as FolderItem} from './FolderItem';
+export {default as FileCard} from './FileCard';
+export {default as FolderCard} from './FolderCard';
 export {default as useFileUpload} from './useFileUpload';
 export {default as FileTableRow} from './FileTableRow';

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -107,6 +107,7 @@
   "share": "Share",
   "select": "Select",
   "move": "Move",
+  "rename": "Rename",
   "delete_confirm": "Delete?",
   "multi_delete_confirm": "Delete selected files?",
   "create_folder": "Create folder",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -107,6 +107,7 @@
   "share": "Поделиться",
   "select": "Выделить",
   "move": "Переместить",
+  "rename": "Переименовать",
   "delete_confirm": "Удалить?",
   "multi_delete_confirm": "Удалить выбранные файлы?",
   "create_folder": "Создать папку",


### PR DESCRIPTION
## Summary
- implement rename_item API endpoint
- expose the new endpoint in routes
- add FileCard and FolderCard components for grid view
- add RenameDialog helper
- update Master page to use new cards and allow folder rename/delete
- provide translation strings for rename

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68662d0d1fec8330b64dbb4a0cffedbf