### PR TITLE
Clean debug prints and switch to logging

### DIFF
--- a/backend/apps/ckassa/providers.py
+++ b/backend/apps/ckassa/providers.py
@@ -3,12 +3,15 @@ from __future__ import annotations
 from decimal import Decimal
 
 import httpx
+import logging
 from adjango.utils.base import apprint
 from django.conf import settings
 
 from apps.commerce.exceptions.payment import PaymentException
 from apps.commerce.providers.base import BasePaymentProvider
 from .models import CKassaPayment
+
+logger = logging.getLogger(__name__)
 
 
 class CKassaProvider(BasePaymentProvider):
@@ -25,7 +28,7 @@ class CKassaProvider(BasePaymentProvider):
             'ApiLoginAuthorization': settings.CKASSA_LOGIN,
             'ApiAuthorization': settings.CKASSA_TOKEN,
         }
-        print(1)
+        logger.debug('Starting CKassa payment initialization')
         async with httpx.AsyncClient(base_url=settings.CKASSA_API_URL, timeout=30) as client:
             resp = await client.post('invoice/create2/', json=data, headers=headers)
 

--- a/backend/apps/software/services/software.py
+++ b/backend/apps/software/services/software.py
@@ -2,10 +2,14 @@
 from datetime import timedelta
 from typing import TYPE_CHECKING
 
+import logging
 from django.utils import timezone
 
 if TYPE_CHECKING:
     from apps.software.models import SoftwareOrder, Software
+
+
+logger = logging.getLogger(__name__)
 
 
 class SoftwareService:
@@ -15,7 +19,7 @@ class SoftwareService:
         s = SoftwareOrderCreateSerializer(
             data=request.data, context={'request': request}
         )
-        print(1)
+        logger.debug('new_order: serializer validation start')
         await s.ais_valid(raise_exception=True)
         data = s.validated_data
         promocode = data.get('promocode', None)
@@ -26,7 +30,7 @@ class SoftwareService:
                 currency=data['currency'],
                 raise_exception=True
             )
-        print(2)
+        logger.debug('new_order: serializer validated')
         order = SoftwareOrder(
             user=request.user,
             currency=request.data['currency'],
@@ -36,9 +40,9 @@ class SoftwareService:
             promocode=promocode
         )
         await order.asave()
-        print(3)
+        logger.debug('new_order: order saved')
         await order.init(request)
-        print(8)
+        logger.debug('new_order: initialization complete')
         return order
 
     async def can_pregive(

--- a/backend/utils/copy_only_server_mods.py
+++ b/backend/utils/copy_only_server_mods.py
@@ -1,5 +1,8 @@
 import os
 import shutil
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def copy_mods(source_path: str, client_mods: list) -> None:  # noqa
@@ -32,10 +35,10 @@ def copy_mods(source_path: str, client_mods: list) -> None:  # noqa
                     shutil.copy2(src_file, dst_file)
                     # print(f'Скопирован мод: {filename}')
                 except Exception as e:
-                    print(f'Ошибка при копировании {filename}: {e}')
+                    logger.error('Copy failed for %s: %s', filename, e)
             else:
                 # Если имя файла содержит одну из исключающих подстрок, пропускаем копирование
-                print(f'Пропущен мод (client): {filename}')
+                logger.info('Skipped client mod: %s', filename)
 
 
 if __name__ == '__main__':

--- a/backend/utils/gradient_by_symbol_text.py
+++ b/backend/utils/gradient_by_symbol_text.py
@@ -1,3 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
 def hex_to_rgb(hex_color: str) -> tuple:
     """
     Преобразует HEX-строку (например, '#FF0000' или 'FF0000') в кортеж RGB.
@@ -62,4 +67,4 @@ if __name__ == '__main__':
     start_color = '#FF0000'  # Красный
     end_color = '#00FF00'  # Зеленый
     result = generate_gradient_text(text, start_color, end_color)
-    print(result)
+    logger.info(result)

--- a/backend/utils/make_xlmine_build.py
+++ b/backend/utils/make_xlmine_build.py
@@ -5,10 +5,13 @@ import os
 import shutil
 import zipfile
 from pathlib import Path
+import logging
 
 SOURCE_DIR = Path(r'C:\Users\xl\AppData\Roaming\xlmine-launcher\xlartas-client')
 RELEASE_DIR = SOURCE_DIR.parent / 'xlartas-xlmine-release'
 SECURITY_PATH = SOURCE_DIR.parent / 'security.json'
+
+logger = logging.getLogger(__name__)
 
 FILES_TO_COPY = [
     'version.txt',
@@ -131,7 +134,7 @@ def is_editable(rel: str) -> bool:
 
 
 def log(msg: str) -> None:
-    print(f'[BUILD] {msg}')
+    logger.info('[BUILD] %s', msg)
 
 
 # ───────────────── подготовка директории релиза ──────────────────────────────
@@ -202,4 +205,4 @@ log(f'Archive created at {ARCHIVE_PATH}')
 shutil.rmtree(RELEASE_DIR, ignore_errors=True)
 log('Temporary release directory cleaned up')
 
-print('[BUILD] Done')
+logger.info('[BUILD] Done')

--- a/backend/utils/two_dir_difference.py
+++ b/backend/utils/two_dir_difference.py
@@ -1,4 +1,7 @@
 import os
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def find_unique_files(dir1, dir2):
@@ -31,4 +34,4 @@ if __name__ == '__main__':
     folder2 = r'C:\Users\xl\AppData\Roaming\xlartas-launcher\xlartas-client\mods'
     unique = find_unique_files(folder1, folder2)
     for path in unique:
-        print(path)
+        logger.info(path)


### PR DESCRIPTION
## Summary
- replace stray `print()` calls with logger usage across backend utilities
- cleanup debug prints in `software` service and `CKassa` provider
- ensure various helper scripts use `logging` rather than `print`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686cce461f18833087fdc2dddebb23db