### PR TITLE
Refactor chat room into hooks

### DIFF
--- a/frontend/src/Modules/Chat/MessagesList.tsx
+++ b/frontend/src/Modules/Chat/MessagesList.tsx
@@ -1,4 +1,4 @@
-// Modules/Chat/MessagesContainer.tsx
+// Modules/Chat/MessagesList.tsx
 
 import React, {useContext} from 'react';
 import {CircularProgress} from '@mui/material';
@@ -9,7 +9,7 @@ import {useTheme} from "Theme/ThemeContext";
 import {AuthContext, AuthContextType} from "Auth/AuthContext";
 import {useTranslation} from "react-i18next";
 
-interface MessagesContainerProps {
+interface MessagesListProps {
     messages: IMessage[];
     room: IRoom | null;
     renderDateLabel: (message: IMessage, previousMessage?: IMessage) => React.ReactNode;
@@ -18,7 +18,7 @@ interface MessagesContainerProps {
     messagesContainerRef: React.RefObject<HTMLDivElement>;
 }
 
-const MessagesContainer: React.FC<MessagesContainerProps> = (
+const MessagesList: React.FC<MessagesListProps> = (
     {
         messages,
         room,
@@ -79,4 +79,4 @@ const MessagesContainer: React.FC<MessagesContainerProps> = (
     );
 };
 
-export default React.memo(MessagesContainer);
+export default React.memo(MessagesList);

--- a/frontend/src/Modules/Chat/Room.tsx
+++ b/frontend/src/Modules/Chat/Room.tsx
@@ -1,61 +1,77 @@
 // Modules/Chat/Room.tsx
-import React, {RefObject, useCallback, useContext, useEffect, useLayoutEffect, useRef, useState,} from 'react';
+import React, {RefObject, useCallback, useContext, useEffect, useState} from 'react';
 import {useTranslation} from 'react-i18next';
 import {useParams} from 'react-router-dom';
 import {AuthContext, AuthContextType} from 'Auth/AuthContext';
 import Divider from 'Core/components/elements/Divider';
-import {parseISO} from 'date-fns';
 import {Message as ToastMessage} from 'Core/components/Message';
 import {useErrorProcessing} from 'Core/components/ErrorProvider';
 import {IMessage, IRoom} from 'types/chat/models';
 import {FC} from 'wide-containers';
 import MessageInput from 'Chat/MessageInput';
-import {useRooms} from './RoomsContext';
+
 import RoomHeader from './RoomHeader';
-import MessagesContainer from './MessagesContainer';
-import DateLabel from './DateLabel';
-import useWebSocket from './useWebSocket';
-import {useNavigation} from "Core/components/Header/HeaderProvider";
-import {useApi} from "../Api/useApi";
+import MessagesList from './MessagesList';
+import useRoomMessages from './useRoomMessages';
+import useRoomSocket from './useRoomSocket';
+import {useNavigation} from 'Core/components/Header/HeaderProvider';
+import {useApi} from '../Api/useApi';
 
 interface RoomProps {
-    /** Если хотим передать комнату напрямую (чтобы не делать запрос на получение Room). */
     room?: IRoom | null;
-    /** ID комнаты (обычно строка из URL) */
     roomId?: string;
     showHeader?: boolean;
 }
 
-const Room: React.FC<RoomProps> = (
-    {
-        room: roomProp,
-        roomId: propRoomId,
-        showHeader,
-    }) => {
+const Room: React.FC<RoomProps> = ({room: roomProp, roomId: propRoomId, showHeader}) => {
     const {roomId: routeRoomId} = useParams<{ roomId: string }>();
     const roomId = propRoomId ?? routeRoomId;
     const {headerNavHeight} = useNavigation();
-    const [messages, setMessages] = useState<IMessage[]>([]);
     const [room, setRoom] = useState<IRoom | null>(roomProp ?? null);
-    const messagesEndRef = useRef<HTMLDivElement | null>(null);
-    const messagesContainerRef = useRef<HTMLDivElement | null>(null);
-    const [nextPageUrl, setNextPageUrl] = useState<string | null>(null);
-    const {isAuthenticated: authStatus, user} =
-        useContext(AuthContext) as AuthContextType;
-    const isAuthenticated = authStatus ?? false; // Обеспечиваем, что это всегда boolean
+    const {isAuthenticated: authStatus, user} = useContext(AuthContext) as AuthContextType;
+    const isAuthenticated = authStatus ?? false;
     const {notAuthentication} = useErrorProcessing();
-    const {updateRoom} = useRooms();
     const {api} = useApi();
     const {t} = useTranslation();
-    const [isLoadingMore, setIsLoadingMore] = useState<boolean>(false);
-    const isInitialLoad = useRef<boolean>(true);
-    const prevScrollHeightRef = useRef<number>(0);
-    const messagesRef = useRef<IMessage[]>(messages);
-    const isFetchingRef = useRef<boolean>(false); // Ref для предотвращения множественных запросов
+
+    const {
+        messages,
+        setMessages,
+        messagesEndRef,
+        messagesContainerRef,
+        isLoadingMore,
+        renderDateLabel,
+        fetchMessages,
+        reset,
+        messagesRef,
+    } = useRoomMessages({roomId, api});
+
+    const sendMessage = useRoomSocket({
+        roomId: roomId || '',
+        isAuthenticated,
+        userId: user?.id || null,
+        setMessages,
+    });
+
+    const fetchRoom = useCallback(async () => {
+        if (roomProp || !roomId) return;
+        api.get(`/api/v1/rooms/${roomId}/`).then(data => setRoom(data));
+    }, [roomId, api, roomProp]);
 
     useEffect(() => {
-        messagesRef.current = messages;
-    }, [messages]);
+        if (!isAuthenticated) {
+            notAuthentication();
+            return;
+        }
+        if (roomId) {
+            fetchMessages();
+            fetchRoom();
+        }
+    }, [roomId, fetchMessages, fetchRoom, notAuthentication, isAuthenticated]);
+
+    useEffect(() => {
+        reset();
+    }, [roomId, reset]);
 
     const base64ToBlob = useCallback((base64: string, type: string): Blob => {
         const byteCharacters = atob(base64);
@@ -67,238 +83,63 @@ const Room: React.FC<RoomProps> = (
         return new Blob([byteArray], {type});
     }, []);
 
-    const fetchMessages = useCallback(
-        async (url: string | null = null) => {
-            if (isLoadingMore || isFetchingRef.current) return;
-            if (url === null && !isInitialLoad.current) return;
-            if (!roomId) return;
-            isFetchingRef.current = true;
-            setIsLoadingMore(true);
-            if (url && messagesContainerRef.current) {
-                prevScrollHeightRef.current = messagesContainerRef.current.scrollHeight;
-            }
-            api.get(url || `/api/v1/rooms/${roomId}/messages/`).then(data => {
-                setMessages((prevMessages) => {
-                    const newMessages = data.results.filter(
-                        (msg: IMessage) => !prevMessages.some((existing) => existing.id === msg.id)
-                    );
-                    return [...newMessages, ...prevMessages];
-                });
-                setNextPageUrl(data.next);
-
-                // При первой загрузке скроллим вниз
-                if (isInitialLoad.current && !url) {
-                    setTimeout(() => {
-                        messagesContainerRef.current?.scrollTo({
-                            top: messagesContainerRef.current.scrollHeight,
-                            behavior: 'auto',
-                        });
-                    }, 100);
-                    isInitialLoad.current = false;
-                } else if (url && messagesContainerRef.current) {
-                    // Если догружаем историю (скроллим вверх)
-                    setTimeout(() => {
-                        if (messagesContainerRef.current) {
-                            const newScrollHeight = messagesContainerRef.current.scrollHeight;
-                            messagesContainerRef.current.scrollTop =
-                                newScrollHeight - prevScrollHeightRef.current;
-                        }
-                    }, 100);
-                }
-            }).finally(() => {
-                setIsLoadingMore(false);
-                isFetchingRef.current = false;
-            })
-        },
-        [roomId, api, isLoadingMore]
-    );
-
-    const fetchRoom = useCallback(async () => {
-        if (roomProp || !roomId) return;
-        api.get(`/api/v1/rooms/${roomId}/`).then(data => setRoom(data));
-    }, [roomId, api, roomProp]);
-
-    const handleWebSocketMessage = useCallback(
-        (data: any) => {
-            if (data.action === 'confirm_message_saved') {
-                setMessages((prevMessages) => {
-                    const index = prevMessages.findIndex(
-                        (msg) => msg.id === data.tempId || msg.tempId === data.tempId
-                    );
-                    if (index !== -1) {
-                        const newMessages = [...prevMessages];
-                        newMessages[index] = {...data, status: 'sent'};
-                        return newMessages;
-                    } else {
-                        return [...prevMessages, data];
-                    }
-                });
-
-                if (data.room) {
-                    updateRoom(data.room);
-                }
-            } else if (data.action === 'read_message') {
-                setMessages((prevMessages) => {
-                    const index = prevMessages.findIndex((msg) => msg.id === data.id);
-                    if (index !== -1) {
-                        const newMessages = [...prevMessages];
-                        newMessages[index] = {...newMessages[index], is_read: true};
-                        return newMessages;
-                    }
-                    return prevMessages;
-                });
-
-                if (data.room) {
-                    updateRoom(data.room);
-                }
-            }
-        },
-        [updateRoom]
-    );
-
-    const sendMessage = useWebSocket({
-        roomId: roomId || '',
-        isAuthenticated,
-        userId: user?.id || null,
-        onMessage: handleWebSocketMessage,
-    });
-
-    useEffect(() => {
-        if (!isAuthenticated) {
-            notAuthentication();
+    const handleSendMessage = useCallback((messageText: string, attachedFiles: any[], isImportant: boolean) => {
+        if (!user) {
+            ToastMessage.error(t('not_authorized'));
             return;
         }
-
-        // Загружаем сообщения
-        if (roomId) {
-            fetchMessages().then();
-            // Загружаем информацию о комнате, если нет готовой
-            fetchRoom().then();
-        }
-    }, [roomId, fetchMessages, fetchRoom, notAuthentication, isAuthenticated]);
-
-    // При смене roomId сбрасываем сообщения и состояние
-    useEffect(() => {
-        setMessages([]);
-        setNextPageUrl(null);
-        isInitialLoad.current = true;
-        if (messagesContainerRef.current) {
-            messagesContainerRef.current.scrollTop = 0;
-        }
-    }, [roomId]);
-
-    const handleSendMessage = useCallback(
-        async (messageText: string, attachedFiles: any[], isImportant: boolean) => {
-            if (!user) {
-                ToastMessage.error(t('not_authorized'));
-                return;
-            }
-
-            const tempId = 'temp_' + new Date().toISOString();
-
-            const messagePayload = {
-                type: 'chat_message',
-                room: roomId,
-                message: messageText,
-                files: attachedFiles,
-                is_important: isImportant,
-                tempId: tempId,
-            };
-
-            const tempMessage: IMessage = {
-                id: null,
-                tempId: tempId,
-                room: Number(roomId),
-                text: messageText,
-                user: {
-                    id: user.id,
-                    first_name: user.first_name,
-                    last_name: user.last_name,
-                    avatar: user.avatar,
-                },
-                files: attachedFiles.map((file) => {
-                    const blob = base64ToBlob(file.data, file.type);
-                    const url = URL.createObjectURL(blob);
-                    return {
-                        id: null,
-                        name: file.name,
-                        type: file.type,
-                        size: file.size,
-                        file: url,
-                    };
-                }),
-                created_at: new Date().toISOString(),
-                is_read: false,
-                is_important: isImportant,
-                status: 'sending',
-            };
-
-            setMessages((prevMessages) => [...prevMessages, tempMessage]);
-
-            if (sendMessage) {
-                sendMessage(JSON.stringify(messagePayload));
-            } else {
-                ToastMessage.error(t('websocket_not_connected'));
-            }
-        },
-        [roomId, user, base64ToBlob, sendMessage]
-    );
-
-    const handleFileChange = useCallback((_updatedFiles: File[]) => {
-        // Дополнительная логика при необходимости
-    }, []);
-
-    useLayoutEffect(() => {
-        if (!isLoadingMore && !isInitialLoad.current) {
-            messagesContainerRef.current?.scrollTo({
-                top: messagesContainerRef.current.scrollHeight,
-                behavior: 'smooth',
-            });
-        }
-    }, [messages, isLoadingMore]);
-
-    // Очищаем blob-URL при размонтировании
-    useEffect(() => {
-        return () => {
-            messages.forEach((message) => {
-                message.files.forEach((file: any) => {
-                    if (file.file.startsWith('blob:')) {
-                        URL.revokeObjectURL(file.file);
-                    }
-                });
-            });
+        const tempId = 'temp_' + new Date().toISOString();
+        const messagePayload = {
+            type: 'chat_message',
+            room: roomId,
+            message: messageText,
+            files: attachedFiles,
+            is_important: isImportant,
+            tempId,
         };
-    }, [messages]);
-
-    const renderDateLabel = useCallback((message: IMessage, previousMessage?: IMessage) => {
-        const messageDate = parseISO(message.created_at);
-        if (!previousMessage) {
-            return <DateLabel key={`date-${message.id}`} date={message.created_at}/>;
+        const tempMessage: IMessage = {
+            id: null,
+            tempId,
+            room: Number(roomId),
+            text: messageText,
+            user: {
+                id: user.id,
+                first_name: user.first_name,
+                last_name: user.last_name,
+                avatar: user.avatar,
+            },
+            files: attachedFiles.map(file => {
+                const blob = base64ToBlob(file.data, file.type);
+                const url = URL.createObjectURL(blob);
+                return {id: null, name: file.name, type: file.type, size: file.size, file: url};
+            }),
+            created_at: new Date().toISOString(),
+            is_read: false,
+            is_important: isImportant,
+            status: 'sending',
+        };
+        setMessages(prev => [...prev, tempMessage]);
+        if (sendMessage) {
+            sendMessage(JSON.stringify(messagePayload));
+        } else {
+            ToastMessage.error(t('websocket_not_connected'));
         }
+    }, [roomId, user, base64ToBlob, sendMessage]);
 
-        const previousMessageDate = parseISO(previousMessage.created_at);
-        if (messageDate.getDate() !== previousMessageDate.getDate()) {
-            return <DateLabel key={`date-${message.id}`} date={message.created_at}/>;
-        }
+    const handleFileChange = useCallback((_updatedFiles: File[]) => {}, []);
 
-        return null;
-    }, []);
-
-    const handleMarkAsRead = useCallback(
-        (message: IMessage) => {
-            if (user && user.id !== message.user.id && !message.is_read) {
-                const readPayload = {type: 'read_message', message_id: message.id};
-                if (sendMessage) {
-                    sendMessage(JSON.stringify(readPayload));
-                }
+    const handleMarkAsRead = useCallback((message: IMessage) => {
+        if (user && user.id !== message.user.id && !message.is_read) {
+            const readPayload = {type: 'read_message', message_id: message.id};
+            if (sendMessage) {
+                sendMessage(JSON.stringify(readPayload));
             }
-        },
-        [user, sendMessage]
-    );
+        }
+    }, [user, sendMessage]);
 
     const handleMarkAsReadForAll = useCallback(() => {
-        messagesRef.current.forEach((message) => handleMarkAsRead(message));
-    }, [handleMarkAsRead]);
+        messagesRef.current.forEach(m => handleMarkAsRead(m));
+    }, [handleMarkAsRead, messagesRef]);
 
     useEffect(() => {
         if (isAuthenticated && room) {
@@ -306,37 +147,13 @@ const Room: React.FC<RoomProps> = (
         }
     }, [messages, isAuthenticated, room, handleMarkAsReadForAll]);
 
-    const handleScroll = useCallback(() => {
-        if (
-            messagesContainerRef.current?.scrollTop === 0 &&
-            nextPageUrl &&
-            !isLoadingMore &&
-            !isFetchingRef.current
-        ) {
-            fetchMessages(nextPageUrl).then();
-        }
-    }, [fetchMessages, nextPageUrl, isLoadingMore]);
-
-    useEffect(() => {
-        if (room) {
-            const container = messagesContainerRef.current;
-            container?.addEventListener('scroll', handleScroll);
-            return () => {
-                container?.removeEventListener('scroll', handleScroll);
-            };
-        }
-    }, [room, handleScroll]);
-
     return (
         <FC h={'100%'} cls={'room'} maxH={`calc(100vh - ${headerNavHeight}px)`}>
-            {/* Заголовок комнаты */}
             {showHeader && <>
                 <RoomHeader room={room}/>
                 <Divider width={'90%'}/>
             </>}
-
-            {/* Контейнер сообщений */}
-            <MessagesContainer
+            <MessagesList
                 messages={messages}
                 room={room}
                 renderDateLabel={renderDateLabel}
@@ -344,8 +161,6 @@ const Room: React.FC<RoomProps> = (
                 messagesEndRef={messagesEndRef as RefObject<HTMLDivElement>}
                 messagesContainerRef={messagesContainerRef as RefObject<HTMLDivElement>}
             />
-
-            {/* Поле ввода сообщения */}
             <FC px={1} pb={1}>
                 <FC rounded={3} px={1} pt={1} pb={1}>
                     <MessageInput onSend={handleSendMessage} onFileChange={handleFileChange}/>

--- a/frontend/src/Modules/Chat/useRoomMessages.ts
+++ b/frontend/src/Modules/Chat/useRoomMessages.ts
@@ -1,0 +1,141 @@
+// Modules/Chat/useRoomMessages.ts
+
+import {useCallback, useEffect, useLayoutEffect, useRef, useState} from 'react';
+import {parseISO} from 'date-fns';
+import DateLabel from './DateLabel';
+import {IMessage} from 'types/chat/models';
+
+interface UseRoomMessagesParams {
+    roomId?: string;
+    api: any;
+}
+
+const useRoomMessages = ({roomId, api}: UseRoomMessagesParams) => {
+    const [messages, setMessages] = useState<IMessage[]>([]);
+    const messagesRef = useRef<IMessage[]>(messages);
+    const [nextPageUrl, setNextPageUrl] = useState<string | null>(null);
+    const [isLoadingMore, setIsLoadingMore] = useState<boolean>(false);
+
+    const messagesEndRef = useRef<HTMLDivElement | null>(null);
+    const messagesContainerRef = useRef<HTMLDivElement | null>(null);
+    const isInitialLoad = useRef<boolean>(true);
+    const prevScrollHeightRef = useRef<number>(0);
+    const isFetchingRef = useRef<boolean>(false);
+
+    useEffect(() => {
+        messagesRef.current = messages;
+    }, [messages]);
+
+    const fetchMessages = useCallback(async (url: string | null = null) => {
+        if (isLoadingMore || isFetchingRef.current) return;
+        if (url === null && !isInitialLoad.current) return;
+        if (!roomId) return;
+        isFetchingRef.current = true;
+        setIsLoadingMore(true);
+        if (url && messagesContainerRef.current) {
+            prevScrollHeightRef.current = messagesContainerRef.current.scrollHeight;
+        }
+        api.get(url || `/api/v1/rooms/${roomId}/messages/`).then((data: any) => {
+            setMessages(prev => {
+                const newMessages = data.results.filter((msg: IMessage) => !prev.some(e => e.id === msg.id));
+                return [...newMessages, ...prev];
+            });
+            setNextPageUrl(data.next);
+
+            if (isInitialLoad.current && !url) {
+                setTimeout(() => {
+                    messagesContainerRef.current?.scrollTo({
+                        top: messagesContainerRef.current.scrollHeight,
+                        behavior: 'auto',
+                    });
+                }, 100);
+                isInitialLoad.current = false;
+            } else if (url && messagesContainerRef.current) {
+                setTimeout(() => {
+                    if (messagesContainerRef.current) {
+                        const newScrollHeight = messagesContainerRef.current.scrollHeight;
+                        messagesContainerRef.current.scrollTop = newScrollHeight - prevScrollHeightRef.current;
+                    }
+                }, 100);
+            }
+        }).finally(() => {
+            setIsLoadingMore(false);
+            isFetchingRef.current = false;
+        });
+    }, [roomId, api, isLoadingMore]);
+
+    const handleScroll = useCallback(() => {
+        if (
+            messagesContainerRef.current?.scrollTop === 0 &&
+            nextPageUrl &&
+            !isLoadingMore &&
+            !isFetchingRef.current
+        ) {
+            fetchMessages(nextPageUrl);
+        }
+    }, [fetchMessages, nextPageUrl, isLoadingMore]);
+
+    useEffect(() => {
+        const container = messagesContainerRef.current;
+        container?.addEventListener('scroll', handleScroll);
+        return () => {
+            container?.removeEventListener('scroll', handleScroll);
+        };
+    }, [handleScroll]);
+
+    useLayoutEffect(() => {
+        if (!isLoadingMore && !isInitialLoad.current) {
+            messagesContainerRef.current?.scrollTo({
+                top: messagesContainerRef.current.scrollHeight,
+                behavior: 'smooth',
+            });
+        }
+    }, [messages, isLoadingMore]);
+
+    useEffect(() => {
+        return () => {
+            messages.forEach(message => {
+                message.files.forEach((file: any) => {
+                    if (file.file && typeof file.file === 'string' && file.file.startsWith('blob:')) {
+                        URL.revokeObjectURL(file.file);
+                    }
+                });
+            });
+        };
+    }, [messages]);
+
+    const renderDateLabel = useCallback((message: IMessage, previousMessage?: IMessage) => {
+        const messageDate = parseISO(message.created_at);
+        if (!previousMessage) {
+            return <DateLabel key={`date-${message.id}`} date={message.created_at}/>;
+        }
+        const previousMessageDate = parseISO(previousMessage.created_at);
+        if (messageDate.getDate() !== previousMessageDate.getDate()) {
+            return <DateLabel key={`date-${message.id}`} date={message.created_at}/>;
+        }
+        return null;
+    }, []);
+
+    const reset = useCallback(() => {
+        setMessages([]);
+        setNextPageUrl(null);
+        isInitialLoad.current = true;
+        if (messagesContainerRef.current) {
+            messagesContainerRef.current.scrollTop = 0;
+        }
+    }, []);
+
+    return {
+        messages,
+        setMessages,
+        messagesEndRef,
+        messagesContainerRef,
+        isLoadingMore,
+        renderDateLabel,
+        fetchMessages,
+        reset,
+        messagesRef,
+    };
+};
+
+export default useRoomMessages;

--- a/frontend/src/Modules/Chat/useRoomSocket.ts
+++ b/frontend/src/Modules/Chat/useRoomSocket.ts
@@ -1,0 +1,53 @@
+// Modules/Chat/useRoomSocket.ts
+
+import {useCallback} from 'react';
+import {IMessage} from 'types/chat/models';
+import {useRooms} from './RoomsContext';
+import useWebSocket from './useWebSocket';
+
+interface UseRoomSocketProps {
+    roomId: string;
+    isAuthenticated: boolean;
+    userId: number | null;
+    setMessages: React.Dispatch<React.SetStateAction<IMessage[]>>;
+}
+
+const useRoomSocket = ({roomId, isAuthenticated, userId, setMessages}: UseRoomSocketProps) => {
+    const {updateRoom} = useRooms();
+
+    const handleWebSocketMessage = useCallback((data: any) => {
+        if (data.action === 'confirm_message_saved') {
+            setMessages(prevMessages => {
+                const index = prevMessages.findIndex(msg => msg.id === data.tempId || msg.tempId === data.tempId);
+                if (index !== -1) {
+                    const newMessages = [...prevMessages];
+                    newMessages[index] = {...data, status: 'sent'};
+                    return newMessages;
+                }
+                return [...prevMessages, data];
+            });
+            if (data.room) {
+                updateRoom(data.room);
+            }
+        } else if (data.action === 'read_message') {
+            setMessages(prevMessages => {
+                const index = prevMessages.findIndex(msg => msg.id === data.id);
+                if (index !== -1) {
+                    const newMessages = [...prevMessages];
+                    newMessages[index] = {...newMessages[index], is_read: true};
+                    return newMessages;
+                }
+                return prevMessages;
+            });
+            if (data.room) {
+                updateRoom(data.room);
+            }
+        }
+    }, [setMessages, updateRoom]);
+
+    const sendMessage = useWebSocket({roomId, isAuthenticated, userId, onMessage: handleWebSocketMessage});
+
+    return sendMessage;
+};
+
+export default useRoomSocket;


### PR DESCRIPTION
## Summary
- create `useRoomMessages` to load and scroll messages
- create `useRoomSocket` for WebSocket logic
- rename `MessagesContainer` -> `MessagesList`
- simplify `Room` to compose hooks and components

## Testing
- `npm test` *(fails: `craco` not found due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_686e2df0d2148330b1792ef1607ea6a1