### PR TITLE
Add icons and previews for files

### DIFF
--- a/frontend/src/Modules/FileHost/FileCard.tsx
+++ b/frontend/src/Modules/FileHost/FileCard.tsx
@@ -10,7 +10,7 @@ import useLongPress from './useLongPress';
 import FileActions from './FileActions';
 import {setAllFilesCached, setFavoriteFilesCached, setFolderCached} from './storageCache';
 import {FC, FR, FRBC, FRC} from "wide-containers";
-import InsertDriveFileOutlinedIcon from '@mui/icons-material/InsertDriveFileOutlined';
+import {getFileIcon, isImage} from './fileIcons';
 
 interface Props {
     file: IFile;
@@ -113,7 +113,11 @@ const FileCard: React.FC<Props> = (
                     )}
                 </FRBC>
                 <FRC opacity={80} mt={1}>
-                    <InsertDriveFileOutlinedIcon sx={{fontSize: '5rem'}}/>
+                    {isImage(file.name) ? (
+                        <img src={file.file} alt={file.name} style={{maxWidth: '5rem', maxHeight: '5rem'}}/>
+                    ) : (
+                        getFileIcon(file.name, {sx: {fontSize: '5rem'}})
+                    )}
                 </FRC>
                 <FRC fontSize={'0.9rem'} sx={{wordBreak: 'break-all'}}>
                     {file.name}

--- a/frontend/src/Modules/FileHost/FileDetail.tsx
+++ b/frontend/src/Modules/FileHost/FileDetail.tsx
@@ -9,6 +9,8 @@ import {useTranslation} from 'react-i18next';
 import BackButton from "Core/components/BackButton";
 import ShareDialog from './ShareDialog';
 import FileActions from './FileActions';
+import ImagePreview from './ImagePreview';
+import {isImage, isVideo} from './fileIcons';
 
 const FileDetail: React.FC = () => {
     const {id} = useParams();
@@ -17,6 +19,7 @@ const FileDetail: React.FC = () => {
     const {t} = useTranslation();
     const [file, setFile] = useState<IFile | null>(null);
     const [showShare, setShowShare] = useState(false);
+    const [showImage, setShowImage] = useState(false);
     useEffect(() => {
         if (id) api.post('/api/v1/filehost/file/', {id: Number(id)}).then(setFile);
     }, [id]);
@@ -27,6 +30,12 @@ const FileDetail: React.FC = () => {
             <FR component={'h3'}>{file.name}</FR>
             <FR>{t('upload_date')}: {new Date(file.created_at).toLocaleString()}</FR>
             <FR>{t('size')}: {formatFileSize(file.size)}</FR>
+            {isImage(file.name) && (
+                <img src={file.file} alt={file.name} style={{maxWidth: '100%', maxHeight: '60vh', cursor: 'pointer'}} onClick={() => setShowImage(true)}/>
+            )}
+            {isVideo(file.name) && (
+                <video src={file.file} controls style={{maxWidth: '100%', maxHeight: '60vh'}}/>
+            )}
             <FileActions
                 file={file}
                 variant="buttons"
@@ -38,6 +47,9 @@ const FileDetail: React.FC = () => {
                 }}
             />
             <ShareDialog file={file} open={showShare} onClose={() => setShowShare(false)}/>
+            {isImage(file.name) && (
+                <ImagePreview src={file.file} open={showImage} onClose={() => setShowImage(false)}/>
+            )}
         </FC>
     );
 };

--- a/frontend/src/Modules/FileHost/FileTableRow.tsx
+++ b/frontend/src/Modules/FileHost/FileTableRow.tsx
@@ -11,6 +11,7 @@ import {useTranslation} from 'react-i18next';
 import useLongPress from './useLongPress';
 import FileActions from './FileActions';
 import {setAllFilesCached, setFavoriteFilesCached, setFolderCached} from './storageCache';
