### PR TITLE
Improve mobile views in filehost

### DIFF
--- a/frontend/src/Modules/FileHost/AllFiles.tsx
+++ b/frontend/src/Modules/FileHost/AllFiles.tsx
@@ -62,10 +62,9 @@ const AllFiles: React.FC = () => {
             <Table size="small">
                 <TableHead>
                     <TableRow>
-                        {selectMode && <TableCell padding="checkbox"/>}
                         <TableCell>{t('name')}</TableCell>
                         {isGtSm && <TableCell>{t('upload_date')}</TableCell>}
-                        <TableCell>{t('size')}</TableCell>
+                        {isGtSm && <TableCell>{t('size')}</TableCell>}
                         <TableCell/>
                     </TableRow>
                 </TableHead>

--- a/frontend/src/Modules/FileHost/FavoriteFiles.tsx
+++ b/frontend/src/Modules/FileHost/FavoriteFiles.tsx
@@ -62,10 +62,9 @@ const FavoriteFiles: React.FC = () => {
             <Table size="small">
                 <TableHead>
                     <TableRow>
-                        {selectMode && <TableCell padding="checkbox"/>}
                         <TableCell>{t('name')}</TableCell>
                         {isGtSm && <TableCell>{t('upload_date')}</TableCell>}
-                        <TableCell>{t('size')}</TableCell>
+                        {isGtSm && <TableCell>{t('size')}</TableCell>}
                         <TableCell/>
                     </TableRow>
                 </TableHead>

--- a/frontend/src/Modules/FileHost/FileCard.tsx
+++ b/frontend/src/Modules/FileHost/FileCard.tsx
@@ -1,5 +1,5 @@
 import React, {useEffect, useState} from 'react';
-import {Checkbox, IconButton, Paper} from '@mui/material';
+import {IconButton, Paper} from '@mui/material';
 import StarIcon from '@mui/icons-material/Star';
 import {useNavigate} from 'react-router-dom';
 import {useApi} from 'Api/useApi';
@@ -87,22 +87,14 @@ const FileCard: React.FC<Props> = (
     };
 
     return (
-        <Paper sx={{px: 1, pt: 1, pb: .5, width: 156, minHeight: 140}}
+        <Paper sx={{px: 1, pt: 1, pb: .5, width: '100%', minHeight: 140, bgcolor: selected ? '#eef2ff' : undefined}}
                onClick={handleClick} onContextMenu={e => {
             e.preventDefault();
             setAnchorEl(e.currentTarget);
         }} {...longPress}>
             <FC h={'100%'}>
                 <FRBC>
-                    {selectMode && (
-                        <Checkbox
-                            sx={{p: .4, ml: -.7, mt: -.7}}
-                            size="small"
-                            checked={selected}
-                            onChange={handleToggleSelect}
-                            onClick={e => e.stopPropagation()}
-                        />
-                    )}
+                    {selectMode && <></>}
                     {favorite && (
                         <IconButton size="small" onClick={e => {
                             e.stopPropagation();

--- a/frontend/src/Modules/FileHost/FileItem.tsx
+++ b/frontend/src/Modules/FileHost/FileItem.tsx
@@ -1,6 +1,5 @@
 import React, {useEffect, useState} from 'react';
-import {Menu, MenuItem, IconButton, Checkbox} from '@mui/material';
-import MoreVertIcon from '@mui/icons-material/MoreVert';
+import {Menu, MenuItem, IconButton} from '@mui/material';
 import StarIcon from '@mui/icons-material/Star';
 import {IFile} from './types';
 import {useApi} from '../Api/useApi';
@@ -75,7 +74,7 @@ const FileItem: React.FC<Props> = ({file, selectMode, selected, onToggleSelect, 
 
     return (
         <FRSE p={0.5} borderBottom={'1px solid #ccc'} onClick={handleClick} onContextMenu={(e)=>{e.preventDefault();setAnchorEl(e.currentTarget);}}>
-            {selectMode && <Checkbox size="small" checked={selected} onChange={handleToggleSelect}/>} 
+            {selectMode && <></>}
             <span style={{flexGrow:1}}>{file.name}</span>
             <FRSE g={0.5}>
                 {favorite && (
@@ -84,9 +83,7 @@ const FileItem: React.FC<Props> = ({file, selectMode, selected, onToggleSelect, 
                         <StarIcon fontSize="small"/>
                     </IconButton>
                 )}
-                <IconButton size="small" onClick={(e) => {e.stopPropagation();setAnchorEl(e.currentTarget);}}>
-                    <MoreVertIcon fontSize="small"/>
-                </IconButton>
+                
                 <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={() => setAnchorEl(null)}>
                     <MenuItem onClick={handleDownload}>{t('download')}</MenuItem>
                     <MenuItem onClick={handleShare}>{t('share')}</MenuItem>

--- a/frontend/src/Modules/FileHost/FileTableRow.tsx
+++ b/frontend/src/Modules/FileHost/FileTableRow.tsx
@@ -1,6 +1,5 @@
 import React, {useEffect, useState} from 'react';
-import {Checkbox, IconButton, TableRow, TableCell, useMediaQuery} from '@mui/material';
-import MoreVertIcon from '@mui/icons-material/MoreVert';
+import {IconButton, TableRow, TableCell, useMediaQuery} from '@mui/material';
 import StarIcon from '@mui/icons-material/Star';
 import {IFile} from './types';
 import formatFileSize from 'Utils/formatFileSize';
@@ -72,6 +71,7 @@ const FileTableRow: React.FC<Props> = ({
     return (
         <TableRow
             hover
+            selected={selected}
             onClick={handleClick}
             onContextMenu={e => {
                 e.preventDefault();
@@ -80,12 +80,6 @@ const FileTableRow: React.FC<Props> = ({
             {...longPress}
             sx={{cursor: 'pointer'}}
         >
-            {selectMode && (
-                <TableCell padding="checkbox">
-                    <Checkbox size="small" checked={selected} onChange={handleToggleSelect}
-                              onClick={e => e.stopPropagation()}/>
-                </TableCell>
-            )}
             <TableCell padding="checkbox">
                 {getFileIcon(file.name)}
             </TableCell>
@@ -95,7 +89,7 @@ const FileTableRow: React.FC<Props> = ({
             {isGtSm && (
                 <TableCell>{new Date(file.created_at).toLocaleString()}</TableCell>
             )}
-            <TableCell>{formatFileSize(file.size)}</TableCell>
+            {isGtSm && <TableCell>{formatFileSize(file.size)}</TableCell>}
             <TableCell>
                 <FRSE g={0.5}>
                     {favorite && (
@@ -106,12 +100,6 @@ const FileTableRow: React.FC<Props> = ({
                             <StarIcon fontSize="small"/>
                         </IconButton>
                     )}
-                    <IconButton size="small" onClick={e => {
-                        e.stopPropagation();
-                        setAnchorEl(e.currentTarget);
-                    }}>
-                        <MoreVertIcon fontSize="small"/>
-                    </IconButton>
                     <FileActions
                         anchorEl={anchorEl}
                         file={{...file, is_favorite: favorite}}

--- a/frontend/src/Modules/FileHost/Master.tsx
+++ b/frontend/src/Modules/FileHost/Master.tsx
@@ -28,7 +28,8 @@ import {
     TableHead,
     TableRow,
     TextField,
-    useMediaQuery
+    useMediaQuery,
+    Box
 } from '@mui/material';
 import ViewListIcon from '@mui/icons-material/ViewList';
 import ViewModuleIcon from '@mui/icons-material/ViewModule';
@@ -226,7 +227,7 @@ const Master: React.FC = () => {
                     </FR>
                 </FRBC>
                 {view === 'cards' ? (
-                    <FR g={1} wrap mt={.4}>
+                    <Box mt={.4} sx={{display:'grid',gap:'0.5rem',gridTemplateColumns:{xs:'repeat(2,1fr)',sm:'repeat(3,1fr)',md:'repeat(4,1fr)',lg:'repeat(5,1fr)'}}}>
                         {folders.map(f => (
                             <FolderCard
                                 key={f.id}
@@ -259,16 +260,15 @@ const Master: React.FC = () => {
                                           onShare={() => setShowShare(f)}
                                           onDownload={file => window.open(file.file)}/>
                             ))}
-                    </FR>
+                    </Box>
                 ) : (
                     <Table size="small">
                         <TableHead>
                             <TableRow>
-                                {selectMode && <TableCell padding="checkbox"/>}
                                 <TableCell/>
                                 <TableCell>{t('name')}</TableCell>
                                 {isGtSm && <TableCell>{t('upload_date')}</TableCell>}
-                                <TableCell>{t('size')}</TableCell>
+                                {isGtSm && <TableCell>{t('size')}</TableCell>}
                                 <TableCell/>
                             </TableRow>
                         </TableHead>

--- a/frontend/src/Modules/FileHost/useLongPress.ts
+++ b/frontend/src/Modules/FileHost/useLongPress.ts
@@ -11,6 +11,7 @@ const useLongPress = (cb: (e: React.TouchEvent) => void, ms = 600): LongPressHan
     const timer = useRef<NodeJS.Timeout | null>(null);
 
     const start = (e: React.TouchEvent) => {
+        if (typeof e.persist === 'function') e.persist();
         timer.current = setTimeout(() => cb(e), ms);
     };
 


### PR DESCRIPTION
## Summary
- hide Size column on small screens
- drop selection checkboxes and action buttons
- highlight selected items
- show card grid responsive to screen
- fix long press logic

## Testing
- `npm test` *(fails: craco not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6868706655888330a90e65c85154d703