### PR TITLE
Add collapse animations

### DIFF
--- a/frontend/src/Modules/FileHost/Storage.tsx
+++ b/frontend/src/Modules/FileHost/Storage.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useEffect, useState} from 'react';
 import {Route, Routes, useLocation, useNavigate} from 'react-router-dom';
 import {Tab, Tabs} from '@mui/material';
 import Master from './Master';
@@ -8,9 +8,11 @@ import StorageUsageBar from './StorageUsageBar';
 import FileDetail from './FileDetail';
 import {FC, FR} from 'wide-containers';
 import {useTranslation} from 'react-i18next';
+import Collapse from '@mui/material/Collapse';
 
 const Storage: React.FC = () => {
     const {t} = useTranslation();
+    const [animate, setAnimate] = useState(false);
     const location = useLocation();
     const navigate = useNavigate();
 
@@ -20,7 +22,10 @@ const Storage: React.FC = () => {
             ? '/storage/files/all/'
             : '/storage/master/';
 
+    useEffect(() => setAnimate(true), []);
+
     return (
+        <Collapse in={animate} appear timeout={400}>
         <FC h={'100%'} px={2}>
             <Tabs value={current} onChange={(_, v) => navigate(v)}>
                 <Tab value="/storage/master/" label={t('storage')}/>
@@ -36,6 +41,7 @@ const Storage: React.FC = () => {
                 <Route path="files/:id/" element={<FileDetail/>}/>
             </Routes>
         </FC>
+        </Collapse>
     );
 };
 

--- a/frontend/src/Modules/Order/OrderDetail.tsx
+++ b/frontend/src/Modules/Order/OrderDetail.tsx
@@ -14,6 +14,7 @@ import {useTheme} from "Theme/ThemeContext";
 import {FC, FCCC, FR, FRBC, FRSC} from "wide-containers";
 import {useApi} from "../Api/useApi";
 import {useTranslation} from 'react-i18next';
+import Collapse from '@mui/material/Collapse';
 
 interface OrderDetailProps {
     className?: string;
@@ -26,6 +27,7 @@ const OrderDetail: React.FC<OrderDetailProps> = ({className}) => {
     const [order, setOrder] = useState<IOrder | null>(null);
     const [orderNotFound, setOrderNotFound] = useState(false);
     const [loading, setLoading] = useState(true);
+    const [animate, setAnimate] = useState(false);
     const [isActionLoading, setIsActionLoading] = useState<boolean>(false);
     const navigate = useNavigate();
     const {plt} = useTheme();
@@ -44,10 +46,15 @@ const OrderDetail: React.FC<OrderDetailProps> = ({className}) => {
         }).catch(_ => null).finally(() => setLoading(false));
     }, [id, isAuthenticated]);
 
+    useEffect(() => {
+        if (!loading) setAnimate(true);
+    }, [loading]);
+
     if (loading) return <FCCC w={'100%'} mt={5}><CircularProgress size="90px"/></FCCC>;
     if (orderNotFound || !order) return <div className={'p-3 text-center mt-2'}>Заказ не найден.</div>;
 
     return (
+        <Collapse in={animate} appear timeout={400}>
         <FC p={2} h={'100%'} scroll={'y-auto'} pos={'relative'} cls={'no-scrollbar'} sx={{
             background: `linear-gradient(45deg, #00000000, ${plt.text.primary + '07'})`
         }}>
@@ -124,6 +131,7 @@ const OrderDetail: React.FC<OrderDetailProps> = ({className}) => {
                 </FCCC>
             )}
         </FC>
+        </Collapse>
     );
 };
 

--- a/frontend/src/Modules/Order/UserOrders.tsx
+++ b/frontend/src/Modules/Order/UserOrders.tsx
@@ -8,6 +8,7 @@ import OrderItem from "Order/OrderItem";
 import {FC as FCC, FCCC, FR} from "wide-containers";
 import CircularProgress from "Core/components/elements/CircularProgress";
 import {useApi} from "../Api/useApi";
