### PR TITLE
Fix folder click behavior

### DIFF
--- a/frontend/src/Modules/FileHost/FolderCard.tsx
+++ b/frontend/src/Modules/FileHost/FolderCard.tsx
@@ -28,7 +28,7 @@ const FolderCard: React.FC<Props> = ({id, name, onDelete, onRenamed}) => {
         <>
             <Paper
                 sx={{p: 1, width: 150, cursor: 'pointer'}}
-                onDoubleClick={open}
+                onClick={open}
                 onContextMenu={e => {e.preventDefault(); setAnchorEl(e.currentTarget);}}
                 {...longPress}
             >

--- a/frontend/src/Modules/FileHost/FolderTableRow.tsx
+++ b/frontend/src/Modules/FileHost/FolderTableRow.tsx
@@ -29,7 +29,7 @@ const FolderTableRow: React.FC<Props> = ({id, name, onDelete, onRenamed}) => {
             <TableRow
                 hover
                 sx={{cursor: 'pointer'}}
-                onDoubleClick={open}
+                onClick={open}
                 onContextMenu={e => {
                     e.preventDefault();
                     setAnchorEl(e.currentTarget);


### PR DESCRIPTION
## Summary
- open folders with a single click instead of a double click

## Testing
- `npm test --prefix frontend` *(fails: craco not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6867aa503eec8330a37edf8352ffb1df