### PR TITLE
Add long press support and FileActions menu

### DIFF
--- a/frontend/src/Modules/FileHost/FileActions.tsx
+++ b/frontend/src/Modules/FileHost/FileActions.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import {Menu, MenuItem} from '@mui/material';
+import {IFile} from './types';
+import {useTranslation} from 'react-i18next';
+
+interface Props {
+    anchorEl: HTMLElement | null;
+    file: IFile;
+    selectMode?: boolean;
+    selected?: boolean;
+    onClose: () => void;
+    onToggleSelect?: (f: IFile) => void;
+    onToggleFavorite?: (f: IFile) => void;
+    onDelete?: (f: IFile) => void;
+    onDownload?: (f: IFile) => void;
+    onShare?: (f: IFile) => void;
+    onSelectMode?: (f: IFile) => void;
+}
+
+const FileActions: React.FC<Props> = ({anchorEl, file, selectMode, selected, onClose, onToggleSelect, onToggleFavorite, onDelete, onDownload, onShare, onSelectMode}) => {
+    const {t} = useTranslation();
+
+    const handleDownload = () => { onDownload && onDownload(file); onClose(); };
+    const handleShare = () => { onShare && onShare(file); onClose(); };
+    const handleDelete = () => { onDelete && onDelete(file); onClose(); };
+    const handleSelectMode = () => { onSelectMode && onSelectMode(file); onClose(); };
+    const handleToggleSelect = () => { onToggleSelect && onToggleSelect(file); onClose(); };
+    const handleFavorite = () => { onToggleFavorite && onToggleFavorite(file); onClose(); };
+
+    return (
+        <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={onClose}>
+            <MenuItem onClick={handleDownload}>{t('download')}</MenuItem>
+            <MenuItem onClick={handleShare}>{t('share')}</MenuItem>
+            {selectMode ? (
+                <MenuItem onClick={handleToggleSelect}>{t('select')}</MenuItem>
+            ) : (
+                <MenuItem onClick={handleSelectMode}>{t('select')}</MenuItem>
+            )}
+            <MenuItem onClick={handleFavorite}>{file.is_favorite ? 'Unfavorite' : 'Favorite'}</MenuItem>
+            <MenuItem onClick={handleDelete}>{t('delete')}</MenuItem>
+        </Menu>
+    );
+};
+
+export default FileActions;

--- a/frontend/src/Modules/FileHost/FileCard.tsx
+++ b/frontend/src/Modules/FileHost/FileCard.tsx
@@ -1,5 +1,5 @@
 import React, {useState} from 'react';
-import {Checkbox, IconButton, Menu, MenuItem, Paper} from '@mui/material';
+import {Checkbox, IconButton, Paper} from '@mui/material';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
 import StarIcon from '@mui/icons-material/Star';
 import StarBorderIcon from '@mui/icons-material/StarBorder';
@@ -8,6 +8,8 @@ import {useApi} from '../Api/useApi';
 import {IFile} from './types';
 import formatFileSize from 'Utils/formatFileSize';
 import {useTranslation} from 'react-i18next';
