### PR TITLE
Fix CKassa IP range handling

### DIFF
--- a/backend/apps/ckassa/consts.py
+++ b/backend/apps/ckassa/consts.py
@@ -1,6 +1,8 @@
 # ckassa/consts.py
 
+from ipaddress import ip_network
+
 CKASSA_NOTIFICATION_ALLOWED_URLS = (
-    '178.161.210.54',
-    '94.138.149.0/24',
+    ip_network('178.161.210.54'),
+    ip_network('94.138.149.0/24'),
 )


### PR DESCRIPTION
## Summary
- handle CIDR ranges in CKassa allowed IPs
- check incoming IPs using `ipaddress`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686d0033c35c8330bc94f3d7ff662726