### PR TITLE
Implement folder actions component

### DIFF
--- a/frontend/src/Modules/FileHost/FolderActions.tsx
+++ b/frontend/src/Modules/FileHost/FolderActions.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import {Menu, MenuItem, IconButton, Tooltip} from '@mui/material';
+import DriveFileRenameOutlineIcon from '@mui/icons-material/DriveFileRenameOutline';
+import DeleteIcon from '@mui/icons-material/Delete';
+import {FRSE} from 'wide-containers';
+import {useTranslation} from 'react-i18next';
+
+interface Props {
+    anchorEl?: HTMLElement | null;
+    variant?: 'menu' | 'buttons';
+    onClose?: () => void;
+    onRename?: () => void;
+    onDelete?: () => void;
+}
+
+const FolderActions: React.FC<Props> = ({anchorEl, variant = 'menu', onClose, onRename, onDelete}) => {
+    const {t} = useTranslation();
+
+    const handleRename = () => { onRename && onRename(); onClose && onClose(); };
+    const handleDelete = () => { onDelete && onDelete(); onClose && onClose(); };
+
+    if (variant === 'buttons') {
+        return (
+            <FRSE g={0.5}>
+                <Tooltip title={t('rename')}><IconButton size="small" onClick={handleRename}><DriveFileRenameOutlineIcon/></IconButton></Tooltip>
+                <Tooltip title={t('delete')}><IconButton size="small" onClick={handleDelete}><DeleteIcon/></IconButton></Tooltip>
+            </FRSE>
+        );
+    }
+
+    return (
+        <Menu
+            sx={{'& .MuiPaper-root': {backdropFilter: 'blur(10px)'}}}
+            slotProps={{backdrop: {sx: {backdropFilter: 'none !important'}}}}
+            anchorEl={anchorEl}
+            open={Boolean(anchorEl)}
+            onClose={onClose}
+        >
+            <MenuItem onClick={handleRename}>{t('rename')}</MenuItem>
+            <MenuItem onClick={handleDelete}>{t('delete')}</MenuItem>
+        </Menu>
+    );
+};
+
+export default FolderActions;

--- a/frontend/src/Modules/FileHost/FolderCard.tsx
+++ b/frontend/src/Modules/FileHost/FolderCard.tsx
@@ -1,10 +1,9 @@
 import React, {useState} from 'react';
-import {Menu, MenuItem, Paper} from '@mui/material';
+import {Paper} from '@mui/material';
 import {useNavigate} from 'react-router-dom';
-import {useTranslation} from 'react-i18next';
 import RenameDialog from './RenameDialog';
-import {useApi} from '../Api/useApi';
 import useLongPress from './useLongPress';
