### PR TITLE
Refactor payment info helper

### DIFF
--- a/frontend/src/Modules/Order/BalanceTopUpDialog.tsx
+++ b/frontend/src/Modules/Order/BalanceTopUpDialog.tsx
@@ -1,23 +1,10 @@
 import React, {useContext, useEffect, useState} from 'react';
 import {useTranslation} from 'react-i18next';
-import {Button, Collapse, Dialog, DialogContent, DialogTitle, TextField} from '@mui/material';
+import {Button, Dialog, DialogContent, DialogTitle, TextField} from '@mui/material';
 import CircularProgress from 'Core/components/elements/CircularProgress';
 import {FC, FR} from 'wide-containers';
-import PaymentSystemIcons from './PaymentSystemIcons';
+import PaymentSystemInfo from './PaymentSystemInfo';
 
-import iconVisa from '../../Static/img/icon/payments/visa.svg';
-import iconMastercard from '../../Static/img/icon/payments/mastercard.svg';
-import iconMir from '../../Static/img/icon/payments/mir.svg';
-import iconSBP from '../../Static/img/icon/payments/sbp.svg';
-import iconSteam from '../../Static/img/icon/payments/steam.svg';
-import iconBitcoin from '../../Static/img/icon/payments/bitcoin.svg';
-import iconLitecoin from '../../Static/img/icon/payments/litecoin.svg';
-import iconEthereum from '../../Static/img/icon/payments/ethereum.svg';
-import iconTron from '../../Static/img/icon/payments/tron.svg';
-import iconTon from '../../Static/img/icon/payments/toncoin.svg';
-import iconBnb from '../../Static/img/icon/payments/bnb.svg';
-import iconUnionPay from '../../Static/img/icon/payments/unionpay.svg';
-import iconSberPay from '../../Static/img/icon/payments/sberpay.svg';
 import {useApi} from 'Api/useApi';
 import PaymentTypePicker from 'Order/PaymentTypePicker';
 import {ICurrencyWithPrice, IPaymentSystem, IProduct} from 'types/commerce/shop';
@@ -42,29 +29,6 @@ const BalanceTopUpDialog: React.FC<BalanceTopUpDialogProps> = ({open, onClose}) 
     const [system, setSystem] = useState<IPaymentSystem | null>(null);
     const [loading, setLoading] = useState(false);
 
