### PR TITLE
Refactor user lookups to use by_creds helpers

### DIFF
--- a/backend/apps/commerce/controllers/order.py
+++ b/backend/apps/commerce/controllers/order.py
@@ -52,9 +52,8 @@ async def create_order(request):
         # Так как не сохраняли при регистрации, а чек куда-то выслать нужно
         email = s.validated_data.get('email')
         if not email: raise UserException.EmailWasNotProvided()
-        if email and await User.objects.filter(
-                email=email
-        ).aexists(): raise UserException.AlreadyExistsWithThisEmail()
+        if email and await User.objects.aby_creds(email):
+            raise UserException.AlreadyExistsWithThisEmail()
         request.user.email = email
         await request.user.asave()
 

--- a/backend/apps/core/auth/obtain_tokens.py
+++ b/backend/apps/core/auth/obtain_tokens.py
@@ -20,17 +20,8 @@ class CustomTokenObtainPairSerializer(TokenObtainPairSerializer):
         username_or_email = attrs.get('username', None)
         password = attrs.get('password')
 
-        if '@' in username_or_email:
-            try:
-                user = User.objects.get(email=username_or_email)
-            except User.DoesNotExist:
-                try:
-                    user = User.objects.get(username=username_or_email)
-                except User.DoesNotExist:
-                    pass
-            username = user.username
-        else:
-            username = username_or_email
+        user = User.objects.by_creds(username_or_email)
+        username = user.username if user else username_or_email
 
         if username:
             user = authenticate(username=username, password=password)

--- a/backend/apps/core/confirmations/funcs.py
+++ b/backend/apps/core/confirmations/funcs.py
@@ -46,8 +46,8 @@ async def confirm_email_action(code: 'ConfirmationCode'):
 async def confirm_phone_action(code: 'ConfirmationCode', new_phone: str):
     """Confirm phone number and update it if necessary."""
     # Ensure the phone number does not belong to another user
-    exists = await User.objects.filter(phone=new_phone).exclude(pk=code.user.pk).aexists()
-    if exists:
+    user = await User.objects.aby_creds(new_phone)
+    if user and user.pk != code.user.pk:
         raise UserException.AlreadyExistsWithThisPhone()
 
     # Update phone if it differs from the current one

--- a/backend/apps/core/controllers/user/base.py
+++ b/backend/apps/core/controllers/user/base.py
@@ -41,7 +41,7 @@ async def rename_current_user(request) -> Response:
     data = await serializer.adata
     username = data.get('username')
     if username == request.user.username: raise UserException.AlreadyThisUsername()
-    if await User.objects.filter(username=username).aexists():
+    if await User.objects.aby_creds(username):
         raise UserException.UsernameAlreadyExists()
     request.user.username = username
     await request.user.asave()


### PR DESCRIPTION
## Summary
- replace manual email and username checks with `by_creds`/`aby_creds`
- simplify confirmation phone check
- streamline login validation in token serializer

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686e43b534348330b3bbbc9f35905b13