+import {getFileIcon} from './fileIcons';
 
 interface Props {
     file: IFile;
@@ -85,6 +86,9 @@ const FileTableRow: React.FC<Props> = ({
                               onClick={e => e.stopPropagation()}/>
                 </TableCell>
             )}
+            <TableCell padding="checkbox">
+                {getFileIcon(file.name)}
+            </TableCell>
             <TableCell component="th" scope="row" sx={{lineHeight: '1rem'}}>
                 {file.name}
             </TableCell>

--- a/frontend/src/Modules/FileHost/FolderTableRow.tsx
+++ b/frontend/src/Modules/FileHost/FolderTableRow.tsx
@@ -1,9 +1,10 @@
 import React, {useState} from 'react';
-import {TableCell, TableRow} from '@mui/material';
+import {TableCell, TableRow, useMediaQuery} from '@mui/material';
 import {useNavigate} from 'react-router-dom';
 import RenameDialog from './RenameDialog';
 import useLongPress from './useLongPress';
 import FolderActions from './FolderActions';
+import FolderRoundedIcon from '@mui/icons-material/FolderRounded';
 
 interface Props {
     id: number;
@@ -18,6 +19,7 @@ const FolderTableRow: React.FC<Props> = ({id, name, onDelete, onRenamed, onOpen}
     const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
     const [showRename, setShowRename] = useState(false);
     const longPress = useLongPress(e => setAnchorEl(e.currentTarget as HTMLElement));
+    const isGtSm = useMediaQuery('(min-width: 576px)');
 
     const open = () => {
         if (onOpen) onOpen(id);
@@ -40,9 +42,14 @@ const FolderTableRow: React.FC<Props> = ({id, name, onDelete, onRenamed, onOpen}
                 }}
                 {...longPress}
             >
+                <TableCell padding="checkbox">
+                    <FolderRoundedIcon/>
+                </TableCell>
                 <TableCell component="th" scope="row">
                     {name}
                 </TableCell>
+                {isGtSm && <TableCell/>}
+                <TableCell/>
                 <TableCell/>
             </TableRow>
             <FolderActions

--- a/frontend/src/Modules/FileHost/ImagePreview.tsx
+++ b/frontend/src/Modules/FileHost/ImagePreview.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import {Dialog, IconButton} from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
+
+interface Props {
+    src: string;
+    open: boolean;
+    onClose: () => void;
+}
+
+const ImagePreview: React.FC<Props> = ({src, open, onClose}) => (
+    <Dialog open={open} onClose={onClose} maxWidth={'xl'}>
+        <IconButton onClick={onClose} sx={{position: 'absolute', top: 8, right: 8}}>
+            <CloseIcon/>
+        </IconButton>
+        <img src={src} alt="preview" style={{maxWidth: '100%', maxHeight: '90vh'}}/>
+    </Dialog>
+);
+
+export default ImagePreview;

--- a/frontend/src/Modules/FileHost/Master.tsx
+++ b/frontend/src/Modules/FileHost/Master.tsx
@@ -265,6 +265,7 @@ const Master: React.FC = () => {
                         <TableHead>
                             <TableRow>
                                 {selectMode && <TableCell padding="checkbox"/>}
+                                <TableCell/>
                                 <TableCell>{t('name')}</TableCell>
                                 {isGtSm && <TableCell>{t('upload_date')}</TableCell>}
                                 <TableCell>{t('size')}</TableCell>
@@ -329,14 +330,19 @@ const Master: React.FC = () => {
                     }}>{t('create_folder')}</MenuItem>
                 </Menu>
 
-                <MoveDialog files={selected} open={showMove} onClose={() => {
-                    setShowMove(false);
-                    setSelected([]);
-                    setFolderCached(folderId, undefined as any);
-                    setAllFilesCached(undefined as any);
-                    setFavoriteFilesCached(undefined as any);
-                    load();
-                }}/>
+                <MoveDialog
+                    files={selected}
+                    open={showMove}
+                    onMoved={tid => setFolderCached(tid, undefined as any)}
+                    onClose={() => {
+                        setShowMove(false);
+                        setSelected([]);
+                        setFolderCached(folderId, undefined as any);
+                        setAllFilesCached(undefined as any);
+                        setFavoriteFilesCached(undefined as any);
+                        load();
+                    }}
+                />
                 <ShareDialog file={showShare} open={!!showShare} onClose={() => setShowShare(null)}/>
 
                 <Dialog open={confirmOpen} onClose={() => setConfirmOpen(false)}>

--- a/frontend/src/Modules/FileHost/MoveDialog.tsx
+++ b/frontend/src/Modules/FileHost/MoveDialog.tsx
@@ -8,9 +8,10 @@ interface Props {
     files: IFile[];
     open: boolean;
     onClose: () => void;
+    onMoved?: (folderId: number) => void;
 }
 
-const MoveDialog: React.FC<Props> = ({files, open, onClose}) => {
+const MoveDialog: React.FC<Props> = ({files, open, onClose, onMoved}) => {
     const {api} = useApi();
     const {t} = useTranslation();
     const [folders, setFolders] = useState<IFolder[]>([]);
@@ -27,6 +28,7 @@ const MoveDialog: React.FC<Props> = ({files, open, onClose}) => {
         for (const f of files) {
             await api.post('/api/v1/filehost/item/move/', {item_id: f.id, new_folder_id: target});
         }
+        onMoved && onMoved(target as number);
         onClose();
     };
 

--- a/frontend/src/Modules/FileHost/fileIcons.tsx
+++ b/frontend/src/Modules/FileHost/fileIcons.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import InsertDriveFileOutlinedIcon from '@mui/icons-material/InsertDriveFileOutlined';
+import ImageIcon from '@mui/icons-material/Image';
+import VideoFileOutlinedIcon from '@mui/icons-material/VideoFileOutlined';
+import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf';
+import DescriptionIcon from '@mui/icons-material/Description';
+import ArticleIcon from '@mui/icons-material/Article';
+import ArchiveIcon from '@mui/icons-material/Archive';
+import CodeIcon from '@mui/icons-material/Code';
+import {SvgIconProps} from '@mui/material';
+
+export const isImage = (name: string): boolean => {
+    const ext = name.split('.').pop()?.toLowerCase() || '';
+    return ['png', 'jpg', 'jpeg', 'gif', 'bmp', 'webp', 'svg'].includes(ext);
+};
+
+export const isVideo = (name: string): boolean => {
+    const ext = name.split('.').pop()?.toLowerCase() || '';
+    return ['mp4', 'avi', 'mkv', 'mov', 'webm'].includes(ext);
+};
+
+export const getFileIcon = (name: string, props?: SvgIconProps) => {
+    const ext = name.split('.').pop()?.toLowerCase() || '';
+    if (isImage(name)) return <ImageIcon {...props}/>;
+    if (isVideo(name)) return <VideoFileOutlinedIcon {...props}/>;
+    if (['pdf'].includes(ext)) return <PictureAsPdfIcon {...props}/>;
+    if (['zip', 'rar', '7z', 'tar', 'gz', 'bz2'].includes(ext)) return <ArchiveIcon {...props}/>;
+    if (['txt', 'md', 'rtf'].includes(ext)) return <ArticleIcon {...props}/>;
+    if (['doc', 'docx', 'odt', 'xls', 'xlsx', 'ppt', 'pptx', 'csv'].includes(ext)) return <DescriptionIcon {...props}/>;
+    if (['py', 'js', 'ts', 'java', 'c', 'cpp', 'cs', 'go', 'rb', 'php', 'html', 'css', 'json'].includes(ext)) return <CodeIcon {...props}/>;
+    return <InsertDriveFileOutlinedIcon {...props}/>;
+};


### PR DESCRIPTION
## Summary
- show preview thumbnails in file cards
- support image/video previews in FileDetail
- add mapping of file extensions to icons
- add icons to table rows and fix folder row layout
- clear target folder cache after moving files

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6868671ce1e08330be025b62467013d3