### PR TITLE
Add collapsing animation for cabinet tabs

### DIFF
--- a/frontend/src/Modules/Cabinet/Cabinet.tsx
+++ b/frontend/src/Modules/Cabinet/Cabinet.tsx
@@ -198,21 +198,15 @@ const Cabinet: React.FC = () => {
                         }
                         ref={cabinetContainerRef}>
                         <Routes>
-                            <Route path="profile/*" element={
-                                <Profile selectedProfile={selectedProfile ? selectedProfile : 'client'}/>
-                            }/>
-                            <Route path="/softwares" element={<FCSS g={2} p={2}>
-                                <Softwares/>
-                            </FCSS>}/>
+                            <Route path="profile/*" element={<Profile selectedProfile={selectedProfile ? selectedProfile : 'client'}/>}/>
+                            <Route path="/softwares" element={<FCSS g={2} p={2}><Softwares/></FCSS>}/>
                             <Route path="/softwares/:id" element={<SoftwareDetail/>}/>
                             <Route path='/licenses' element={<Licenses/>}/>
                             <Route path='/wireless' element={<MacrosExecutorPage/>}/>
                             <Route path='/xlmine-release' element={<MinecraftVersionsManager/>}/>
                             <Route path='/storage/*' element={<Storage/>}/>
 
-                            <Route path="/orders" element={<FCSS scroll={'y-auto'} g={1} pt={2} p={1}>
-                                <UserOrders className={'px-2'}/>
-                            </FCSS>}/>
+                            <Route path="/orders" element={<FCSS scroll={'y-auto'} g={1} pt={2} p={1}><UserOrders className={'px-2'}/></FCSS>}/>
                             <Route path="orders/:id" element={<OrderDetail className={'px-3'}/>}/>
                         </Routes>
                     </FC>

--- a/frontend/src/Modules/Order/UserOrders.tsx
+++ b/frontend/src/Modules/Order/UserOrders.tsx
@@ -8,6 +8,7 @@ import OrderItem from "Order/OrderItem";
 import {FC as FCC, FCCC, FR} from "wide-containers";
 import CircularProgress from "Core/components/elements/CircularProgress";
 import {useApi} from "../Api/useApi";
