### PR TITLE
Improve visit tracking and analytics

### DIFF
--- a/backend/apps/analytics/controllers/graphics.py
+++ b/backend/apps/analytics/controllers/graphics.py
@@ -29,7 +29,7 @@ def visits_chart(request):
             return HttpResponseBadRequest(_('Invalid start_date'))
         return HttpResponseBadRequest(_('Invalid end_date'))
 
-    qs = Visit.objects.filter(**filters).annotate(period=trunc_func).values('period').annotate(
+    qs = Visit.objects.exclude(user_id=1).filter(**filters).annotate(period=trunc_func).values('period').annotate(
         unique_ips=Count('ip_address', distinct=True)
     ).order_by('period')
 
@@ -60,7 +60,7 @@ def orders_chart(request):
             return HttpResponseBadRequest(_('Invalid start_date'))
         return HttpResponseBadRequest(_('Invalid end_date'))
 
-    qs = Order.objects.filter(**filters).annotate(period=trunc_func).values('period').annotate(
+    qs = Order.objects.exclude(user_id=1).filter(**filters).annotate(period=trunc_func).values('period').annotate(
         total=Count('id'),
         executed=Count('id', filter=Q(is_executed=True)),
         cancelled=Count('id', filter=Q(is_cancelled=True))

--- a/backend/apps/analytics/tests/test_middleware.py
+++ b/backend/apps/analytics/tests/test_middleware.py
@@ -7,7 +7,9 @@ from apps.analytics.middleware import VisitLoggingMiddleware
 
 @pytest.mark.django_db
 def test_get_client_ip_forwarded():
-    request = RequestFactory().get('/some-path', HTTP_X_FORWARDED_FOR='1.2.3.4')
+    request = RequestFactory().get(
+        '/some-path', HTTP_X_FORWARDED_FOR='10.0.0.2, 1.2.3.4'
+    )
     middleware = VisitLoggingMiddleware(lambda r: r)
     assert middleware.get_client_ip(request) == '1.2.3.4'
 
@@ -17,3 +19,10 @@ def test_get_client_ip_remote_addr():
     request = RequestFactory().get('/some-path', REMOTE_ADDR='5.6.7.8')
     middleware = VisitLoggingMiddleware(lambda r: r)
     assert middleware.get_client_ip(request) == '5.6.7.8'
+
+
+@pytest.mark.django_db
+def test_get_client_ip_private_remote():
+    request = RequestFactory().get('/some-path', REMOTE_ADDR='10.0.0.2')
+    middleware = VisitLoggingMiddleware(lambda r: r)
+    assert middleware.get_client_ip(request) is None


### PR DESCRIPTION
## Summary
- ignore private network addresses when logging visits
- exclude the staff user from visits and orders statistics
- update middleware tests for new IP filtering behaviour

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686e4253315c8330bc8727bf6b6e6d38