+import FolderActions from './FolderActions';
 
 interface Props {
     id: number;
@@ -15,8 +14,6 @@ interface Props {
 
 const FolderCard: React.FC<Props> = ({id, name, onDelete, onRenamed}) => {
     const navigate = useNavigate();
-    const {t} = useTranslation();
-    const {api} = useApi();
     const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
     const [showRename, setShowRename] = useState(false);
     const longPress = useLongPress(e => setAnchorEl(e.currentTarget as HTMLElement));
@@ -29,18 +26,27 @@ const FolderCard: React.FC<Props> = ({id, name, onDelete, onRenamed}) => {
 
     return (
         <>
-            <Paper sx={{p:1,width:150,cursor:'pointer'}} onDoubleClick={open}
-                   onContextMenu={e=>{e.preventDefault();setAnchorEl(e.currentTarget);}}
-                   {...longPress}>
-                <strong style={{wordBreak:'break-all'}}>{name}</strong>
+            <Paper
+                sx={{p: 1, width: 150, cursor: 'pointer'}}
+                onDoubleClick={open}
+                onContextMenu={e => {e.preventDefault(); setAnchorEl(e.currentTarget);}}
+                {...longPress}
+            >
+                <strong style={{wordBreak: 'break-all'}}>{name}</strong>
             </Paper>
-            <Menu
-                slotProps={{backdrop:{sx:{backdropFilter:'none !important'}}}}
-                anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={()=>setAnchorEl(null)}>
-                <MenuItem onClick={()=>{setShowRename(true); setAnchorEl(null);}}>{t('rename')}</MenuItem>
-                <MenuItem onClick={handleDelete}>{t('delete')}</MenuItem>
-            </Menu>
-            <RenameDialog open={showRename} id={id} name={name} onClose={()=>setShowRename(false)} onRenamed={onRenamed}/>
+            <FolderActions
+                anchorEl={anchorEl}
+                onClose={() => setAnchorEl(null)}
+                onRename={() => setShowRename(true)}
+                onDelete={handleDelete}
+            />
+            <RenameDialog
+                open={showRename}
+                id={id}
+                name={name}
+                onClose={() => setShowRename(false)}
+                onRenamed={onRenamed}
+            />
         </>
     );
 };

--- a/frontend/src/Modules/FileHost/FolderTableRow.tsx
+++ b/frontend/src/Modules/FileHost/FolderTableRow.tsx
@@ -1,10 +1,9 @@
 import React, {useState} from 'react';
-import {Menu, MenuItem, TableCell, TableRow} from '@mui/material';
+import {TableCell, TableRow} from '@mui/material';
 import {useNavigate} from 'react-router-dom';
-import {useTranslation} from 'react-i18next';
 import RenameDialog from './RenameDialog';
-import {useApi} from '../Api/useApi';
 import useLongPress from './useLongPress';
+import FolderActions from './FolderActions';
 
 interface Props {
     id: number;
@@ -15,8 +14,6 @@ interface Props {
 
 const FolderTableRow: React.FC<Props> = ({id, name, onDelete, onRenamed}) => {
     const navigate = useNavigate();
-    const {t} = useTranslation();
-    const {api} = useApi();
     const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
     const [showRename, setShowRename] = useState(false);
     const longPress = useLongPress(e => setAnchorEl(e.currentTarget as HTMLElement));
@@ -44,20 +41,19 @@ const FolderTableRow: React.FC<Props> = ({id, name, onDelete, onRenamed}) => {
                 </TableCell>
                 <TableCell/>
             </TableRow>
-            <Menu
-                slotProps={{backdrop:{sx:{backdropFilter:'none !important'}}}}
-                anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={() => setAnchorEl(null)}>
-                <MenuItem
-                    onClick={() => {
-                        setShowRename(true);
-                        setAnchorEl(null);
-                    }}
-                >
-                    {t('rename')}
-                </MenuItem>
-                <MenuItem onClick={handleDelete}>{t('delete')}</MenuItem>
-            </Menu>
-            <RenameDialog open={showRename} id={id} name={name} onClose={() => setShowRename(false)} onRenamed={onRenamed}/>
+            <FolderActions
+                anchorEl={anchorEl}
+                onClose={() => setAnchorEl(null)}
+                onRename={() => setShowRename(true)}
+                onDelete={handleDelete}
+            />
+            <RenameDialog
+                open={showRename}
+                id={id}
+                name={name}
+                onClose={() => setShowRename(false)}
+                onRenamed={onRenamed}
+            />
         </>
     );
 };

--- a/frontend/src/Modules/FileHost/UploadProgressWindow.tsx
+++ b/frontend/src/Modules/FileHost/UploadProgressWindow.tsx
@@ -1,5 +1,5 @@
 import React, {useState} from 'react';
-import {LinearProgress, Paper, IconButton, Button} from '@mui/material';
+import {LinearProgress, Paper, IconButton, Button, Collapse, useMediaQuery} from '@mui/material';
 import {FC, FRSE} from 'wide-containers';
 import CheckIcon from '@mui/icons-material/Check';
 import ExpandLessIcon from '@mui/icons-material/ExpandLess';
@@ -11,9 +11,10 @@ interface Props {items: UploadItem[]; onClose?:()=>void;}
 
 const UploadProgressWindow: React.FC<Props> = ({items, onClose}) => {
     const [collapsed, setCollapsed] = useState(false);
-    const allDone = items.length>0 && items.every(it=>it.progress===100);
+    const isGtSm = useMediaQuery('(min-width: 576px)');
+    const allDone = items.length > 0 && items.every(it => it.progress === 100);
     return (
-        <Paper sx={{position:'fixed',bottom:16,right:16,p:2,width:250,zIndex:9999}}>
+        <Paper sx={{position:'fixed',bottom:16,right:isGtSm?16:'auto',left:isGtSm?'auto':'50%',transform:isGtSm?'':'translateX(-50%)',p:2,width:250,zIndex:9999}}>
             <IconButton size="small" onClick={()=>setCollapsed(o=>!o)} sx={{position:'absolute',top:4,right:4}}>
                 {collapsed ? <ExpandMoreIcon/> : <ExpandLessIcon/>}
             </IconButton>
@@ -22,7 +23,7 @@ const UploadProgressWindow: React.FC<Props> = ({items, onClose}) => {
                     <CheckIcon color="success"/>
                 </IconButton>
             )}
-            {!collapsed && (
+            <Collapse in={!collapsed}>
                 <FC g={1} mt={2}>
                     {items.map(it=> (
                         <div key={it.name} style={{display:'flex',flexDirection:'column',gap:4}}>
@@ -38,7 +39,7 @@ const UploadProgressWindow: React.FC<Props> = ({items, onClose}) => {
                         </div>
                     ))}
                 </FC>
-            )}
+            </Collapse>
         </Paper>
     );
 };

--- a/frontend/src/Modules/FileHost/index.ts
+++ b/frontend/src/Modules/FileHost/index.ts
@@ -7,4 +7,5 @@ export {default as useFileUpload} from './useFileUpload';
 export {default as FileTableRow} from './FileTableRow';
 export {default as FolderTableRow} from './FolderTableRow';
 export {default as FileActions} from './FileActions';
+export {default as FolderActions} from './FolderActions';
 export {default as useLongPress} from './useLongPress';


### PR DESCRIPTION
## Summary
- add `FolderActions` component that reuses logic from file menu
- integrate `FolderActions` with folder card and table row
- adjust upload progress window position and animate collapse
- export `FolderActions` in module index

## Testing
- `npm test` *(fails: ENOTFOUND registry.npmjs.org)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68679fbd4d848330a9f2783a62464412