+import Collapse from '@mui/material/Collapse';
 
 interface UserOrdersProps {
     className?: string;
@@ -20,6 +21,7 @@ const UserOrders: React.FC<UserOrdersProps> = ({className}) => {
     const {api} = useApi();
     const navigate = useNavigate();
     const [loading, setLoading] = useState(false);
+    const [animate, setAnimate] = useState(false);
 
     useEffect(() => {
         if (user === null || !isAuthenticated) {
@@ -33,6 +35,10 @@ const UserOrders: React.FC<UserOrdersProps> = ({className}) => {
         ).finally(() => setLoading(false));
     }, [user, isAuthenticated]);
 
+    useEffect(() => {
+        if (!loading) setAnimate(true);
+    }, [loading]);
+
     const handleOrderUpdate = (updatedOrder: IOrder) => {
         setOrders((prevOrders) =>
             prevOrders.map(order => order.id === updatedOrder.id ? updatedOrder : order)
@@ -45,15 +51,22 @@ const UserOrders: React.FC<UserOrdersProps> = ({className}) => {
     return (
         <FR wrap w={'100%'} g={2} py={1} cls={`${className}`}>
             {orders.length > 0 ?
-                orders.map((order) => (
-                    <OrderItem
+                orders.map((order, index) => (
+                    <Collapse
                         key={order.id}
-                        onClick={() => navigate(`/orders/${order.id}`)}
-                        order={order}
-                        onSomeUpdatingOrderAction={handleOrderUpdate}
-                        // передаём колбэк удаления внутрь OrderActions
-                        onOrderDeleted={() => handleOrderDelete(String(order.id))}
-                    />
+                        in={animate}
+                        timeout={200 + index * 100}
+                        mountOnEnter
+                        unmountOnExit={false}
+                    >
+                        <OrderItem
+                            onClick={() => navigate(`/orders/${order.id}`)}
+                            order={order}
+                            onSomeUpdatingOrderAction={handleOrderUpdate}
+                            // передаём колбэк удаления внутрь OrderActions
+                            onOrderDeleted={() => handleOrderDelete(String(order.id))}
+                        />
+                    </Collapse>
                 ))
                 : loading
                     ? <FCCC w={'100%'} mt={5}><CircularProgress size="90px"/></FCCC>

--- a/frontend/src/Modules/Software/Licenses.tsx
+++ b/frontend/src/Modules/Software/Licenses.tsx
@@ -6,12 +6,14 @@ import CircularProgress from 'Core/components/elements/CircularProgress';
 import {FCC, FCCC, FR} from 'wide-containers';
 import LicenseCard from './LicenseCard';
 import {Message} from 'Core/components/Message';
+import Collapse from '@mui/material/Collapse';
 
 const Licenses: React.FC = () => {
     const {api} = useApi();
     const {t} = useTranslation();
     const [licenses, setLicenses] = useState<any[]>([]);
     const [loading, setLoading] = useState(true);
+    const [animate, setAnimate] = useState(false);
 
     useEffect(() => {
         setLoading(true);
@@ -21,13 +23,27 @@ const Licenses: React.FC = () => {
             .finally(() => setLoading(false));
     }, [api]);
 
+    useEffect(() => {
+        if (!loading) setAnimate(true);
+    }, [loading]);
+
 
     return (
         <FR wrap g={2} p={2}>
             {loading
                 ? <FCCC w={'100%'} mt={5}><CircularProgress size="90px"/></FCCC>
                 : licenses && licenses.length > 0
-                    ? licenses.map(license => <LicenseCard key={license.id} license={license}/>)
+                    ? licenses.map((license, index) => (
+                        <Collapse
+                            key={license.id}
+                            in={animate}
+                            timeout={200 + index * 100}
+                            mountOnEnter
+                            unmountOnExit={false}
+                        >
+                            <LicenseCard license={license}/>
+                        </Collapse>
+                    ))
                     : <FCC>Лицензии не найдены</FCC>
             }
         </FR>

--- a/frontend/src/Modules/Software/Macros/MacrosExecutorPage.tsx
+++ b/frontend/src/Modules/Software/Macros/MacrosExecutorPage.tsx
@@ -1,5 +1,5 @@
 // Modules/Software/Macros/MacrosExecutorPage.tsx
-import React, {useState} from 'react';
+import React, {useEffect, useState} from 'react';
 import {Tab, Tabs, useMediaQuery} from '@mui/material';
 import {FC, FCCC} from 'wide-containers';
 import {useTheme} from 'Theme/ThemeContext';
@@ -13,6 +13,7 @@ import MacrosInfo from "./MacrosInfo";
 import {ScreenViewerProvider} from './ScreenViewerProvider';
 import ScreenViewer from "./ScreenViewer";
 import {useTranslation} from "react-i18next";
+import Collapse from '@mui/material/Collapse';
 
 const MacrosExecutorPage: React.FC = () => {
     const {plt} = useTheme();
@@ -21,8 +22,12 @@ const MacrosExecutorPage: React.FC = () => {
         useState<'panel' | 'io' | 'byname'>('panel');
     const isGtSm = useMediaQuery('(min-width: 576px)');
     const {t} = useTranslation();
+    const [animate, setAnimate] = useState(false);
+
+    useEffect(() => setAnimate(true), []);
 
     return (
+        <Collapse in={animate} appear timeout={400}>
         <MacroControlProvider>
             <FC w="100%" scroll="y-hidden" px={2} pt={isGtSm ? 2 : 0} g={1}>
                 <Tabs
@@ -81,6 +86,7 @@ const MacrosExecutorPage: React.FC = () => {
                 )}
             </FC>
         </MacroControlProvider>
+        </Collapse>
     );
 };
 

--- a/frontend/src/Modules/xLMine/MinecraftVersionsManager.tsx
+++ b/frontend/src/Modules/xLMine/MinecraftVersionsManager.tsx
@@ -28,6 +28,7 @@ import FileUpload from "../../UI/FileUpload";
 import {ILauncher, IRelease} from "./types/base";
 import {v4 as uuidv4} from 'uuid';
 import TextField from "@mui/material/TextField";
+import Collapse from '@mui/material/Collapse';
 
 // ==== Форматирование даты (если хочешь как есть — можно убрать toLocaleString) ====
 
@@ -45,6 +46,7 @@ const LauncherManager: React.FC = () => {
     const [loading, setLoading] = useState<boolean>(false);
 
     const [version, setVersion] = useState<string>("1.0.0");
+    const [animate, setAnimate] = useState(false);
     // Удаление
     const [confirmDeleteId, setConfirmDeleteId] = useState<number | null>(null);
     const [deletingId, setDeletingId] = useState<number | null>(null);
@@ -66,6 +68,10 @@ const LauncherManager: React.FC = () => {
         fetchVersions().then();
         // eslint-disable-next-line
     }, []);
+
+    useEffect(() => {
+        if (!loading) setAnimate(true);
+    }, [loading]);
 
     // ==== Выбор файла ====
     const handleFileSelect = (picked: File | null) => {
@@ -127,6 +133,7 @@ const LauncherManager: React.FC = () => {
     };
 
     return (
+        <Collapse in={animate} appear timeout={400}>
         <FC g={1}>
             <Paper sx={{p: 2}}>
                 <FC g={1}>
@@ -227,6 +234,7 @@ const LauncherManager: React.FC = () => {
                 </DialogActions>
             </Dialog>
         </FC>
+        </Collapse>
     );
 };
 
@@ -256,6 +264,7 @@ const ReleaseManager: React.FC = () => {
     const [version, setVersion] = useState<string>("1.0.0");
     const [releases, setReleases] = useState<IRelease[]>([]);
     const [loading, setLoading] = useState<boolean>(false);
+    const [animate, setAnimate] = useState(false);
 
     const [confirmDeleteId, setConfirmDeleteId] = useState<number | null>(null);
     const [deletingId, setDeletingId] = useState<number | null>(null);
@@ -275,6 +284,10 @@ const ReleaseManager: React.FC = () => {
     useEffect(() => {
         fetchVersions().then();
     }, []);
+
+    useEffect(() => {
+        if (!loading) setAnimate(true);
+    }, [loading]);
 
     const handleFileChange = (picked: File | null) => {
         setFile(picked);
@@ -367,6 +380,7 @@ const ReleaseManager: React.FC = () => {
     };
 
     return (
+        <Collapse in={animate} appear timeout={400}>
         <FC g={1}>
             <Paper sx={{p: 2}}>
                 <FC g={1}>
@@ -467,19 +481,24 @@ const ReleaseManager: React.FC = () => {
                 </DialogActions>
             </Dialog>
         </FC>
+        </Collapse>
     );
 };
 
 
 const MinecraftVersionsManager: React.FC = () => {
     const [tabIndex, setTabIndex] = useState<number>(0);
+    const [animate, setAnimate] = useState(false);
     const {t} = useTranslation();
 
     const handleTabChange = (_event: React.SyntheticEvent, newValue: number) => {
         setTabIndex(newValue);
     };
 
+    useEffect(() => setAnimate(true), []);
+
     return (
+        <Collapse in={animate} appear timeout={400}>
         <FC>
             <Tabs value={tabIndex} onChange={handleTabChange}>
                 <Tab label="Launcher"/>
@@ -490,6 +509,7 @@ const MinecraftVersionsManager: React.FC = () => {
                 {tabIndex === 1 && <ReleaseManager/>}
             </FC>
         </FC>
+        </Collapse>
     );
 };
 


### PR DESCRIPTION
## Summary
- add Collapse to UserOrders listing
- animate OrderDetail page on load
- animate licenses page results
- fade in wireless executor page
- fade in storage page
- add collapses to launcher/release management
- fix duplicate effect in storage animation

## Testing
- `npm test --silent` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686d60e6c9f88330b09e9a173c68c0df