### PR TITLE
Add shared OAuth mixin

### DIFF
--- a/backend/apps/social_oauth/oauth_provider.py
+++ b/backend/apps/social_oauth/oauth_provider.py
@@ -4,10 +4,71 @@ import logging
 from abc import ABC, abstractmethod
 from typing import Any
 
+from adjango.utils.funcs import set_image_by_url
+
 from apps.core.models import User
 from apps.core.services.auth import JWTPair
 
 log = logging.getLogger('social_auth')
+
+
+class OAuthProviderMixin:
+    """Mixin containing helper methods for OAuth providers."""
+
+    async def _set_avatar_from_url(self, user: User, url: str | None) -> None:
+        """Download and attach user avatar from URL if available."""
+        if not url:
+            return
+        try:
+            await set_image_by_url(user, 'avatar', url)
+        except Exception as exc:  # pragma: no cover - logging only
+            log.warning(f'Failed to set avatar for user {user.id} from {url}: {exc}')
+
+    async def _get_or_create_user_base(
+        self,
+        provider_model: type,
+        provider_id_field: str,
+        provider_id: str,
+        *,
+        email: str | None = '',
+        username: str = '',
+        first_name: str = '',
+        last_name: str = '',
+        avatar_url: str | None = None,
+    ) -> User:
+        """Shared logic of retrieving or creating a user for OAuth providers."""
+
+        try:
+            provider_user = await provider_model.objects.select_related('user').aget(**{provider_id_field: provider_id})
+            return provider_user.user
+        except provider_model.DoesNotExist:
+            user = None
+            if email:
+                try:
+                    user = await User.objects.aget(email=email)
+                except User.DoesNotExist:
+                    user = None
+
+            if not user:
+                if not username:
+                    username = email.split('@')[0] if email else f'{provider_id_field}_{provider_id}'
+                user = await User.objects.acreate(
+                    email=email or '',
+                    username=username,
+                    first_name=first_name,
+                    last_name=last_name,
+                    is_email_confirmed=bool(email),
+                )
+                await self._set_avatar_from_url(user, avatar_url)
+            elif email and not user.is_email_confirmed:
+                user.is_email_confirmed = True
+                await user.asave()
+
+            kwargs = {'user': user, provider_id_field: provider_id}
+            if hasattr(provider_model, 'email'):
+                kwargs['email'] = email or ''
+            await provider_model.objects.acreate(**kwargs)
+            return user
 
 
 class OAuthProvider(ABC):


### PR DESCRIPTION
## Summary
- centralize helper logic in `OAuthProviderMixin`
- refactor Discord, Google, VK and Yandex providers to use the mixin
- remove placeholder TODO comments about avatar fetching

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for Django)*

------
https://chatgpt.com/codex/tasks/task_e_686e2de4b2788330b21a9755af3af318