### PR TITLE
Use by_creds for user lookups

### DIFF
--- a/backend/apps/core/controllers/auth/common.py
+++ b/backend/apps/core/controllers/auth/common.py
@@ -50,12 +50,10 @@ async def signup(request) -> Response:
 
         if phone: phone = phone_format(phone)
 
-        if email is not None and await User.objects.filter(
-                email=email
-        ).aexists(): raise UserException.AlreadyExistsWithThisEmail()
-        if phone is not None and await User.objects.filter(
-                phone=phone
-        ).aexists(): raise UserException.AlreadyExistsWithThisPhone()
+        if email is not None and await User.objects.by_creds(email):
+            raise UserException.AlreadyExistsWithThisEmail()
+        if phone is not None and await User.objects.by_creds(phone):
+            raise UserException.AlreadyExistsWithThisPhone()
 
         if email:
             username = f'{email.split('@')[0]}{randint(1000, 9999)}'

--- a/backend/apps/core/controllers/user/base.py
+++ b/backend/apps/core/controllers/user/base.py
@@ -114,8 +114,8 @@ async def check_email_exists(request):
     email = request.data.get('email')
     if not is_email(email):
         raise UserException.WrongCredential()
-    exists = await User.objects.filter(email=email).aexists()
-    return Response({'exists': exists}, status=200)
+    exists = await User.objects.by_creds(email)
+    return Response({'exists': bool(exists)}, status=200)
 
 
 @acontroller('Check if phone exists')
@@ -124,5 +124,5 @@ async def check_email_exists(request):
 async def check_phone_exists(request):
     phone = request.data.get('phone')
     if not is_phone(phone): raise UserException.WrongCredential()
-    exists = await User.objects.filter(phone=phone).aexists()
-    return Response({'exists': exists}, status=200)
+    exists = await User.objects.by_creds(phone)
+    return Response({'exists': bool(exists)}, status=200)

--- a/backend/apps/filehost/controllers/accesses.py
+++ b/backend/apps/filehost/controllers/accesses.py
@@ -28,9 +28,8 @@ async def grant_access(request):
 
     user = None
     if email:
-        try:
-            user = await User.objects.aget(email=email)
-        except User.DoesNotExist:
+        user = await User.objects.by_creds(email)
+        if not user:
             raise UserException.UserWithThisEmailNotFound()
 
     access = await Access.objects.acreate(

--- a/backend/apps/social_oauth/oauth_provider.py
+++ b/backend/apps/social_oauth/oauth_provider.py
@@ -44,10 +44,7 @@ class OAuthProviderMixin:
         except provider_model.DoesNotExist:
             user = None
             if email:
-                try:
-                    user = await User.objects.aget(email=email)
-                except User.DoesNotExist:
-                    user = None
+                user = await User.objects.by_creds(email)
 
             if not user:
                 if not username:

--- a/backend/apps/surveys/controllers/accesses.py
+++ b/backend/apps/surveys/controllers/accesses.py
@@ -53,9 +53,8 @@ async def survey_access_create(request) -> Response:
     if await survey.arelated('author') != request.user:
         raise CurrentUserNotSurveyAuthor()
 
-    try:
-        user = await User.objects.aget(email=email)
-    except User.DoesNotExist:
+    user = await User.objects.by_creds(email)
+    if not user:
         username = email.split('@')[0]
         password = get_random_string(length=12)
         user = User.objects.create_user(

--- a/backend/apps/xlmine/controllers/yggdrasil.py
+++ b/backend/apps/xlmine/controllers/yggdrasil.py
@@ -62,12 +62,8 @@ async def authenticate_view(request):
     client_token = data.get('clientToken', str(uuid.uuid4()))
 
     # Ищем пользователя:
-    try:
-        if '@' in username_or_email:
-            user = await User.objects.aget(email=username_or_email)
-        else:
-            user = await User.objects.aget(username=username_or_email)
-    except User.DoesNotExist:
+    user = await User.objects.by_creds(username_or_email)
+    if not user:
         return Response({'error': 'Нет пользователя с таким credential'}, status=status.HTTP_403_FORBIDDEN)
 
     # Проверяем пароль (либо делаем свою custom-логику)
@@ -261,12 +257,8 @@ async def signout_view(request):
     password = data.get('password')
 
     # Ищем пользователя
-    try:
-        if '@' in username_or_email:
-            user = await User.objects.aget(email=username_or_email)
-        else:
-            user = await User.objects.aget(username=username_or_email)
-    except User.DoesNotExist:
+    user = await User.objects.by_creds(username_or_email)
+    if not user:
         return Response({'error': 'Forbidden'}, status=status.HTTP_403_FORBIDDEN)
 
     if not user.check_password(password):
@@ -358,9 +350,8 @@ async def has_joined_view(request):
     server_id = request.GET.get('serverId')
 
     # Ищем user по имени
-    try:
-        user = await User.objects.aget(username=username)
-    except User.DoesNotExist:
+    user = await User.objects.by_creds(username)
+    if not user:
         return Response(status=status.HTTP_204_NO_CONTENT)  # user not found => пусто
 
     # Ищем сессию, где last_server_id = server_id


### PR DESCRIPTION
## Summary
- call `User.objects.by_creds` instead of filtering by email/phone/username
- apply this in file host, social oauth, survey access and xlmine controllers
- use `by_creds` to validate uniqueness in sign up flow
- rework email/phone existence check to use `by_creds`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686e409b75348330a1edd38deed95363