### PR TITLE
Refactor settings modules

### DIFF
--- a/backend/config/modules/cache.py
+++ b/backend/config/modules/cache.py
@@ -1,13 +1,5 @@
-from os import environ
-from os.path import join
-
-from dotenv import load_dotenv
-
-from config.base import BASE_DIR
+from config.base import env
 from config.modules.redis import REDIS_CACHE_URL
-
-env = environ.get
-load_dotenv(dotenv_path=join(BASE_DIR.parent, '.env'))
 
 # Cache
 CACHALOT_ENABLED = bool(int(env('CACHALOT_ENABLED')))

--- a/backend/config/modules/email.py
+++ b/backend/config/modules/email.py
@@ -1,12 +1,4 @@
-from os import environ
-from os.path import join
-
-from dotenv import load_dotenv
-
-from config.base import BASE_DIR
-
-env = environ.get
-load_dotenv(dotenv_path=join(BASE_DIR.parent, '.env'))
+from config.base import env
 
 EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
 EMAIL_HOST = 'smtp.timeweb.ru'

--- a/backend/config/modules/redis.py
+++ b/backend/config/modules/redis.py
@@ -1,13 +1,5 @@
 # Redis
-from os import environ
-from os.path import join
-
-from dotenv import load_dotenv
-
-from config.base import BASE_DIR
-
-env = environ.get
-load_dotenv(dotenv_path=join(BASE_DIR.parent, '.env'))
+from config.base import env
 
 REDIS_HOST = env('REDIS_HOST')
 REDIS_PORT = int(env('REDIS_PORT'))
@@ -17,5 +9,4 @@ REDISUI_URL_PREFIX = 'redis/'
 REDISUI_CONTROLLERS_SETTINGS = {
     'auth_required': True,
     'log_name': False,
-    'not_auth_redirect': f'/admin/login/?next=/{REDISUI_URL_PREFIX}'
-}
+    'not_auth_redirect': f'/admin/login/?next=/{REDISUI_URL_PREFIX}'}

--- a/backend/config/modules/storage.py
+++ b/backend/config/modules/storage.py
@@ -1,13 +1,9 @@
 from datetime import timedelta
-from os import environ, makedirs
+from os import makedirs
 from os.path import join
 
-from dotenv import load_dotenv
+from config.base import BASE_DIR, FRONTEND_DIR, MAIN_DOMAIN, env
 
-from config.base import BASE_DIR, FRONTEND_DIR, MAIN_DOMAIN
-
-env = environ.get
-load_dotenv(dotenv_path=join(BASE_DIR.parent, '.env'))
 MINIO_USE = bool(int(env('MINIO_USE')))
 
 # Internationalization defaults
@@ -24,7 +20,6 @@ FILE_UPLOAD_TEMP_DIR = join(BASE_DIR.parent, 'data', 'temp')
 makedirs(FILE_UPLOAD_TEMP_DIR, exist_ok=True)
 
 # Static | Media
-env = environ.get
 STATICFILES_DIRS = (
     join(FRONTEND_DIR, 'build', 'static'),
     join(BASE_DIR, 'static')

--- a/backend/config/modules/third_party_services.py
+++ b/backend/config/modules/third_party_services.py
@@ -1,12 +1,4 @@
-from os import environ
-from os.path import join
-
-from dotenv import load_dotenv
-
-from config.base import BASE_DIR, DOMAIN_URL
-
-env = environ.get
-load_dotenv(dotenv_path=join(BASE_DIR.parent, '.env'))
+from config.base import DOMAIN_URL, env
 
 # Google
 GOOGLE_CLIENT_ID = env('GOOGLE_CLIENT_ID')

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -1,12 +1,5 @@
-import logging
-from datetime import timedelta
-from os import environ, makedirs
-from os.path import join, exists
-from pathlib import Path
-
 from adjango.utils.common import is_celery
 from django.utils.translation import gettext_lazy as _
-from dotenv import load_dotenv
 
 from config.base import *
 from config.modules.adjango import *
@@ -25,8 +18,6 @@ from config.modules.third_party_services import *
 from config.modules.xl_dashboard import *
 from utils.handle_exceptions import handling_function
 
-env = environ.get
-load_dotenv(dotenv_path=join(BASE_DIR.parent, '.env'))
 
 AUTH_USER_MODEL = 'core.User'
 INSTALLED_APPS = [


### PR DESCRIPTION
## Summary
- remove unused imports in main settings
- load environment variables only from `config.base`
- drop repeated env initialization in individual settings modules

## Testing
- `python -m py_compile backend/config/settings.py backend/config/modules/email.py backend/config/modules/cache.py backend/config/modules/redis.py backend/config/modules/storage.py backend/config/modules/third_party_services.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686e40c05318833095d5437766fe2f7e