### PR TITLE
Fix grid alignment and use Table

### DIFF
--- a/frontend/src/Modules/Core/components/elements/PaginatedList.tsx
+++ b/frontend/src/Modules/Core/components/elements/PaginatedList.tsx
@@ -1,7 +1,7 @@
 // Modules/Core/components/elements/PaginatedList.tsx
 
 import React, {useCallback, useEffect, useRef, useState} from 'react';
-import {FC, FCCC} from "wide-containers";
+import {FC as FCContainer, FCCC} from "wide-containers";
 import CircularProgress from "Core/components/elements/CircularProgress";
 
 interface PaginatedListProps<T> {
@@ -13,6 +13,7 @@ interface PaginatedListProps<T> {
     resetTrigger?: any;
     loadMoreAtTop?: boolean;
     renderEmpty?: () => React.ReactNode;
+    component?: React.ElementType;
 }
 
 const PaginatedList = <T extends unknown>(
@@ -25,6 +26,7 @@ const PaginatedList = <T extends unknown>(
         resetTrigger,
         loadMoreAtTop = false,
         renderEmpty,
+        component: Component = FCContainer,
     }: PaginatedListProps<T>) => {
     const [data, setData] = useState<T[]>([]);
     const [page, setPage] = useState<number>(1);
@@ -90,7 +92,7 @@ const PaginatedList = <T extends unknown>(
     }, [data, loadMoreAtTop]);
 
     return (
-        <FC cls={className} sx={style}>
+        <Component className={className} style={style}>
             {data.length === 0 && !loading && renderEmpty ? renderEmpty() : null}
             {loadMoreAtTop && hasMore && !loading && <div ref={targetRef}></div>}
             {data.map((item, index) => (
@@ -100,7 +102,7 @@ const PaginatedList = <T extends unknown>(
             ))}
             {!loadMoreAtTop && hasMore && <div ref={targetRef}></div>}
             {loading && <FCCC mt={4}><CircularProgress size={'120px'}/></FCCC>}
-        </FC>
+        </Component>
     );
 };
 

--- a/frontend/src/Modules/FileHost/AllFiles.tsx
+++ b/frontend/src/Modules/FileHost/AllFiles.tsx
@@ -7,7 +7,7 @@ import useFileUpload from './useFileUpload';
 import UploadProgressWindow from './UploadProgressWindow';
 import MoveDialog from './MoveDialog';
 import ShareDialog from './ShareDialog';
-import {Button, Dialog, DialogActions, DialogTitle, useMediaQuery} from '@mui/material';
+import {Button, Dialog, DialogActions, DialogTitle, Table, TableHead, TableBody, TableRow, TableCell, useMediaQuery} from '@mui/material';
 import {FR, FRC, FRSE} from 'wide-containers';
 import DropOverlay from './DropOverlay';
 import {useTranslation} from 'react-i18next';
@@ -51,30 +51,35 @@ const AllFiles: React.FC = () => {
                     <Button color="error" onClick={() => setConfirmOpen(true)}>Delete</Button>
                 </FRSE>
             )}
-            <FRSE p={0.5} sx={{gridTemplateColumns: selectMode ? '24px 1fr 160px 100px auto' : '1fr 160px 100px auto', display:'grid',fontWeight:600}}>
-                {selectMode && <span/>}
-                <FRC>{t('name')}</FRC>
-                {isGtSm && <FRC>{t('upload_date')}</FRC>}
-                <FRC>{t('size')}</FRC>
-                <span></span>
-            </FRSE>
-            <PaginatedList
-                loadData={load}
-                renderItem={(item) => (
-                    <FileTableRow
-                        key={item.id}
-                        file={item}
-                        selectMode={selectMode}
-                        selected={!!selected.find(s => s.id === item.id)}
-                        onToggleSelect={toggleSelect}
-                        onSelectMode={(f)=>{setSelectMode(true); toggleSelect(f);}}
-                        onDelete={()=>{setSelected([item]); setConfirmOpen(true);}}
-                        onDownload={f=>window.open(f.file)}
-                        onShare={()=>setShowShare(item)}
-                    />
-                )}
-                resetTrigger={trigger}
-            />
+            <Table size="small">
+                <TableHead>
+                    <TableRow>
+                        {selectMode && <TableCell padding="checkbox"/>}
+                        <TableCell>{t('name')}</TableCell>
+                        {isGtSm && <TableCell>{t('upload_date')}</TableCell>}
+                        <TableCell>{t('size')}</TableCell>
+                        <TableCell/>
+                    </TableRow>
+                </TableHead>
+                <PaginatedList
+                    loadData={load}
+                    component={TableBody}
+                    renderItem={(item) => (
+                        <FileTableRow
+                            key={item.id}
+                            file={item}
+                            selectMode={selectMode}
+                            selected={!!selected.find(s => s.id === item.id)}
+                            onToggleSelect={toggleSelect}
+                            onSelectMode={(f)=>{setSelectMode(true); toggleSelect(f);}}
+                            onDelete={()=>{setSelected([item]); setConfirmOpen(true);}}
+                            onDownload={f=>window.open(f.file)}
+                            onShare={()=>setShowShare(item)}
+                        />
+                    )}
+                    resetTrigger={trigger}
+                />
+            </Table>
             <MoveDialog files={selected} open={showMove} onClose={()=>{setShowMove(false); setSelected([]); setTrigger(t=>t+1);}}/>
             <ShareDialog file={showShare} open={!!showShare} onClose={()=>setShowShare(null)}/>
             <Dialog open={confirmOpen} onClose={()=>setConfirmOpen(false)}>

