### PR TITLE
Implement cache invalidation updates

### DIFF
--- a/frontend/src/Modules/FileHost/FileCard.tsx
+++ b/frontend/src/Modules/FileHost/FileCard.tsx
@@ -8,6 +8,7 @@ import formatFileSize from 'Utils/formatFileSize';
 import {useTranslation} from 'react-i18next';
 import useLongPress from './useLongPress';
 import FileActions from './FileActions';
+import {setAllFilesCached, setFavoriteFilesCached, setFolderCached} from './storageCache';
 import {FC, FR, FRBC} from "wide-containers";
 
 interface Props {
@@ -48,6 +49,9 @@ const FileCard: React.FC<Props> = (
         api.post('/api/v1/filehost/files/toggle_favorite/', {file_id: file.id}).then(d => {
             setFavorite(d.is_favorite);
             onFavorite && onFavorite({...file, is_favorite: d.is_favorite});
+            setFavoriteFilesCached(undefined as any);
+            setAllFilesCached(undefined as any);
+            setFolderCached(file.folder, undefined as any);
         });
     };
 

--- a/frontend/src/Modules/FileHost/FileItem.tsx
+++ b/frontend/src/Modules/FileHost/FileItem.tsx
@@ -7,6 +7,7 @@ import {useApi} from '../Api/useApi';
 import {FRSE} from 'wide-containers';
 import {useNavigate} from 'react-router-dom';
 import {useTranslation} from 'react-i18next';
+import {setAllFilesCached, setFavoriteFilesCached, setFolderCached} from './storageCache';
 
 interface Props {
     file: IFile;
@@ -33,6 +34,9 @@ const FileItem: React.FC<Props> = ({file, selectMode, selected, onToggleSelect, 
         api.post('/api/v1/filehost/files/toggle_favorite/', {file_id: file.id}).then((d) => {
             setFavorite(d.is_favorite);
             onFavorite && onFavorite({...file, is_favorite: d.is_favorite});
+            setFavoriteFilesCached(undefined as any);
+            setAllFilesCached(undefined as any);
+            setFolderCached(file.folder, undefined as any);
         });
     };
 

--- a/frontend/src/Modules/FileHost/FileTableRow.tsx
+++ b/frontend/src/Modules/FileHost/FileTableRow.tsx
@@ -10,6 +10,7 @@ import {useNavigate} from 'react-router-dom';
 import {useTranslation} from 'react-i18next';
 import useLongPress from './useLongPress';
 import FileActions from './FileActions';
+import {setAllFilesCached, setFavoriteFilesCached, setFolderCached} from './storageCache';
 
 interface Props {
     file: IFile;
@@ -48,6 +49,9 @@ const FileTableRow: React.FC<Props> = ({
         api.post('/api/v1/filehost/files/toggle_favorite/', {file_id: file.id}).then(d => {
             setFavorite(d.is_favorite);
             onFavorite && onFavorite({...file, is_favorite: d.is_favorite});
+            setFavoriteFilesCached(undefined as any);
+            setAllFilesCached(undefined as any);
+            setFolderCached(file.folder, undefined as any);
         });
     };
     const handleToggleSelect = () => {

--- a/frontend/src/Modules/FileHost/Master.tsx
+++ b/frontend/src/Modules/FileHost/Master.tsx
@@ -17,7 +17,13 @@ import FileUpload from 'UI/FileUpload';
 import {useTranslation} from 'react-i18next';
 import {useNavigate, useParams} from 'react-router-dom';
 import DropOverlay from './DropOverlay';
-import {getFolderCached, setFolderCached, FolderContent} from './storageCache';
+import {
+    getFolderCached,
+    setFolderCached,
+    setAllFilesCached,
+    setFavoriteFilesCached,
+    FolderContent
+} from './storageCache';
 
 const Master: React.FC = () => {
     const {api} = useApi();
@@ -88,6 +94,8 @@ const Master: React.FC = () => {
         await api.post('/api/v1/filehost/items/bulk_delete/', {file_ids: selected.map(s => s.id)});
         setSelected([]);
         setFolderCached(folderId, undefined as any);
+        setAllFilesCached(undefined as any);
+        setFavoriteFilesCached(undefined as any);
         load();
     };
 
@@ -99,6 +107,8 @@ const Master: React.FC = () => {
     const handleUpload = async (file: File | null) => {
         await uploadFile(file);
         setFolderCached(folderId, undefined as any);
+        setAllFilesCached(undefined as any);
+        setFavoriteFilesCached(undefined as any);
         load();
     };
 
@@ -107,12 +117,16 @@ const Master: React.FC = () => {
         setShowCreate(false);
         setNewFolderName('');
         setFolderCached(folderId, undefined as any);
+        setAllFilesCached(undefined as any);
+        setFavoriteFilesCached(undefined as any);
         load();
     };
 
     const handleDeleteFolder = async (id: number) => {
         await api.delete('/api/v1/filehost/item/delete/', {data: {folder_id: id}});
         setFolderCached(folderId, undefined as any);
+        setAllFilesCached(undefined as any);
+        setFavoriteFilesCached(undefined as any);
         load();
     };
 
@@ -165,7 +179,13 @@ const Master: React.FC = () => {
                 {view === 'cards' ? (
                     <div style={{display: 'flex', flexWrap: 'wrap', gap: 8}}>
                         {folders.map(f => (
-                            <FolderCard key={f.id} id={f.id} name={f.name} onDelete={handleDeleteFolder} onRenamed={load}/>
+                            <FolderCard key={f.id} id={f.id} name={f.name} onDelete={handleDeleteFolder}
+                                        onRenamed={() => {
+                                            setFolderCached(folderId, undefined as any);
+                                            setAllFilesCached(undefined as any);
+                                            setFavoriteFilesCached(undefined as any);
+                                            load();
+                                        }}/>
                         ))}
                         {files
                             .sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime())
@@ -198,7 +218,13 @@ const Master: React.FC = () => {
                         </TableHead>
                         <TableBody>
                             {folders.map(f => (
-                                <FolderTableRow key={f.id} id={f.id} name={f.name} onDelete={handleDeleteFolder} onRenamed={load}/>
+                                <FolderTableRow key={f.id} id={f.id} name={f.name} onDelete={handleDeleteFolder}
+                                                onRenamed={() => {
+                                                    setFolderCached(folderId, undefined as any);
+                                                    setAllFilesCached(undefined as any);
+                                                    setFavoriteFilesCached(undefined as any);
+                                                    load();
+                                                }}/>
                             ))}
                             {files
                                 .sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime())
@@ -245,6 +271,9 @@ const Master: React.FC = () => {
                 <MoveDialog files={selected} open={showMove} onClose={() => {
                     setShowMove(false);
                     setSelected([]);
+                    setFolderCached(folderId, undefined as any);
+                    setAllFilesCached(undefined as any);
+                    setFavoriteFilesCached(undefined as any);
                     load();
                 }}/>
                 <ShareDialog file={showShare} open={!!showShare} onClose={() => setShowShare(null)}/>


### PR DESCRIPTION
## Summary
- keep cache consistent when uploading/deleting/moving items
- invalidate caches on favourite toggles

## Testing
- `CI=true npm test --prefix frontend` *(fails: craco not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867a60960ac833091b484850013ec5a