### PR TITLE
Fix share in upload window and folder navigation

### DIFF
--- a/frontend/src/Modules/FileHost/AllFiles.tsx
+++ b/frontend/src/Modules/FileHost/AllFiles.tsx
@@ -97,7 +97,13 @@ const AllFiles: React.FC = () => {
                     <Button color="error" onClick={async()=>{await deleteSelected(); setConfirmOpen(false);}}>Delete</Button>
                 </DialogActions>
             </Dialog>
-            {uploads.length>0 && <UploadProgressWindow items={uploads} onClose={clearUploads}/>}
+            {uploads.length>0 && (
+                <UploadProgressWindow
+                    items={uploads}
+                    onClose={clearUploads}
+                    onShare={f => setShowShare(f)}
+                />
+            )}
         </div>
         </>
     );

--- a/frontend/src/Modules/FileHost/FavoriteFiles.tsx
+++ b/frontend/src/Modules/FileHost/FavoriteFiles.tsx
@@ -97,7 +97,13 @@ const FavoriteFiles: React.FC = () => {
                     <Button color="error" onClick={async()=>{await deleteSelected(); setConfirmOpen(false);}}>Delete</Button>
                 </DialogActions>
             </Dialog>
-            {uploads.length>0 && <UploadProgressWindow items={uploads} onClose={clearUploads}/>}
+            {uploads.length>0 && (
+                <UploadProgressWindow
+                    items={uploads}
+                    onClose={clearUploads}
+                    onShare={f => setShowShare(f)}
+                />
+            )}
         </div>
         </>
     );

--- a/frontend/src/Modules/FileHost/FolderCard.tsx
+++ b/frontend/src/Modules/FileHost/FolderCard.tsx
@@ -10,15 +10,19 @@ interface Props {
     name: string;
     onDelete?: (id: number) => void;
     onRenamed?: () => void;
+    onOpen?: (id: number) => void;
 }
 
