### PR TITLE
Fix duplicate payment registry initialization

### DIFF
--- a/backend/apps/commerce/services/payment_registry.py
+++ b/backend/apps/commerce/services/payment_registry.py
@@ -104,4 +104,3 @@ def _bootstrap_registry():
     ))
 
 
-_bootstrap_registry()


### PR DESCRIPTION
## Summary
- remove a stray `_bootstrap_registry()` call

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686cc5a94e408330a5c36b05e71e4e5e