--- a/frontend/src/Modules/FileHost/FavoriteFiles.tsx
+++ b/frontend/src/Modules/FileHost/FavoriteFiles.tsx
@@ -7,7 +7,7 @@ import useFileUpload from './useFileUpload';
 import UploadProgressWindow from './UploadProgressWindow';
 import MoveDialog from './MoveDialog';
 import ShareDialog from './ShareDialog';
-import {Button, Dialog, DialogActions, DialogTitle} from '@mui/material';
+import {Button, Dialog, DialogActions, DialogTitle, Table, TableHead, TableBody, TableRow, TableCell, useMediaQuery} from '@mui/material';
 import {FRSE} from 'wide-containers';
 import DropOverlay from './DropOverlay';
 import {useTranslation} from 'react-i18next';
@@ -16,6 +16,7 @@ const FavoriteFiles: React.FC = () => {
     const {api} = useApi();
     const {handleUpload, uploads} = useFileUpload(null);
     const {t} = useTranslation();
+    const isGtSm = useMediaQuery('(min-width: 576px)');
 
     const [selected, setSelected] = useState<IFile[]>([]);
     const [selectMode, setSelectMode] = useState(false);
@@ -50,30 +51,35 @@ const FavoriteFiles: React.FC = () => {
                     <Button color="error" onClick={() => setConfirmOpen(true)}>Delete</Button>
                 </FRSE>
             )}
-            <FRSE p={0.5} sx={{gridTemplateColumns: selectMode ? '24px 1fr 160px 100px auto' : '1fr 160px 100px auto', display:'grid',fontWeight:600}}>
-                {selectMode && <span/>}
-                <span>{t('name')}</span>
-                <span>{t('upload_date')}</span>
-                <span>{t('size')}</span>
-                <span></span>
-            </FRSE>
-            <PaginatedList
-                loadData={load}
-                renderItem={(item) => (
-                    <FileTableRow
-                        key={item.id}
-                        file={item}
-                        selectMode={selectMode}
-                        selected={!!selected.find(s => s.id === item.id)}
-                        onToggleSelect={toggleSelect}
-                        onSelectMode={(f)=>{setSelectMode(true); toggleSelect(f);}}
-                        onDelete={()=>{setSelected([item]); setConfirmOpen(true);}}
-                        onDownload={f=>window.open(f.file)}
-                        onShare={()=>setShowShare(item)}
-                    />
-                )}
-                resetTrigger={trigger}
-            />
+            <Table size="small">
+                <TableHead>
+                    <TableRow>
+                        {selectMode && <TableCell padding="checkbox"/>}
+                        <TableCell>{t('name')}</TableCell>
+                        {isGtSm && <TableCell>{t('upload_date')}</TableCell>}
+                        <TableCell>{t('size')}</TableCell>
+                        <TableCell/>
+                    </TableRow>
+                </TableHead>
+                <PaginatedList
+                    loadData={load}
+                    component={TableBody}
+                    renderItem={(item) => (
+                        <FileTableRow
+                            key={item.id}
+                            file={item}
+                            selectMode={selectMode}
+                            selected={!!selected.find(s => s.id === item.id)}
+                            onToggleSelect={toggleSelect}
+                            onSelectMode={(f)=>{setSelectMode(true); toggleSelect(f);}}
+                            onDelete={()=>{setSelected([item]); setConfirmOpen(true);}}
+                            onDownload={f=>window.open(f.file)}
+                            onShare={()=>setShowShare(item)}
+                        />
+                    )}
+                    resetTrigger={trigger}
+                />
+            </Table>
             <MoveDialog files={selected} open={showMove} onClose={()=>{setShowMove(false); setSelected([]); setTrigger(t=>t+1);}}/>
             <ShareDialog file={showShare} open={!!showShare} onClose={()=>setShowShare(null)}/>
             <Dialog open={confirmOpen} onClose={()=>setConfirmOpen(false)}>

--- a/frontend/src/Modules/FileHost/FileTableRow.tsx
+++ b/frontend/src/Modules/FileHost/FileTableRow.tsx
@@ -1,11 +1,11 @@
 import React, {useEffect, useState} from 'react';