+import useLongPress from './useLongPress';
+import FileActions from './FileActions';
 
 interface Props {
     file: IFile;
@@ -26,6 +28,8 @@ const FileCard: React.FC<Props> = ({file, selectMode, selected, onToggleSelect, 
     const navigate = useNavigate();
     const {t} = useTranslation();
     const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+
+    const longPress = useLongPress(e => setAnchorEl(e.currentTarget));
 
     const toggleFav = () => {
         api.post('/api/v1/filehost/files/toggle_favorite/', {file_id: file.id}).then(d => {
@@ -52,7 +56,10 @@ const FileCard: React.FC<Props> = ({file, selectMode, selected, onToggleSelect, 
     };
 
     return (
-        <Paper sx={{p:1,width:150}} onClick={handleClick} onContextMenu={e=>{e.preventDefault();setAnchorEl(e.currentTarget);}}>
+        <Paper sx={{p:1,width:150}}
+               onClick={handleClick}
+               onContextMenu={e=>{e.preventDefault();setAnchorEl(e.currentTarget);}}
+               {...longPress}>
             <div style={{display:'flex',justifyContent:'space-between',alignItems:'center'}}>
                 {selectMode && <Checkbox size="small" checked={selected} onChange={handleToggleSelect}/>} 
                 <IconButton size="small" onClick={e=>{e.stopPropagation();toggleFav();}} sx={{color:file.is_favorite? '#fbc02d':'inherit'}}>
@@ -64,17 +71,19 @@ const FileCard: React.FC<Props> = ({file, selectMode, selected, onToggleSelect, 
             </div>
             <div style={{wordBreak:'break-all',fontSize:'0.9rem'}}>{file.name}</div>
             <div style={{fontSize:'0.75rem',color:'#666'}}>{new Date(file.created_at).toLocaleDateString()} · {formatFileSize(file.size)}</div>
-            <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={()=>setAnchorEl(null)}>
-                <MenuItem onClick={handleDownload}>{t('download')}</MenuItem>
-                <MenuItem onClick={handleShare}>{t('share')}</MenuItem>
-                {selectMode ? (
-                    <MenuItem onClick={handleToggleSelect}>{t('select')}</MenuItem>
-                ) : (
-                    <MenuItem onClick={handleSelectMode}>{t('select')}</MenuItem>
-                )}
-                <MenuItem onClick={toggleFav}>{file.is_favorite ? 'Unfavorite' : 'Favorite'}</MenuItem>
-                <MenuItem onClick={handleDelete}>{t('delete')}</MenuItem>
-            </Menu>
+            <FileActions
+                anchorEl={anchorEl}
+                file={file}
+                selectMode={selectMode}
+                selected={selected}
+                onClose={()=>setAnchorEl(null)}
+                onToggleSelect={onToggleSelect}
+                onSelectMode={onSelectMode}
+                onDelete={onDelete}
+                onDownload={onDownload}
+                onShare={onShare}
+                onToggleFavorite={() => {toggleFav();}}
+            />
         </Paper>
     );
 };

--- a/frontend/src/Modules/FileHost/FileTableRow.tsx
+++ b/frontend/src/Modules/FileHost/FileTableRow.tsx
@@ -1,5 +1,5 @@
 import React, {useState} from 'react';
-import {Checkbox, IconButton, Menu, MenuItem} from '@mui/material';
+import {Checkbox, IconButton} from '@mui/material';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
 import StarIcon from '@mui/icons-material/Star';
 import StarBorderIcon from '@mui/icons-material/StarBorder';
@@ -9,6 +9,8 @@ import {useApi} from '../Api/useApi';
 import {FRSE} from 'wide-containers';
 import {useNavigate} from 'react-router-dom';
 import {useTranslation} from 'react-i18next';
+import useLongPress from './useLongPress';
+import FileActions from './FileActions';
 
 interface Props {
     file: IFile;
@@ -27,6 +29,7 @@ const FileTableRow: React.FC<Props> = ({file, selectMode, selected, onToggleSele
     const {t} = useTranslation();
     const navigate = useNavigate();
     const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+    const longPress = useLongPress(e => setAnchorEl(e.currentTarget));
 
     const toggleFav = () => {
         api.post('/api/v1/filehost/files/toggle_favorite/', {file_id: file.id}).then(d => {
@@ -53,7 +56,9 @@ const FileTableRow: React.FC<Props> = ({file, selectMode, selected, onToggleSele
     };
 
     return (
-        <FRSE p={0.5} borderBottom={'1px solid #ccc'} onClick={handleClick} onContextMenu={e=>{e.preventDefault();setAnchorEl(e.currentTarget);}}
+        <FRSE p={0.5} borderBottom={'1px solid #ccc'} onClick={handleClick}
+              onContextMenu={e=>{e.preventDefault();setAnchorEl(e.currentTarget);}}
+              {...longPress}
               sx={{gridTemplateColumns: selectMode ? '24px 1fr 160px 100px auto' : '1fr 160px 100px auto', display:'grid', alignItems:'center'}}>
             {selectMode && <Checkbox size="small" checked={selected} onChange={handleToggleSelect}/>}
             <span>{file.name}</span>
@@ -66,17 +71,19 @@ const FileTableRow: React.FC<Props> = ({file, selectMode, selected, onToggleSele
                 <IconButton size="small" onClick={e=>{e.stopPropagation();setAnchorEl(e.currentTarget);}}>
                     <MoreVertIcon fontSize="small"/>
                 </IconButton>
-                <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={()=>setAnchorEl(null)}>
-                    <MenuItem onClick={handleDownload}>{t('download')}</MenuItem>
-                    <MenuItem onClick={handleShare}>{t('share')}</MenuItem>
-                    {selectMode ? (
-                        <MenuItem onClick={handleToggleSelect}>{t('select')}</MenuItem>
-                    ) : (
-                        <MenuItem onClick={handleSelectMode}>{t('select')}</MenuItem>
-                    )}
-                    <MenuItem onClick={toggleFav}>{file.is_favorite ? 'Unfavorite' : 'Favorite'}</MenuItem>
-                    <MenuItem onClick={handleDelete}>{t('delete')}</MenuItem>
-                </Menu>
+                <FileActions
+                    anchorEl={anchorEl}
+                    file={file}
+                    selectMode={selectMode}
+                    selected={selected}
+                    onClose={()=>setAnchorEl(null)}
+                    onToggleSelect={onToggleSelect}
+                    onSelectMode={onSelectMode}
+                    onDelete={onDelete}
+                    onDownload={onDownload}
+                    onShare={onShare}
+                    onToggleFavorite={() => {toggleFav();}}
+                />
             </FRSE>
         </FRSE>
     );

--- a/frontend/src/Modules/FileHost/index.ts
+++ b/frontend/src/Modules/FileHost/index.ts
@@ -5,3 +5,5 @@ export {default as FileCard} from './FileCard';
 export {default as FolderCard} from './FolderCard';
 export {default as useFileUpload} from './useFileUpload';
 export {default as FileTableRow} from './FileTableRow';
+export {default as FileActions} from './FileActions';
+export {default as useLongPress} from './useLongPress';

--- a/frontend/src/Modules/FileHost/useLongPress.ts
+++ b/frontend/src/Modules/FileHost/useLongPress.ts
@@ -1,0 +1,32 @@
+import {useRef} from 'react';
+
+export interface LongPressHandlers {
+    onTouchStart: (e: React.TouchEvent) => void;
+    onTouchEnd: () => void;
+    onTouchMove: () => void;
+    onTouchCancel: () => void;
+}
+
+const useLongPress = (cb: (e: React.TouchEvent) => void, ms = 600): LongPressHandlers => {
+    const timer = useRef<NodeJS.Timeout | null>(null);
+
+    const start = (e: React.TouchEvent) => {
+        timer.current = setTimeout(() => cb(e), ms);
+    };
+
+    const clear = () => {
+        if (timer.current) {
+            clearTimeout(timer.current);
+            timer.current = null;
+        }
+    };
+
+    return {
+        onTouchStart: start,
+        onTouchEnd: clear,
+        onTouchMove: clear,
+        onTouchCancel: clear,
+    };
+};
+
+export default useLongPress;


### PR DESCRIPTION
## Summary
- create reusable `FileActions` component for file context actions
- add `useLongPress` hook
- use new components in `FileCard` and `FileTableRow`
- export helpers from index

## Testing
- `npm test` *(fails: craco not found)*

------
https://chatgpt.com/codex/tasks/task_e_686632123aac8330961b78add57b72b8