-const FolderCard: React.FC<Props> = ({id, name, onDelete, onRenamed}) => {
+const FolderCard: React.FC<Props> = ({id, name, onDelete, onRenamed, onOpen}) => {
     const navigate = useNavigate();
     const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
     const [showRename, setShowRename] = useState(false);
     const longPress = useLongPress(e => setAnchorEl(e.currentTarget as HTMLElement));
 
-    const open = () => navigate(`/storage/master/${id}/`);
+    const open = () => {
+        if (onOpen) onOpen(id);
+        else navigate(`/storage/master/${id}/`);
+    };
     const handleDelete = async () => {
         onDelete && onDelete(id);
         setAnchorEl(null);

--- a/frontend/src/Modules/FileHost/FolderTableRow.tsx
+++ b/frontend/src/Modules/FileHost/FolderTableRow.tsx
@@ -10,15 +10,19 @@ interface Props {
     name: string;
     onDelete?: (id: number) => void;
     onRenamed?: () => void;
+    onOpen?: (id: number) => void;
 }
 
-const FolderTableRow: React.FC<Props> = ({id, name, onDelete, onRenamed}) => {
+const FolderTableRow: React.FC<Props> = ({id, name, onDelete, onRenamed, onOpen}) => {
     const navigate = useNavigate();
     const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
     const [showRename, setShowRename] = useState(false);
     const longPress = useLongPress(e => setAnchorEl(e.currentTarget as HTMLElement));
 
-    const open = () => navigate(`/storage/master/${id}/`);
+    const open = () => {
+        if (onOpen) onOpen(id);
+        else navigate(`/storage/master/${id}/`);
+    };
     const handleDelete = async () => {
         onDelete && onDelete(id);
         setAnchorEl(null);

--- a/frontend/src/Modules/FileHost/Master.tsx
+++ b/frontend/src/Modules/FileHost/Master.tsx
@@ -130,6 +130,12 @@ const Master: React.FC = () => {
         load();
     };
 
+    const openFolder = (fid: number) => {
+        setSelected([]);
+        setSelectMode(false);
+        navigate(`/storage/master/${fid}/`);
+    };
+
     return (
         <>
             <DropOverlay onFileDrop={handleUpload}/>
@@ -179,13 +185,19 @@ const Master: React.FC = () => {
                 {view === 'cards' ? (
                     <div style={{display: 'flex', flexWrap: 'wrap', gap: 8}}>
                         {folders.map(f => (
-                            <FolderCard key={f.id} id={f.id} name={f.name} onDelete={handleDeleteFolder}
-                                        onRenamed={() => {
-                                            setFolderCached(folderId, undefined as any);
-                                            setAllFilesCached(undefined as any);
-                                            setFavoriteFilesCached(undefined as any);
-                                            load();
-                                        }}/>
+                            <FolderCard
+                                key={f.id}
+                                id={f.id}
+                                name={f.name}
+                                onDelete={handleDeleteFolder}
+                                onOpen={openFolder}
+                                onRenamed={() => {
+                                    setFolderCached(folderId, undefined as any);
+                                    setAllFilesCached(undefined as any);
+                                    setFavoriteFilesCached(undefined as any);
+                                    load();
+                                }}
+                            />
                         ))}
                         {files
                             .sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime())
@@ -218,13 +230,19 @@ const Master: React.FC = () => {
                         </TableHead>
                         <TableBody>
                             {folders.map(f => (
-                                <FolderTableRow key={f.id} id={f.id} name={f.name} onDelete={handleDeleteFolder}
-                                                onRenamed={() => {
-                                                    setFolderCached(folderId, undefined as any);
-                                                    setAllFilesCached(undefined as any);
-                                                    setFavoriteFilesCached(undefined as any);
-                                                    load();
-                                                }}/>
+                                <FolderTableRow
+                                    key={f.id}
+                                    id={f.id}
+                                    name={f.name}
+                                    onDelete={handleDeleteFolder}
+                                    onOpen={openFolder}
+                                    onRenamed={() => {
+                                        setFolderCached(folderId, undefined as any);
+                                        setAllFilesCached(undefined as any);
+                                        setFavoriteFilesCached(undefined as any);
+                                        load();
+                                    }}
+                                />
                             ))}
                             {files
                                 .sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime())
@@ -306,7 +324,13 @@ const Master: React.FC = () => {
                     </DialogActions>
                 </Dialog>
 
-                {uploads.length > 0 && <UploadProgressWindow items={uploads} onClose={clearUploads}/>}                
+                {uploads.length > 0 && (
+                    <UploadProgressWindow
+                        items={uploads}
+                        onClose={clearUploads}
+                        onShare={f => setShowShare(f)}
+                    />
+                )}
             </FC>
         </>
     );

--- a/frontend/src/Modules/FileHost/UploadProgressWindow.tsx
+++ b/frontend/src/Modules/FileHost/UploadProgressWindow.tsx
@@ -15,9 +15,10 @@ export interface UploadItem {
 interface Props {
     items: UploadItem[];
     onClose?: () => void;
+    onShare?: (file: any) => void;
 }
 
-const UploadProgressWindow: React.FC<Props> = ({items, onClose}) => {
+const UploadProgressWindow: React.FC<Props> = ({items, onClose, onShare}) => {
     const [collapsed, setCollapsed] = useState(false);
     const isGtSm = useMediaQuery('(min-width: 576px)');
     const allDone = items.length > 0 && items.every(it => it.progress === 100);
@@ -53,7 +54,9 @@ const UploadProgressWindow: React.FC<Props> = ({items, onClose}) => {
                             {it.progress === 100 ? (
                                 <FRSE>
                                     <CheckIcon color="success" fontSize="small"/>
-                                    <Button size="small">Share</Button>
+                                    <Button size="small" onClick={() => onShare && it.file && onShare(it.file)}>
+                                        Share
+                                    </Button>
                                 </FRSE>
                             ) : (
                                 <LinearProgress variant="determinate" value={it.progress}/>


### PR DESCRIPTION
## Summary
- enable share button in the upload progress window
- allow resetting selection when navigating folders
- expose optional onOpen handlers for folder components
- pass share and onOpen handlers in file list components

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6867b0bc99d083309afdaed213f5d191