### PR TITLE
Refactor websocket consumers

### DIFF
--- a/backend/apps/software/consumers/base.py
+++ b/backend/apps/software/consumers/base.py
@@ -1,0 +1,57 @@
+# software/consumers/base.py
+from urllib.parse import parse_qs
+
+from asgiref.sync import sync_to_async
+from channels.exceptions import ChannelFull
+from channels.generic.websocket import AsyncJsonWebsocketConsumer
+from django.contrib.auth import get_user_model
+
+User = get_user_model()
+
+
+class BaseSoftwareConsumer(AsyncJsonWebsocketConsumer):
+    """Base consumer with username/secret_key auth and group helpers."""
+
+    group_prefix: str = 'user'
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.user = None
+        self.group_name = None
+
+    async def connect(self):
+        if self.scope['user'].is_anonymous:
+            qs = parse_qs(self.scope['query_string'].decode())
+            username = qs.get('username', [None])[0]
+            secret_key = qs.get('secret_key', [None])[0]
+            if not username or not secret_key:
+                await self.close(code=4002)
+                return
+            user = await self._get_user(username, secret_key)
+            if user is None:
+                await self.close(code=4003)
+                return
+        else:
+            user = self.scope['user']
+
+        self.user = user
+        self.group_name = f'{self.group_prefix}_{user.id}'
+        await self.channel_layer.group_add(self.group_name, self.channel_name)
+        await self.accept()
+
+    async def disconnect(self, code):
+        if self.group_name:
+            await self.channel_layer.group_discard(self.group_name, self.channel_name)
+
+    @sync_to_async
+    def _get_user(self, username, secret_key):
+        try:
+            return User.objects.get(username=username, secret_key=secret_key)
+        except User.DoesNotExist:
+            return None
+
+    async def _safe_group_send(self, message: dict):
+        try:
+            await self.channel_layer.group_send(self.group_name, message)
+        except ChannelFull:
+            pass

--- a/backend/apps/software/consumers/screen.py
+++ b/backend/apps/software/consumers/screen.py
@@ -1,20 +1,14 @@
 # software/consumers/screen.py
 import asyncio
 import base64
-from urllib.parse import parse_qs
 
-from asgiref.sync import sync_to_async
-from channels.exceptions import ChannelFull
-from channels.generic.websocket import AsyncJsonWebsocketConsumer
-from django.contrib.auth import get_user_model
-
-User = get_user_model()
+from .base import BaseSoftwareConsumer
 
 # ≈ 20 fps.  При большем значении будет выше задержка, при меньшем — выше нагрузка.
 FLUSH_DELAY = 1 / 20
 
 
-class ScreenStreamConsumer(AsyncJsonWebsocketConsumer):
+class ScreenStreamConsumer(BaseSoftwareConsumer):
     """
     **Desktop-клиент (xlmacros) ➜ сервер**
 
@@ -31,47 +25,26 @@ class ScreenStreamConsumer(AsyncJsonWebsocketConsumer):
 
     # ---------- connect / disconnect ----------
 
+    group_prefix = 'screen'
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.user = None
         self._latest_frame: bytes | None = None
         self._flush_task: asyncio.Task | None = None
 
     async def connect(self):
-        if self.scope['user'].is_anonymous:
-            qs = parse_qs(self.scope['query_string'].decode())
-            username = qs.get('username', [None])[0]
-            secret_key = qs.get('secret_key', [None])[0]
-            if not username or not secret_key:
-                await self.close(code=4002)
-                return
-            user = await self._get_user(username, secret_key)
-            if user is None:
-                await self.close(code=4003)
-                return
-        else:
-            user = self.scope['user']
-
-        self.user = user
-        await self.channel_layer.group_add(f'screen_{user.id}', self.channel_name)
-        await self.accept()
+        await super().connect()
+        if not self.user:
+            return
 
         # буфер последнего кадра
         self._latest_frame: bytes | None = None
         self._flush_task = None
 
     async def disconnect(self, code):
-        if hasattr(self, 'user'):
-            await self.channel_layer.group_discard(f'screen_{self.user.id}', self.channel_name)
         if self._flush_task:
             self._flush_task.cancel()
-
-    @sync_to_async
-    def _get_user(self, username, secret_key):
-        try:
-            return User.objects.get(username=username, secret_key=secret_key)
-        except User.DoesNotExist:
-            return None
+        await super().disconnect(code)
 
     # ---------- receive (desktop → server) ----------
 
@@ -109,13 +82,6 @@ class ScreenStreamConsumer(AsyncJsonWebsocketConsumer):
                 await asyncio.sleep(FLUSH_DELAY)
         finally:
             self._flush_task = None
-
-    async def _safe_group_send(self, message: dict):
-        try:
-            await self.channel_layer.group_send(f'screen_{self.user.id}', message)
-        except ChannelFull:
-            # канал переполнен — просто отбросим кадр
-            pass
 
     # ---------- handlers (browser ← server) ----------
 


### PR DESCRIPTION
## Summary
- add `BaseSoftwareConsumer` with auth and group helpers
- simplify `MacroControlConsumer` and `ScreenStreamConsumer` by inheriting from the base class

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686cc5863d248330a59faf7006d919f5