### PR TITLE
Fix CKassa callback handling

### DIFF
--- a/backend/apps/ckassa/consts.py
+++ b/backend/apps/ckassa/consts.py
@@ -1,0 +1,6 @@
+# ckassa/consts.py
+
+CKASSA_NOTIFICATION_ALLOWED_URLS = (
+    '178.161.210.54',
+    '94.138.149.0/24',
+)

--- a/backend/apps/ckassa/controllers/api.py
+++ b/backend/apps/ckassa/controllers/api.py
@@ -10,6 +10,7 @@ from rest_framework.response import Response
 from rest_framework.status import HTTP_200_OK, HTTP_400_BAD_REQUEST
 
 from apps.ckassa.models import CKassaPayment
+from apps.ckassa.consts import CKASSA_NOTIFICATION_ALLOWED_URLS
 from apps.commerce.models import Order
 
 log = logging.getLogger('global')
@@ -24,15 +25,29 @@ async def notification(request):
     log.debug('CKassa payload: %s', data)
     reg_pay_num = data.get('regPayNum') or data.get('reg_pay_num')
     order_id = data.get('order_id')
+
+    # Check IP for POST notifications
+    if request.method == 'POST' and request.ip not in CKASSA_NOTIFICATION_ALLOWED_URLS:
+        log.warning('CKassa notification ip not allowed: %s', request.ip)
+        return Response({'detail': 'ip not allowed'}, status=HTTP_400_BAD_REQUEST)
     if request.method == 'GET':
         if not order_id:
             return redirect(f'/orders/')
         return redirect(f'/orders/{order_id}/')
 
+    # order_id may come in properties under key 'НОМЕР ЗАКАЗА'
+    if not order_id:
+        props: Dict[str, Any] | list | None = data.get('property') or data.get('map')
+        if isinstance(props, dict):
+            order_id = props.get('НОМЕР ЗАКАЗА') or props.get('номер заказа')
+
     if not all((reg_pay_num, order_id)):
         return Response({'detail': 'wrong payload'}, status=HTTP_400_BAD_REQUEST)
 
-    order = await Order.objects.select_for_update().aget(pk=order_id)
+    order_qs = Order.objects.select_for_update().filter(id__startswith=str(order_id))
+    order = await order_qs.afirst()
+    if not order:
+        return Response({'detail': 'order not found'}, status=HTTP_400_BAD_REQUEST)
     payment: CKassaPayment = await order.arelated('payment')  # type: ignore
 
     payment.is_paid = True


### PR DESCRIPTION
## Summary
- validate CKassa callback IPs
- parse order id from callback properties
- search order by truncated id

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686cf8dc2e0c83308560f9c4b3d374a8