### PR TITLE
Improve storage interface

### DIFF
--- a/frontend/src/Modules/FileHost/DropOverlay.tsx
+++ b/frontend/src/Modules/FileHost/DropOverlay.tsx
@@ -39,7 +39,10 @@ const DropOverlay: React.FC<DropOverlayProps> = ({onFileDrop}) => {
     return <FR
         pos={'fixed'} sx={{inset: 0}}
         bg={'rgba(0,0,0,0.3)'} pEvents={false} zIndex={2000}
-    />;
+        justC={'center'} alignI={'center'} fontSize={'2rem'} color={'white'}
+    >
+        Drop!
+    </FR>;
 };
 
 export default DropOverlay;

--- a/frontend/src/Modules/FileHost/FileDetail.tsx
+++ b/frontend/src/Modules/FileHost/FileDetail.tsx
@@ -3,10 +3,14 @@ import {useNavigate, useParams} from 'react-router-dom';
 import {useApi} from '../Api/useApi';
 import {IFile} from './types';
 import {FC, FR} from 'wide-containers';
-import {Button} from '@mui/material';
+import {Button, IconButton} from '@mui/material';
+import DownloadIcon from '@mui/icons-material/Download';
+import ShareIcon from '@mui/icons-material/Share';
+import DeleteIcon from '@mui/icons-material/Delete';
 import formatFileSize from 'Utils/formatFileSize';
 import {useTranslation} from 'react-i18next';
 import BackButton from "Core/components/BackButton";
