### PR TITLE
Add collapsing animation for cabinet tabs

### DIFF
--- a/frontend/src/Modules/Cabinet/Cabinet.tsx
+++ b/frontend/src/Modules/Cabinet/Cabinet.tsx
@@ -32,6 +32,7 @@ import SettingsRemoteRoundedIcon from '@mui/icons-material/SettingsRemoteRounded
 import ViewInArIcon from '@mui/icons-material/ViewInAr';
 import FeedRoundedIcon from '@mui/icons-material/FeedRounded';
 import Storage from '../FileHost/Storage';
+import ExpandOnMount from '../../UI/ExpandOnMount';
 
 type CabinetWidthContextType = {
     cabinetMaxWidth: string;
@@ -199,21 +200,55 @@ const Cabinet: React.FC = () => {
                         ref={cabinetContainerRef}>
                         <Routes>
                             <Route path="profile/*" element={
-                                <Profile selectedProfile={selectedProfile ? selectedProfile : 'client'}/>
+                                <ExpandOnMount>
+                                    <Profile selectedProfile={selectedProfile ? selectedProfile : 'client'}/>
+                                </ExpandOnMount>
                             }/>
-                            <Route path="/softwares" element={<FCSS g={2} p={2}>
-                                <Softwares/>
-                            </FCSS>}/>
-                            <Route path="/softwares/:id" element={<SoftwareDetail/>}/>
-                            <Route path='/licenses' element={<Licenses/>}/>
-                            <Route path='/wireless' element={<MacrosExecutorPage/>}/>
-                            <Route path='/xlmine-release' element={<MinecraftVersionsManager/>}/>
-                            <Route path='/storage/*' element={<Storage/>}/>
+                            <Route path="/softwares" element={
+                                <ExpandOnMount>
+                                    <FCSS g={2} p={2}>
+                                        <Softwares/>
+                                    </FCSS>
+                                </ExpandOnMount>
+                            }/>
+                            <Route path="/softwares/:id" element={
+                                <ExpandOnMount>
+                                    <SoftwareDetail/>
+                                </ExpandOnMount>
+                            }/>
+                            <Route path='/licenses' element={
+                                <ExpandOnMount>
+                                    <Licenses/>
+                                </ExpandOnMount>
+                            }/>
+                            <Route path='/wireless' element={
+                                <ExpandOnMount>
+                                    <MacrosExecutorPage/>
+                                </ExpandOnMount>
+                            }/>
+                            <Route path='/xlmine-release' element={
+                                <ExpandOnMount>
+                                    <MinecraftVersionsManager/>
+                                </ExpandOnMount>
+                            }/>
+                            <Route path='/storage/*' element={
+                                <ExpandOnMount>
+                                    <Storage/>
+                                </ExpandOnMount>
+                            }/>
 
-                            <Route path="/orders" element={<FCSS scroll={'y-auto'} g={1} pt={2} p={1}>
-                                <UserOrders className={'px-2'}/>
-                            </FCSS>}/>
-                            <Route path="orders/:id" element={<OrderDetail className={'px-3'}/>}/>
+                            <Route path="/orders" element={
+                                <ExpandOnMount>
+                                    <FCSS scroll={'y-auto'} g={1} pt={2} p={1}>
+                                        <UserOrders className={'px-2'}/>
+                                    </FCSS>
+                                </ExpandOnMount>
+                            }/>
+                            <Route path="orders/:id" element={
+                                <ExpandOnMount>
+                                    <OrderDetail className={'px-3'}/>
+                                </ExpandOnMount>
+                            }/>
                         </Routes>
                     </FC>
                 </FRC>

--- a/frontend/src/Modules/User/Profile.tsx
+++ b/frontend/src/Modules/User/Profile.tsx
@@ -6,6 +6,7 @@ import {FC, FRS} from 'wide-containers';
 import UserPersonalInfoForm from 'User/UserPersonalInfoForm';
 import XLMineProfileInfoForm from '../xLMine/xLMineProfileInfoForm';
 import {Tab, Tabs} from '@mui/material';
+import ExpandOnMount from '../../UI/ExpandOnMount';
 import {useDispatch} from "react-redux";
 import {AuthContext, AuthContextType} from "Auth/AuthContext";
 import {openAuthModal} from 'Redux/modalsSlice';
@@ -83,8 +84,16 @@ const Profile: React.FC<ProfileProps> = ({selectedProfile}) => {
             {/* Контент выбранной вкладки */}
             <FC flexGrow={1} scroll="y-auto" px={2} py={1}>
                 <Routes>
-                    <Route path="user" element={<UserPersonalInfoForm/>}/>
-                    <Route path="minecraft" element={<XLMineProfileInfoForm/>}/>
+                    <Route path="user" element={
+                        <ExpandOnMount>
+                            <UserPersonalInfoForm/>
+                        </ExpandOnMount>
+                    }/>
+                    <Route path="minecraft" element={
+                        <ExpandOnMount>
+                            <XLMineProfileInfoForm/>
+                        </ExpandOnMount>
+                    }/>
                     {/* <Route path="client" element={<ClientProfile />} /> */}
                     {/* <Route path="employee" element={<EmployeeProfile />} /> */}
                 </Routes>

--- a/frontend/src/UI/ExpandOnMount.tsx
+++ b/frontend/src/UI/ExpandOnMount.tsx
@@ -1,0 +1,22 @@
+import React, {useEffect, useState} from 'react';
+import {Collapse, CollapseProps} from '@mui/material';
+
+interface Props extends Omit<CollapseProps, 'in'> {
+    children: React.ReactNode;
+}
+
+const ExpandOnMount: React.FC<Props> = ({children, timeout = 350, ...rest}) => {
+    const [open, setOpen] = useState(false);
+    useEffect(() => {
+        const id = setTimeout(() => setOpen(true), 0);
+        return () => clearTimeout(id);
+    }, []);
+
+    return (
+        <Collapse in={open} timeout={timeout} {...rest}>
+            {children}
+        </Collapse>
+    );
+};
+
+export default ExpandOnMount;


### PR DESCRIPTION
## Summary
- add `ExpandOnMount` utility for collapse animations
- wrap cabinet routes in `ExpandOnMount` for smooth opening
- wrap profile tab routes in `ExpandOnMount`

## Testing
- `npm test` *(fails: `craco: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686d49dac3348330a9fc510c0744647b