### PR TITLE
Fix context menu click handling

### DIFF
--- a/frontend/src/Modules/FileHost/FileCard.tsx
+++ b/frontend/src/Modules/FileHost/FileCard.tsx
@@ -40,6 +40,10 @@ const FileCard: React.FC<Props> = ({file, selectMode, selected, onToggleSelect, 
     const handleToggleSelect = () => { onToggleSelect && onToggleSelect(file); setAnchorEl(null); };
 
     const handleClick = () => {
+        if (anchorEl) {
+            setAnchorEl(null);
+            return;
+        }
         if (selectMode) {
             onToggleSelect && onToggleSelect(file);
         } else {

--- a/frontend/src/Modules/FileHost/FileTableRow.tsx
+++ b/frontend/src/Modules/FileHost/FileTableRow.tsx
@@ -41,6 +41,10 @@ const FileTableRow: React.FC<Props> = ({file, selectMode, selected, onToggleSele
     const handleToggleSelect = () => { onToggleSelect && onToggleSelect(file); setAnchorEl(null); };
 
     const handleClick = () => {
+        if (anchorEl) {
+            setAnchorEl(null);
+            return;
+        }
         if (selectMode) {
             onToggleSelect && onToggleSelect(file);
         } else {


### PR DESCRIPTION
## Summary
- close context menu without navigating to file

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68663082701883309fd03c7b1599a4a2