-    const freekassaIcons = [
-        iconSBP,
-        iconVisa,
-        iconMastercard,
-        iconMir,
-        iconSteam,
-        iconBitcoin,
-        iconLitecoin,
-        iconEthereum,
-        iconTron,
-        iconTon,
-        iconBnb,
-        iconTron,
-    ];
-
-    const ckassaIcons = [
-        iconSBP,
-        iconSberPay,
-        iconVisa,
-        iconMastercard,
-        iconMir,
-        iconUnionPay,
-    ];
 
     useEffect(() => {
         if (open) {
@@ -129,19 +93,10 @@ const BalanceTopUpDialog: React.FC<BalanceTopUpDialogProps> = ({open, onClose}) 
                             setPaymentSystem={setSystem}
                             excluded_payment_systems={["balance"]}
                         />
-                        <Collapse in={system === 'freekassa'}>
-                            <FR mb={0.5}>{t('freekassa_help_desc')}</FR>
-                            <PaymentSystemIcons icons={freekassaIcons}/>
-                        </Collapse>
-                        <Collapse in={system === 'ckassa'}>
-                            <PaymentSystemIcons icons={ckassaIcons}/>
-                        </Collapse>
-                        <Collapse in={system === 'handmade'}>
-                            <FR mb={0.5}>{t('handmade_payment_desc')}</FR>
-                        </Collapse>
-                        <Collapse in={system === 'balance'}>
-                            <FR mb={0.5}>{t('balance_payment_desc')}</FR>
-                        </Collapse>
+                        <PaymentSystemInfo
+                            system={system}
+                            freekassaExtra={<FR mb={0.5}>{t('freekassa_help_desc')}</FR>}
+                        />
                         <Button onClick={handleCreate} disabled={loading} sx={{fontWeight: 'bold'}}>
                             {loading ? <CircularProgress size="20px"/> : t('next')}
                         </Button>

--- a/frontend/src/Modules/Order/PaymentSystemInfo.tsx
+++ b/frontend/src/Modules/Order/PaymentSystemInfo.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import {useTranslation} from 'react-i18next';
+import {Collapse} from '@mui/material';
+import {FR} from 'wide-containers';
+import PaymentSystemIcons from './PaymentSystemIcons';
+
+import iconVisa from '../../Static/img/icon/payments/visa.svg';
+import iconMastercard from '../../Static/img/icon/payments/mastercard.svg';
+import iconMir from '../../Static/img/icon/payments/mir.svg';
+import iconSBP from '../../Static/img/icon/payments/sbp.svg';
+import iconSteam from '../../Static/img/icon/payments/steam.svg';
+import iconBitcoin from '../../Static/img/icon/payments/bitcoin.svg';
+import iconLitecoin from '../../Static/img/icon/payments/litecoin.svg';
+import iconEthereum from '../../Static/img/icon/payments/ethereum.svg';
+import iconTron from '../../Static/img/icon/payments/tron.svg';
+import iconTon from '../../Static/img/icon/payments/toncoin.svg';
+import iconBnb from '../../Static/img/icon/payments/bnb.svg';
+import iconUnionPay from '../../Static/img/icon/payments/unionpay.svg';
+import iconSberPay from '../../Static/img/icon/payments/sberpay.svg';
+
+export const freekassaIcons = [
+    iconSBP,
+    iconVisa,
+    iconMastercard,
+    iconMir,
+    iconSteam,
+    iconBitcoin,
+    iconLitecoin,
+    iconEthereum,
+    iconTron,
+    iconTon,
+    iconBnb,
+    iconTron,
+];
+
+export const ckassaIcons = [
+    iconSBP,
+    iconSberPay,
+    iconVisa,
+    iconMastercard,
+    iconMir,
+    iconUnionPay,
+];
+
+interface Props {
+    system: string | null;
+    className?: string;
+    freekassaExtra?: React.ReactNode;
+}
+
+const PaymentSystemInfo: React.FC<Props> = ({system, className, freekassaExtra}) => {
+    const {t} = useTranslation();
+    return (
+        <>
+            <Collapse in={system === 'freekassa'} className={className}>
+                {freekassaExtra}
+                <PaymentSystemIcons icons={freekassaIcons}/>
+            </Collapse>
+            <Collapse in={system === 'ckassa'} className={className}>
+                <PaymentSystemIcons icons={ckassaIcons}/>
+            </Collapse>
+            <Collapse in={system === 'handmade'} className={className}>
+                <FR opacity={80} mb={0.5} fontSize={'.88rem'}>
+                    {t('handmade_payment_desc')}
+                </FR>
+            </Collapse>
+            <Collapse in={system === 'balance'} className={className}>
+                <FR opacity={80} mb={0.5} fontSize={'.88rem'}>
+                    {t('balance_payment_desc')}
+                </FR>
+            </Collapse>
+        </>
+    );
+};
+
+export default PaymentSystemInfo;

--- a/frontend/src/Modules/Order/PaymentTypePickerModal.tsx
+++ b/frontend/src/Modules/Order/PaymentTypePickerModal.tsx
@@ -5,23 +5,9 @@ import Dialog from '@mui/material/Dialog';
 import DialogTitle from '@mui/material/DialogTitle';
 import DialogContent from '@mui/material/DialogContent';
 import PaymentTypePicker from './PaymentTypePicker';
-import PaymentSystemIcons from './PaymentSystemIcons';
-
-import iconVisa from '../../Static/img/icon/payments/visa.svg';
-import iconMastercard from '../../Static/img/icon/payments/mastercard.svg';
-import iconMir from '../../Static/img/icon/payments/mir.svg';
-import iconSBP from '../../Static/img/icon/payments/sbp.svg';
-import iconSteam from '../../Static/img/icon/payments/steam.svg';
-import iconBitcoin from '../../Static/img/icon/payments/bitcoin.svg';
-import iconLitecoin from '../../Static/img/icon/payments/litecoin.svg';
-import iconEthereum from '../../Static/img/icon/payments/ethereum.svg';
-import iconTron from '../../Static/img/icon/payments/tron.svg';
-import iconTon from '../../Static/img/icon/payments/toncoin.svg';
-import iconBnb from '../../Static/img/icon/payments/bnb.svg';
-import iconUnionPay from '../../Static/img/icon/payments/unionpay.svg';
-import iconSberPay from '../../Static/img/icon/payments/sberpay.svg';
+import PaymentSystemInfo from './PaymentSystemInfo';
 import {ICurrencyWithPrice, IOrder, IPaymentSystem} from 'types/commerce/shop';
-import {Button, Collapse} from '@mui/material';
+import {Button} from '@mui/material';
 import {Message} from 'Core/components/Message';
 import CircularProgress from 'Core/components/elements/CircularProgress';
 import {useApi} from 'Api/useApi';
@@ -41,29 +27,6 @@ const PaymentTypePickerModal: React.FC<Props> = ({open, onClose, order, onPaymen
     const [loading, setLoading] = useState(false);
     const {t} = useTranslation();
 
-    const freekassaIcons = [
-        iconSBP,
-        iconVisa,
-        iconMastercard,
-        iconMir,
-        iconSteam,
-        iconBitcoin,
-        iconLitecoin,
-        iconEthereum,
-        iconTron,
-        iconTon,
-        iconBnb,
-        iconTron,
-    ];
-
-    const ckassaIcons = [
-        iconSBP,
-        iconSberPay,
-        iconVisa,
-        iconMastercard,
-        iconMir,
-        iconUnionPay,
-    ];
 
     const confirm = async () => {
         if (!currency || !system) {
@@ -97,22 +60,7 @@ const PaymentTypePickerModal: React.FC<Props> = ({open, onClose, order, onPaymen
                         setPaymentCurrency={setCurrency}
                         setPaymentSystem={setSystem}
                     />
-                    <Collapse in={system === 'freekassa'}>
-                        <PaymentSystemIcons icons={freekassaIcons}/>
-                    </Collapse>
-                    <Collapse in={system === 'ckassa'}>
-                        <PaymentSystemIcons icons={ckassaIcons}/>
-                    </Collapse>
-                    <Collapse in={system === 'handmade'}>
-                        <FR opacity={80} mb={0.5} fontSize={'.88rem'}>
-                            {t('handmade_payment_desc')}
-                        </FR>
-                    </Collapse>
-                    <Collapse in={system === 'balance'}>
-                        <FR opacity={80} mb={0.5} fontSize={'.88rem'}>
-                            {t('balance_payment_desc')}
-                        </FR>
-                    </Collapse>
+                    <PaymentSystemInfo system={system}/>
                     <FRE g={1}>
                         <Button variant="outlined" onClick={onClose}>{t('cancel')}</Button>
                         <Button variant="contained" disabled={loading} onClick={confirm}>

--- a/frontend/src/Modules/Software/SoftwareOrder.tsx
+++ b/frontend/src/Modules/Software/SoftwareOrder.tsx
@@ -9,21 +9,8 @@ import {ICurrencyWithPrice, IPaymentSystem} from 'types/commerce/shop';
 import {ISoftware} from './Types/Software';
 import {IPromocode} from 'types/commerce/promocode';
 import PromoCodeField from 'Order/PromoCodeField';
-import PaymentSystemIcons from '../Order/PaymentSystemIcons';
+import PaymentSystemInfo from '../Order/PaymentSystemInfo';
 
-import iconVisa from '../../Static/img/icon/payments/visa.svg';
-import iconMastercard from '../../Static/img/icon/payments/mastercard.svg';
-import iconMir from '../../Static/img/icon/payments/mir.svg';
-import iconSBP from '../../Static/img/icon/payments/sbp.svg';
-import iconSteam from '../../Static/img/icon/payments/steam.svg';
-import iconBitcoin from '../../Static/img/icon/payments/bitcoin.svg';
-import iconLitecoin from '../../Static/img/icon/payments/litecoin.svg';
-import iconEthereum from '../../Static/img/icon/payments/ethereum.svg';
-import iconTron from '../../Static/img/icon/payments/tron.svg';
-import iconTon from '../../Static/img/icon/payments/toncoin.svg';
-import iconBnb from '../../Static/img/icon/payments/bnb.svg';
-import iconUnionPay from '../../Static/img/icon/payments/unionpay.svg';
-import iconSberPay from '../../Static/img/icon/payments/sberpay.svg';
 import AddRoundedIcon from '@mui/icons-material/AddRounded';
 import RemoveRoundedIcon from '@mui/icons-material/RemoveRounded';
 import {AuthContext, AuthContextType} from 'Auth/AuthContext';
@@ -109,29 +96,6 @@ const SoftwareOrder: React.FC<SoftwareOrderProps> = ({software, onSuccess}) => {
     const offset: number = parseFloat(priceRow.offset?.toString() || '0');
     const totalPrice = calculatePrice(licenseHours, amount, exponent, offset);
 
-    const freekassaIcons = [
-        iconSBP,
-        iconVisa,
-        iconMastercard,
-        iconMir,
-        iconSteam,
-        iconBitcoin,
-        iconLitecoin,
-        iconEthereum,
-        iconTron,
-        iconTon,
-        iconBnb,
-        iconTron,
-    ];
-
-    const ckassaIcons = [
-        iconSBP,
-        iconSberPay,
-        iconVisa,
-        iconMastercard,
-        iconMir,
-        iconUnionPay,
-    ];
 
     /* ------------------------------------------------------------------ */
     /*  order create                                                      */
@@ -249,25 +213,10 @@ const SoftwareOrder: React.FC<SoftwareOrderProps> = ({software, onSuccess}) => {
                                 setPaymentSystem={setSystem}
                             />
                         </FC>
-                        <Collapse in={system === 'freekassa'}>
-                            <FR opacity={80} mb={0.5} fontSize={'.88rem'} sx={{lineHeight: '1.2rem'}}>
-                                {t('freekassa_note')}
-                            </FR>
-                            <PaymentSystemIcons icons={freekassaIcons}/>
-                        </Collapse>
-                        <Collapse in={system === 'ckassa'}>
-                            <PaymentSystemIcons icons={ckassaIcons}/>
-                        </Collapse>
-                        <Collapse in={system === 'handmade'}>
-                            <FR opacity={80} mb={0.5} fontSize={'.88rem'}>
-                                {t('handmade_payment_desc')}
-                            </FR>
-                        </Collapse>
-                        <Collapse in={system === 'balance'}>
-                            <FR opacity={80} mb={0.5} fontSize={'.88rem'}>
-                                {t('balance_payment_desc')}
-                            </FR>
-                        </Collapse>
+                        <PaymentSystemInfo
+                            system={system}
+                            freekassaExtra={<FR opacity={80} mb={0.5} fontSize={'.88rem'} sx={{lineHeight: '1.2rem'}}>{t('freekassa_note')}</FR>}
+                        />
                         <FRC g={1} mt={1}>
                             <Button disabled={creatingOrder} onClick={createOrder} sx={{
                                 fontWeight: 'bold', width: '100%',


### PR DESCRIPTION
## Summary
- centralize payment system icons and notes
- refactor dialogs and forms to reuse PaymentSystemInfo component

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686cce32355083308ad1deae92950843