### PR TITLE
Improve FileHost UX

### DIFF
--- a/frontend/src/Modules/FileHost/FileCard.tsx
+++ b/frontend/src/Modules/FileHost/FileCard.tsx
@@ -1,8 +1,7 @@
-import React, {useState} from 'react';
+import React, {useEffect, useState} from 'react';
 import {Checkbox, IconButton, Paper} from '@mui/material';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
 import StarIcon from '@mui/icons-material/Star';
-import StarBorderIcon from '@mui/icons-material/StarBorder';
 import {useNavigate} from 'react-router-dom';
 import {useApi} from '../Api/useApi';
 import {IFile} from './types';
@@ -28,11 +27,15 @@ const FileCard: React.FC<Props> = ({file, selectMode, selected, onToggleSelect, 
     const navigate = useNavigate();
     const {t} = useTranslation();
     const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+    const [favorite, setFavorite] = useState(file.is_favorite);
+
+    useEffect(() => setFavorite(file.is_favorite), [file.is_favorite]);
 
     const longPress = useLongPress(e => setAnchorEl(e.currentTarget as HTMLElement));
 
     const toggleFav = () => {
         api.post('/api/v1/filehost/files/toggle_favorite/', {file_id: file.id}).then(d => {
+            setFavorite(d.is_favorite);
             onFavorite && onFavorite({...file, is_favorite: d.is_favorite});
         });
     };
@@ -62,9 +65,11 @@ const FileCard: React.FC<Props> = ({file, selectMode, selected, onToggleSelect, 
                {...longPress}>
             <div style={{display:'flex',justifyContent:'space-between',alignItems:'center'}}>
                 {selectMode && <Checkbox size="small" checked={selected} onChange={handleToggleSelect}/>} 
-                <IconButton size="small" onClick={e=>{e.stopPropagation();toggleFav();}} sx={{color:file.is_favorite? '#fbc02d':'inherit'}}>
-                    {file.is_favorite ? <StarIcon fontSize="small"/> : <StarBorderIcon fontSize="small"/>}
-                </IconButton>
+                {favorite && (
+                    <IconButton size="small" onClick={e=>{e.stopPropagation();toggleFav();}} sx={{color:'#fbc02d'}}>
+                        <StarIcon fontSize="small"/>
+                    </IconButton>
+                )}
                 <IconButton size="small" onClick={e=>{e.stopPropagation();setAnchorEl(e.currentTarget);}}>
                     <MoreVertIcon fontSize="small"/>
                 </IconButton>
@@ -73,7 +78,7 @@ const FileCard: React.FC<Props> = ({file, selectMode, selected, onToggleSelect, 
             <div style={{fontSize:'0.75rem',color:'#666'}}>{new Date(file.created_at).toLocaleDateString()} · {formatFileSize(file.size)}</div>
             <FileActions
                 anchorEl={anchorEl}
-                file={file}
+                file={{...file, is_favorite: favorite}}
                 selectMode={selectMode}
                 selected={selected}
                 onClose={()=>setAnchorEl(null)}

--- a/frontend/src/Modules/FileHost/FileDetail.tsx
+++ b/frontend/src/Modules/FileHost/FileDetail.tsx
@@ -1,5 +1,5 @@
 import React, {useEffect, useState} from 'react';
-import {useParams} from 'react-router-dom';
+import {useParams, useNavigate} from 'react-router-dom';
 import {useApi} from '../Api/useApi';
 import {IFile} from './types';
 import {FC} from 'wide-containers';
@@ -7,6 +7,7 @@ import {FC} from 'wide-containers';
 const FileDetail: React.FC = () => {
     const {id} = useParams();
     const {api} = useApi();
+    const navigate = useNavigate();
     const [file, setFile] = useState<IFile | null>(null);
     useEffect(() => {
         if (id) api.post('/api/v1/filehost/file/', {id: Number(id)}).then(setFile);
@@ -14,6 +15,9 @@ const FileDetail: React.FC = () => {
     if (!file) return null;
     return (
         <FC g={1} p={2}>
+            <div>
+                <button onClick={() => navigate(-1)}>Back</button>
+            </div>
             <h3>{file.name}</h3>
             <a href={file.file} target="_blank" rel="noreferrer">Open</a>
         </FC>

--- a/frontend/src/Modules/FileHost/FileItem.tsx
+++ b/frontend/src/Modules/FileHost/FileItem.tsx
@@ -1,8 +1,7 @@
-import React, {useState} from 'react';
+import React, {useEffect, useState} from 'react';
 import {Menu, MenuItem, IconButton, Checkbox} from '@mui/material';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
 import StarIcon from '@mui/icons-material/Star';
-import StarBorderIcon from '@mui/icons-material/StarBorder';
 import {IFile} from './types';
 import {useApi} from '../Api/useApi';
 import {FRSE} from 'wide-containers';
@@ -26,9 +25,13 @@ const FileItem: React.FC<Props> = ({file, selectMode, selected, onToggleSelect, 
     const {t} = useTranslation();
     const navigate = useNavigate();
     const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+    const [favorite, setFavorite] = useState(file.is_favorite);
+
+    useEffect(() => setFavorite(file.is_favorite), [file.is_favorite]);
 
     const toggleFav = () => {
         api.post('/api/v1/filehost/files/toggle_favorite/', {file_id: file.id}).then((d) => {
+            setFavorite(d.is_favorite);
             onFavorite && onFavorite({...file, is_favorite: d.is_favorite});
         });
     };
@@ -71,10 +74,12 @@ const FileItem: React.FC<Props> = ({file, selectMode, selected, onToggleSelect, 
             {selectMode && <Checkbox size="small" checked={selected} onChange={handleToggleSelect}/>} 
             <span style={{flexGrow:1}}>{file.name}</span>
             <FRSE g={0.5}>
-                <IconButton size="small" onClick={(e)=>{e.stopPropagation();toggleFav();}}
-                            sx={{color:file.is_favorite? '#fbc02d': 'inherit'}}>
-                    {file.is_favorite ? <StarIcon fontSize="small"/> : <StarBorderIcon fontSize="small"/>}
-                </IconButton>
+                {favorite && (
+                    <IconButton size="small" onClick={(e)=>{e.stopPropagation();toggleFav();}}
+                                sx={{color:'#fbc02d'}}>
+                        <StarIcon fontSize="small"/>
+                    </IconButton>
+                )}
                 <IconButton size="small" onClick={(e) => {e.stopPropagation();setAnchorEl(e.currentTarget);}}>
                     <MoreVertIcon fontSize="small"/>
                 </IconButton>
@@ -86,7 +91,7 @@ const FileItem: React.FC<Props> = ({file, selectMode, selected, onToggleSelect, 
                     ) : (
                         <MenuItem onClick={handleSelectMode}>{t('select')}</MenuItem>
                     )}
-                    <MenuItem onClick={toggleFav}>{file.is_favorite ? 'Unfavorite' : 'Favorite'}</MenuItem>
+                    <MenuItem onClick={toggleFav}>{favorite ? 'Unfavorite' : 'Favorite'}</MenuItem>
                     <MenuItem onClick={handleDelete}>{t('delete')}</MenuItem>
                 </Menu>
             </FRSE>

--- a/frontend/src/Modules/FileHost/FileTableRow.tsx
+++ b/frontend/src/Modules/FileHost/FileTableRow.tsx
@@ -1,8 +1,7 @@
-import React, {useState} from 'react';
+import React, {useEffect, useState} from 'react';
 import {Checkbox, IconButton} from '@mui/material';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
 import StarIcon from '@mui/icons-material/Star';
-import StarBorderIcon from '@mui/icons-material/StarBorder';
 import {IFile} from './types';
 import formatFileSize from 'Utils/formatFileSize';
 import {useApi} from '../Api/useApi';
@@ -29,10 +28,14 @@ const FileTableRow: React.FC<Props> = ({file, selectMode, selected, onToggleSele
     const {t} = useTranslation();
     const navigate = useNavigate();
     const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+    const [favorite, setFavorite] = useState(file.is_favorite);
+
+    useEffect(() => setFavorite(file.is_favorite), [file.is_favorite]);
     const longPress = useLongPress(e => setAnchorEl(e.currentTarget as HTMLElement));
 
     const toggleFav = () => {
         api.post('/api/v1/filehost/files/toggle_favorite/', {file_id: file.id}).then(d => {
+            setFavorite(d.is_favorite);
             onFavorite && onFavorite({...file, is_favorite: d.is_favorite});
         });
     };
@@ -65,15 +68,17 @@ const FileTableRow: React.FC<Props> = ({file, selectMode, selected, onToggleSele
             <span>{new Date(file.created_at).toLocaleString()}</span>
             <span>{formatFileSize(file.size)}</span>
             <FRSE g={0.5}>
-                <IconButton size="small" onClick={e=>{e.stopPropagation();toggleFav();}} sx={{color:file.is_favorite? '#fbc02d':'inherit'}}>
-                    {file.is_favorite ? <StarIcon fontSize="small"/> : <StarBorderIcon fontSize="small"/>}
-                </IconButton>
+                {favorite && (
+                    <IconButton size="small" onClick={e=>{e.stopPropagation();toggleFav();}} sx={{color:'#fbc02d'}}>
+                        <StarIcon fontSize="small"/>
+                    </IconButton>
+                )}
                 <IconButton size="small" onClick={e=>{e.stopPropagation();setAnchorEl(e.currentTarget);}}>
                     <MoreVertIcon fontSize="small"/>
                 </IconButton>
                 <FileActions
                     anchorEl={anchorEl}
-                    file={file}
+                    file={{...file, is_favorite: favorite}}
                     selectMode={selectMode}
                     selected={selected}
                     onClose={()=>setAnchorEl(null)}

--- a/frontend/src/Modules/FileHost/MoveDialog.tsx
+++ b/frontend/src/Modules/FileHost/MoveDialog.tsx
@@ -35,7 +35,6 @@ const MoveDialog: React.FC<Props> = ({files, open, onClose}) => {
             <DialogTitle>{t('move')}</DialogTitle>
             <DialogContent>
                 <Select fullWidth value={target} onChange={e=>setTarget(Number(e.target.value))}>
-                    <MenuItem value=''>root</MenuItem>
                     {folders.map(f=>(<MenuItem key={f.id} value={f.id}>{f.name}</MenuItem>))}
                 </Select>
             </DialogContent>

--- a/frontend/src/Modules/FileHost/ShareDialog.tsx
+++ b/frontend/src/Modules/FileHost/ShareDialog.tsx
@@ -1,5 +1,6 @@
-import React, {useState} from 'react';
-import {Dialog, DialogTitle, DialogContent, DialogActions, Button, TextField, Chip, Checkbox, FormControlLabel} from '@mui/material';
+import React, {useEffect, useState} from 'react';
+import {Dialog, DialogTitle, DialogContent, DialogActions, Button, TextField, Chip, Checkbox, FormControlLabel, IconButton} from '@mui/material';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import {useApi} from '../Api/useApi';
 import {useTranslation} from 'react-i18next';
 import {IFile} from './types';
@@ -16,6 +17,7 @@ const ShareDialog: React.FC<Props> = ({file, open, onClose}) => {
     const [emails, setEmails] = useState<string[]>([]);
     const [email, setEmail] = useState('');
     const [isPublic, setIsPublic] = useState(false);
+    const [publicAccess, setPublicAccess] = useState<any|null>(null);
     const handleAddEmail = () => {
         if (email && !emails.includes(email)) {
             setEmails([...emails, email]);
@@ -24,22 +26,54 @@ const ShareDialog: React.FC<Props> = ({file, open, onClose}) => {
     };
     const handleDeleteEmail = (e: string) => setEmails(emails.filter(x => x !== e));
 
+    useEffect(() => {
+        if (open && file) {
+            api.get(`/api/v1/filehost/access/list/?file_id=${file.id}`).then((d: any[]) => {
+                const pub = d.find(a => a.is_public);
+                setPublicAccess(pub || null);
+                setIsPublic(!!pub);
+            });
+        }
+    }, [open, file]);
+
     const handleShare = async () => {
         if (!file) return;
-        if (isPublic) await api.post('/api/v1/filehost/access/grant/', {file_id: file.id, is_public: true});
+        if (isPublic && !publicAccess) {
+            const res = await api.post('/api/v1/filehost/access/grant/', {file_id: file.id, is_public: true});
+            setPublicAccess(res);
+        }
         for (const em of emails) {
             await api.post('/api/v1/filehost/access/grant/', {file_id: file.id, email: em});
         }
         onClose();
         setEmails([]);
-        setIsPublic(false);
+    };
+
+    const handlePublicChange = async (checked: boolean) => {
+        setIsPublic(checked);
+        if (!file) return;
+        if (checked) {
+            const res = await api.post('/api/v1/filehost/access/grant/', {file_id: file.id, is_public: true});
+            setPublicAccess(res);
+        } else if (publicAccess) {
+            await api.delete('/api/v1/filehost/access/revoke/', {data:{access_id: publicAccess.id}});
+            setPublicAccess(null);
+        }
     };
 
     return (
         <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
             <DialogTitle>{t('share')}</DialogTitle>
             <DialogContent>
-                <FormControlLabel control={<Checkbox checked={isPublic} onChange={e=>setIsPublic(e.target.checked)}/>} label="Public" />
+                <FormControlLabel control={<Checkbox checked={isPublic} onChange={e=>handlePublicChange(e.target.checked)}/>} label="Public" />
+                {publicAccess && (
+                    <div style={{display:'flex',alignItems:'center',marginBottom:8}}>
+                        <TextField fullWidth value={`${window.location.origin}/public/${publicAccess.public_link}`} InputProps={{readOnly:true}}/>
+                        <IconButton onClick={()=>navigator.clipboard.writeText(`${window.location.origin}/public/${publicAccess.public_link}`)}>
+                            <ContentCopyIcon fontSize="small"/>
+                        </IconButton>
+                    </div>
+                )}
                 <TextField fullWidth label="Email" value={email} onChange={e=>setEmail(e.target.value)} onKeyDown={e=>{if(e.key==='Enter'){e.preventDefault();handleAddEmail();}}} />
                 <div style={{display:'flex',flexWrap:'wrap',gap:4,marginTop:8}}>
                     {emails.map(e=>(<Chip key={e} label={e} onDelete={()=>handleDeleteEmail(e)}/>))}


### PR DESCRIPTION
## Summary
- add back button on file detail screen
- show favorite star only when file is favorite and fix toggle
- display and copy public share link in Share dialog
- avoid duplicate root option in Move dialog

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*
- `npm test --silent` *(fails: craco: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68664b24e998833082385b71584f7aa8