-import {Checkbox, IconButton, useMediaQuery} from '@mui/material';
+import {Checkbox, IconButton, TableRow, TableCell, useMediaQuery} from '@mui/material';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
 import StarIcon from '@mui/icons-material/Star';
 import {IFile} from './types';
 import formatFileSize from 'Utils/formatFileSize';
 import {useApi} from '../Api/useApi';
-import {FR, FRC, FRSE} from 'wide-containers';
+import {FRSE} from 'wide-containers';
 import {useNavigate} from 'react-router-dom';
 import {useTranslation} from 'react-i18next';
 import useLongPress from './useLongPress';
@@ -65,51 +65,63 @@ const FileTableRow: React.FC<Props> = ({
     };
 
     return (
-        <FRSE p={0.5} borderBottom={'1px solid #ccc'} onClick={handleClick}
-              onContextMenu={e => {
-                  e.preventDefault();
-                  setAnchorEl(e.currentTarget);
-              }} {...longPress} sx={{
-            gridTemplateColumns: selectMode ? '24px 1fr 160px 100px auto' : '1fr 160px 100px auto',
-            display: 'grid',
-            alignItems: 'center'
-        }}>
-            {selectMode && <Checkbox size="small" checked={selected} onChange={handleToggleSelect}/>}
-            <FR sx={{lineHeight: '1rem'}}>{file.name}</FR>
-            {isGtSm && <FRC>{new Date(file.created_at).toLocaleString()}</FRC>}
-            <FRC>{formatFileSize(file.size)}</FRC>
-            <FRSE g={0.5}>
-                {favorite && (
+        <TableRow
+            hover
+            onClick={handleClick}
+            onContextMenu={e => {
+                e.preventDefault();
+                setAnchorEl(e.currentTarget);
+            }}
+            {...longPress}
+            sx={{cursor: 'pointer'}}
+        >
+            {selectMode && (
+                <TableCell padding="checkbox">
+                    <Checkbox size="small" checked={selected} onChange={handleToggleSelect}
+                              onClick={e => e.stopPropagation()}/>
+                </TableCell>
+            )}
+            <TableCell component="th" scope="row" sx={{lineHeight: '1rem'}}>
+                {file.name}
+            </TableCell>
+            {isGtSm && (
+                <TableCell>{new Date(file.created_at).toLocaleString()}</TableCell>
+            )}
+            <TableCell>{formatFileSize(file.size)}</TableCell>
+            <TableCell>
+                <FRSE g={0.5}>
+                    {favorite && (
+                        <IconButton size="small" onClick={e => {
+                            e.stopPropagation();
+                            toggleFav();
+                        }} sx={{color: '#fbc02d'}}>
+                            <StarIcon fontSize="small"/>
+                        </IconButton>
+                    )}
                     <IconButton size="small" onClick={e => {
                         e.stopPropagation();
-                        toggleFav();
-                    }} sx={{color: '#fbc02d'}}>
-                        <StarIcon fontSize="small"/>
+                        setAnchorEl(e.currentTarget);
+                    }}>
+                        <MoreVertIcon fontSize="small"/>
                     </IconButton>
-                )}
-                <IconButton size="small" onClick={e => {
-                    e.stopPropagation();
-                    setAnchorEl(e.currentTarget);
-                }}>
-                    <MoreVertIcon fontSize="small"/>
-                </IconButton>
-                <FileActions
-                    anchorEl={anchorEl}
-                    file={{...file, is_favorite: favorite}}
-                    selectMode={selectMode}
-                    selected={selected}
-                    onClose={() => setAnchorEl(null)}
-                    onToggleSelect={onToggleSelect}
-                    onSelectMode={onSelectMode}
-                    onDelete={onDelete}
-                    onDownload={onDownload}
-                    onShare={onShare}
-                    onToggleFavorite={() => {
-                        toggleFav();
-                    }}
-                />
-            </FRSE>
-        </FRSE>
+                    <FileActions
+                        anchorEl={anchorEl}
+                        file={{...file, is_favorite: favorite}}
+                        selectMode={selectMode}
+                        selected={selected}
+                        onClose={() => setAnchorEl(null)}
+                        onToggleSelect={onToggleSelect}
+                        onSelectMode={onSelectMode}
+                        onDelete={onDelete}
+                        onDownload={onDownload}
+                        onShare={onShare}
+                        onToggleFavorite={() => {
+                            toggleFav();
+                        }}
+                    />
+                </FRSE>
+            </TableCell>
+        </TableRow>
     );
 };
 


### PR DESCRIPTION
## Summary
- let PaginatedList wrap items in custom components like `<tbody>`
- show file lists using MUI `<Table>` for consistent headers
- rewrite `FileTableRow` with `<TableRow>` so checkbox clicks don't trigger navigation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6866c73efe54833084be540195509e51