+import {Collapse} from "@mui/material";
 
 interface UserOrdersProps {
     className?: string;
@@ -46,14 +47,15 @@ const UserOrders: React.FC<UserOrdersProps> = ({className}) => {
         <FR wrap w={'100%'} g={2} py={1} cls={`${className}`}>
             {orders.length > 0 ?
                 orders.map((order) => (
-                    <OrderItem
-                        key={order.id}
-                        onClick={() => navigate(`/orders/${order.id}`)}
-                        order={order}
-                        onSomeUpdatingOrderAction={handleOrderUpdate}
-                        // передаём колбэк удаления внутрь OrderActions
-                        onOrderDeleted={() => handleOrderDelete(String(order.id))}
-                    />
+                    <Collapse key={order.id} in={!loading} appear timeout={400}>
+                        <OrderItem
+                            onClick={() => navigate(`/orders/${order.id}`)}
+                            order={order}
+                            onSomeUpdatingOrderAction={handleOrderUpdate}
+                            // передаём колбэк удаления внутрь OrderActions
+                            onOrderDeleted={() => handleOrderDelete(String(order.id))}
+                        />
+                    </Collapse>
                 ))
                 : loading
                     ? <FCCC w={'100%'} mt={5}><CircularProgress size="90px"/></FCCC>

--- a/frontend/src/Modules/Software/Licenses.tsx
+++ b/frontend/src/Modules/Software/Licenses.tsx
@@ -6,6 +6,7 @@ import CircularProgress from 'Core/components/elements/CircularProgress';
 import {FCC, FCCC, FR} from 'wide-containers';
 import LicenseCard from './LicenseCard';
 import {Message} from 'Core/components/Message';
+import {Collapse} from "@mui/material";
 
 const Licenses: React.FC = () => {
     const {api} = useApi();
@@ -27,7 +28,11 @@ const Licenses: React.FC = () => {
             {loading
                 ? <FCCC w={'100%'} mt={5}><CircularProgress size="90px"/></FCCC>
                 : licenses && licenses.length > 0
-                    ? licenses.map(license => <LicenseCard key={license.id} license={license}/>)
+                    ? licenses.map(license => (
+                        <Collapse key={license.id} in={!loading} appear timeout={400}>
+                            <LicenseCard license={license}/>
+                        </Collapse>
+                    ))
                     : <FCC>Лицензии не найдены</FCC>
             }
         </FR>

--- a/frontend/src/Modules/Software/Macros/MacrosWirelessDashboard.tsx
+++ b/frontend/src/Modules/Software/Macros/MacrosWirelessDashboard.tsx
@@ -1,6 +1,6 @@
 // Modules/Software/Macros/MacrosWirelessDashboard.tsx
 import React, {useEffect, useState} from 'react';
-import {Box, CircularProgress, IconButton, List, ListItem, ListItemText, Tooltip,} from '@mui/material';
+import {Box, CircularProgress, IconButton, List, ListItem, ListItemText, Tooltip, Collapse} from '@mui/material';
 import DeleteIcon from '@mui/icons-material/Delete';
 import EditIcon from '@mui/icons-material/Edit';
 import AddIcon from '@mui/icons-material/AddRounded';
@@ -67,13 +67,14 @@ const MacrosWirelessDashboard: React.FC = () => {
                 <p style={{color: plt.text.primary}}>{t('nothing_saved')}</p>
             )}
 
-            <List dense sx={{width: '100%'}}>
-                {macros.map(m => (
-                    <ListItem
-                        key={m.id}
-                        divider
-                        onClick={() => sendMacro(m.name)}
-                        secondaryAction={(
+            <Collapse in appear timeout={400}>
+                <List dense sx={{width: '100%'}}>
+                    {macros.map(m => (
+                        <ListItem
+                            key={m.id}
+                            divider
+                            onClick={() => sendMacro(m.name)}
+                            secondaryAction={(
                             <Box sx={{opacity: '60%'}}>
                                 <Tooltip title={t('edit')}>
                                     <IconButton size="small" onClick={e => {
@@ -93,12 +94,13 @@ const MacrosWirelessDashboard: React.FC = () => {
                                     </IconButton>
                                 </Tooltip>
                             </Box>
-                        )}
-                    >
-                        <ListItemText sx={{opacity: '80%'}} primary={m.name}/>
-                    </ListItem>
-                ))}
-            </List>
+                            )}
+                        >
+                            <ListItemText sx={{opacity: '80%'}} primary={m.name}/>
+                        </ListItem>
+                    ))}
+                </List>
+            </Collapse>
 
             <MacroFormDialog
                 open={formOpen}

--- a/frontend/src/Modules/Software/Softwares.tsx
+++ b/frontend/src/Modules/Software/Softwares.tsx
@@ -9,6 +9,7 @@ import {ISoftware} from "./Types/Software";
 import {useApi} from "../Api/useApi";
 import SoftwareCard from "./SoftwareCard";
 import {useTranslation} from 'react-i18next';
+import {Collapse} from "@mui/material";
 
 
 const Softwares: React.FC = () => {
@@ -31,11 +32,14 @@ const Softwares: React.FC = () => {
     return (
         <FRCC g={2} wrap>
             {softwares.length
-                ? softwares.map(software => <SoftwareCard
-                    key={software.id}
-                    software={software}
-                    onClick={() => navigate(`/softwares/${software.id}`)}
-                />)
+                ? softwares.map(software => (
+                    <Collapse key={software.id} in={!loading} appear timeout={400}>
+                        <SoftwareCard
+                            software={software}
+                            onClick={() => navigate(`/softwares/${software.id}`)}
+                        />
+                    </Collapse>
+                ))
                 : <FRCC>{t('no_softwares')}</FRCC>
             }
         </FRCC>

--- a/frontend/src/Modules/xLMine/MinecraftVersionsManager.tsx
+++ b/frontend/src/Modules/xLMine/MinecraftVersionsManager.tsx
@@ -18,7 +18,8 @@ import {
     TableCell,
     TableHead,
     TableRow,
-    Tabs
+    Tabs,
+    Collapse
 } from '@mui/material';
 import {Message} from 'Core/components/Message';
 import DeleteIcon from '@mui/icons-material/Delete';
@@ -161,8 +162,9 @@ const LauncherManager: React.FC = () => {
                         <CircularProgress/>
                     </Box>
                 ) : (
-                    <Table>
-                        <TableHead>
+                    <Collapse in={!loading} appear timeout={400}>
+                        <Table>
+                            <TableHead>
                             <TableRow>
                                 <TableCell>ID</TableCell>
                                 <TableCell>{t('version')}</TableCell>
@@ -197,7 +199,8 @@ const LauncherManager: React.FC = () => {
                                 </TableRow>
                             ))}
                         </TableBody>
-                    </Table>
+                        </Table>
+                    </Collapse>
                 )}
             </Paper>
 
@@ -426,8 +429,9 @@ const ReleaseManager: React.FC = () => {
                         <CircularProgress/>
                     </Box>
                 ) : (
-                    <Table>
-                        <TableHead>
+                    <Collapse in={!loading} appear timeout={400}>
+                        <Table>
+                            <TableHead>
                             <TableRow>
                                 <TableCell>ID</TableCell>
                                 <TableCell>{t('version')}</TableCell>
@@ -452,7 +456,8 @@ const ReleaseManager: React.FC = () => {
                                 </TableRow>
                             ))}
                         </TableBody>
-                    </Table>
+                        </Table>
+                    </Collapse>
                 )}
             </Paper>
 


### PR DESCRIPTION
## Summary
- remove `ExpandOnMount` wrapper
- animate cards and tables with MUI `Collapse` after content loads
- expand wireless macros list smoothly

## Testing
- `npm test` *(fails: `craco: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686d49dac3348330a9fc510c0744647b