+import ShareDialog from './ShareDialog';
 
 const FileDetail: React.FC = () => {
     const {id} = useParams();
@@ -14,6 +18,7 @@ const FileDetail: React.FC = () => {
     const navigate = useNavigate();
     const {t} = useTranslation();
     const [file, setFile] = useState<IFile | null>(null);
+    const [showShare, setShowShare] = useState(false);
     useEffect(() => {
         if (id) api.post('/api/v1/filehost/file/', {id: Number(id)}).then(setFile);
     }, [id]);
@@ -24,9 +29,11 @@ const FileDetail: React.FC = () => {
             <FR component={'h3'}>{file.name}</FR>
             <FR>{t('upload_date')}: {new Date(file.created_at).toLocaleString()}</FR>
             <FR>{t('size')}: {formatFileSize(file.size)}</FR>
-            <Button variant="contained" href={file.file} target="_blank" rel="noreferrer">
-                {t('open')}
-            </Button>
+            <FR>
+                <IconButton onClick={() => window.open(file.file)}><DownloadIcon/></IconButton>
+                <IconButton onClick={() => setShowShare(true)}><ShareIcon/></IconButton>
+            </FR>
+            <ShareDialog file={file} open={showShare} onClose={() => setShowShare(false)}/>
         </FC>
     );
 };

--- a/frontend/src/Modules/FileHost/FolderCard.tsx
+++ b/frontend/src/Modules/FileHost/FolderCard.tsx
@@ -1,10 +1,10 @@
 import React, {useState} from 'react';
-import {IconButton, Menu, MenuItem, Paper} from '@mui/material';
-import MoreVertIcon from '@mui/icons-material/MoreVert';
+import {Menu, MenuItem, Paper} from '@mui/material';
 import {useNavigate} from 'react-router-dom';
 import {useTranslation} from 'react-i18next';
 import RenameDialog from './RenameDialog';
 import {useApi} from '../Api/useApi';
+import useLongPress from './useLongPress';
 
 interface Props {
     id: number;
@@ -19,6 +19,7 @@ const FolderCard: React.FC<Props> = ({id, name, onDelete, onRenamed}) => {
     const {api} = useApi();
     const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
     const [showRename, setShowRename] = useState(false);
+    const longPress = useLongPress(e => setAnchorEl(e.currentTarget as HTMLElement));
 
     const open = () => navigate(`/storage/master/${id}/`);
     const handleDelete = async () => {
@@ -28,15 +29,14 @@ const FolderCard: React.FC<Props> = ({id, name, onDelete, onRenamed}) => {
 
     return (
         <>
-            <Paper sx={{p:1,width:150,cursor:'pointer'}} onDoubleClick={open} onContextMenu={e=>{e.preventDefault();setAnchorEl(e.currentTarget);}}>
-                <div style={{display:'flex',justifyContent:'space-between',alignItems:'center'}}>
-                    <strong style={{wordBreak:'break-all'}}>{name}</strong>
-                    <IconButton size="small" onClick={e=>{e.stopPropagation();setAnchorEl(e.currentTarget);}}>
-                        <MoreVertIcon fontSize="small"/>
-                    </IconButton>
-                </div>
+            <Paper sx={{p:1,width:150,cursor:'pointer'}} onDoubleClick={open}
+                   onContextMenu={e=>{e.preventDefault();setAnchorEl(e.currentTarget);}}
+                   {...longPress}>
+                <strong style={{wordBreak:'break-all'}}>{name}</strong>
             </Paper>
-            <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={()=>setAnchorEl(null)}>
+            <Menu
+                slotProps={{backdrop:{sx:{backdropFilter:'none !important'}}}}
+                anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={()=>setAnchorEl(null)}>
                 <MenuItem onClick={()=>{setShowRename(true); setAnchorEl(null);}}>{t('rename')}</MenuItem>
                 <MenuItem onClick={handleDelete}>{t('delete')}</MenuItem>
             </Menu>

--- a/frontend/src/Modules/FileHost/FolderTableRow.tsx
+++ b/frontend/src/Modules/FileHost/FolderTableRow.tsx
@@ -1,10 +1,10 @@
 import React, {useState} from 'react';
-import {IconButton, Menu, MenuItem, TableCell, TableRow} from '@mui/material';
-import MoreVertIcon from '@mui/icons-material/MoreVert';
+import {Menu, MenuItem, TableCell, TableRow} from '@mui/material';
 import {useNavigate} from 'react-router-dom';
 import {useTranslation} from 'react-i18next';
 import RenameDialog from './RenameDialog';
 import {useApi} from '../Api/useApi';
+import useLongPress from './useLongPress';
 
 interface Props {
     id: number;
@@ -19,6 +19,7 @@ const FolderTableRow: React.FC<Props> = ({id, name, onDelete, onRenamed}) => {
     const {api} = useApi();
     const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
     const [showRename, setShowRename] = useState(false);
+    const longPress = useLongPress(e => setAnchorEl(e.currentTarget as HTMLElement));
 
     const open = () => navigate(`/storage/master/${id}/`);
     const handleDelete = async () => {
@@ -36,23 +37,16 @@ const FolderTableRow: React.FC<Props> = ({id, name, onDelete, onRenamed}) => {
                     e.preventDefault();
                     setAnchorEl(e.currentTarget);
                 }}
+                {...longPress}
             >
                 <TableCell component="th" scope="row">
                     {name}
                 </TableCell>
-                <TableCell align="right">
-                    <IconButton
-                        size="small"
-                        onClick={e => {
-                            e.stopPropagation();
-                            setAnchorEl(e.currentTarget);
-                        }}
-                    >
-                        <MoreVertIcon fontSize="small"/>
-                    </IconButton>
-                </TableCell>
+                <TableCell/>
             </TableRow>
-            <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={() => setAnchorEl(null)}>
+            <Menu
+                slotProps={{backdrop:{sx:{backdropFilter:'none !important'}}}}
+                anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={() => setAnchorEl(null)}>
                 <MenuItem
                     onClick={() => {
                         setShowRename(true);

--- a/frontend/src/Modules/FileHost/UploadProgressWindow.tsx
+++ b/frontend/src/Modules/FileHost/UploadProgressWindow.tsx
@@ -1,22 +1,48 @@
-import React from 'react';
-import {LinearProgress, Paper} from '@mui/material';
-import {FC} from 'wide-containers';
+import React, {useState} from 'react';
+import {LinearProgress, Paper, IconButton, Button} from '@mui/material';
+import {FC, FRSE} from 'wide-containers';
+import CheckIcon from '@mui/icons-material/Check';
+import ExpandLessIcon from '@mui/icons-material/ExpandLess';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 
 export interface UploadItem {name:string; progress:number;}
 
 interface Props {items: UploadItem[];}
 
-const UploadProgressWindow: React.FC<Props> = ({items}) => (
-    <Paper sx={{position:'fixed',bottom:16,right:16,p:2,width:250,zIndex:9999}}>
-        <FC g={1}>
-            {items.map(it=> (
-                <div key={it.name} style={{display:'flex',flexDirection:'column',gap:4}}>
-                    <span style={{fontSize:'0.8rem'}}>{it.name}</span>
-                    <LinearProgress variant="determinate" value={it.progress}/>
-                </div>
-            ))}
-        </FC>
-    </Paper>
-);
+const UploadProgressWindow: React.FC<Props> = ({items}) => {
+    const [collapsed, setCollapsed] = useState(false);
+    const [closed, setClosed] = useState(false);
+    const allDone = items.every(it=>it.progress===100);
+    if (closed) return null;
+    return (
+        <Paper sx={{position:'fixed',bottom:16,right:16,p:2,width:250,zIndex:9999}}>
+            <IconButton size="small" onClick={()=>setCollapsed(o=>!o)} sx={{position:'absolute',top:4,right:4}}>
+                {collapsed ? <ExpandMoreIcon/> : <ExpandLessIcon/>}
+            </IconButton>
+            {allDone && (
+                <IconButton size="small" onClick={()=>setClosed(true)} sx={{position:'absolute',top:4,left:4}}>
+                    <CheckIcon color="success"/>
+                </IconButton>
+            )}
+            {!collapsed && (
+                <FC g={1} mt={2}>
+                    {items.map(it=> (
+                        <div key={it.name} style={{display:'flex',flexDirection:'column',gap:4}}>
+                            <span style={{fontSize:'0.8rem'}}>{it.name}</span>
+                            {it.progress === 100 ? (
+                                <FRSE>
+                                    <CheckIcon color="success" fontSize="small"/>
+                                    <Button size="small">Share</Button>
+                                </FRSE>
+                            ) : (
+                                <LinearProgress variant="determinate" value={it.progress}/>
+                            )}
+                        </div>
+                    ))}
+                </FC>
+            )}
+        </Paper>
+    );
+};
 
 export default UploadProgressWindow;


### PR DESCRIPTION
## Summary
- add "Drop!" message to drag-n-drop overlay
- remove folder action button and enable long press context menu
- show folder path breadcrumbs in storage view
- update upload progress window with collapse and share prompt
- display file actions as icons in detail view

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6867960fac4c8330ae97c92130f42dc4