### PR TITLE
Implement CircularProgressZoomify

### DIFF
--- a/frontend/src/Modules/Core/components/elements/CircularProgressZoomify.tsx
+++ b/frontend/src/Modules/Core/components/elements/CircularProgressZoomify.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import Zoom from '@mui/material/Zoom';
+import {FRCC} from 'wide-containers';
+import CircularProgress from './CircularProgress';
+
+interface CircularProgressZoomifyProps {
+    in: boolean;
+    size?: number | string;
+}
+
+const CircularProgressZoomify: React.FC<CircularProgressZoomifyProps> = ({in: inProp, size = '90px'}) => (
+    <Zoom
+        in={inProp}
+        appear
+        mountOnEnter
+        unmountOnExit
+        timeout={{enter: 300, exit: 300}}
+    >
+        <FRCC
+            mt={5}
+            w="100%"
+            position="absolute"
+            top={0}
+            left={0}
+            right={0}
+            zIndex={1}
+        >
+            <CircularProgress size={size}/>
+        </FRCC>
+    </Zoom>
+);
+
+export default CircularProgressZoomify;

--- a/frontend/src/Modules/Order/UserOrders.tsx
+++ b/frontend/src/Modules/Order/UserOrders.tsx
@@ -6,10 +6,9 @@ import {AuthContext, AuthContextType} from 'Auth/AuthContext';
 import {IOrder} from 'types/commerce/shop';
 import OrderItem from 'Order/OrderItem';
 import {FC as FCC, FCCC, FR} from 'wide-containers';
-import CircularProgress from 'Core/components/elements/CircularProgress';
+import CircularProgressZoomify from 'Core/components/elements/CircularProgressZoomify';
 import {useApi} from 'Api/useApi';
 import Collapse from '@mui/material/Collapse';
-import Zoom from '@mui/material/Zoom'; // остаётся Zoom
 
 const UserOrders: React.FC = () => {
     const {user, isAuthenticated} = useContext(AuthContext) as AuthContextType;
@@ -51,25 +50,7 @@ const UserOrders: React.FC = () => {
     return (
         <FR wrap w="100%" g={1.2} py={1} px={2} position="relative" cls={'user-orders'}>
             {/* ---------------- Лоадер ---------------- */}
-            <Zoom
-                in={loading}
-                appear
-                mountOnEnter
-                unmountOnExit
-                timeout={{enter: 300, exit: 300}}
-            >
-                <FCCC
-                    w="100%"
-                    mt={5}
-                    position="absolute"
-                    top={0}
-                    left={0}
-                    right={0}
-                    zIndex={1}
-                >
-                    <CircularProgress size="90px"/>
-                </FCCC>
-            </Zoom>
+            <CircularProgressZoomify in={loading} size="90px"/>
 
             {/* ---------------- Список заказов ---------------- */}
             {orders.length > 0 &&

--- a/frontend/src/Modules/Software/Licenses.tsx
+++ b/frontend/src/Modules/Software/Licenses.tsx
@@ -1,12 +1,11 @@
 import React, {useEffect, useState} from 'react';
 import {useTranslation} from 'react-i18next';
 import {useApi} from '../Api/useApi';
-import CircularProgress from 'Core/components/elements/CircularProgress';
+import CircularProgressZoomify from 'Core/components/elements/CircularProgressZoomify';
 import {FCC, FCCC, FR} from 'wide-containers';
 import LicenseCard from './LicenseCard';
 import {Message} from 'Core/components/Message';
 import Collapse from '@mui/material/Collapse';
-import Zoom from '@mui/material/Zoom'; // ← NEW
 
 const Licenses: React.FC = () => {
     const {api} = useApi();
@@ -34,25 +33,7 @@ const Licenses: React.FC = () => {
     return (
         <FR wrap g={2} p={2} position="relative" cls="licenses">
             {/* ---------------- Лоадер ---------------- */}
-            <Zoom
-                in={loading}
-                appear
-                mountOnEnter
-                unmountOnExit
-                timeout={{enter: 300, exit: 300}}
-            >
-                <FCCC
-                    w="100%"
-                    mt={5}
-                    position="absolute"
-                    top={0}
-                    left={0}
-                    right={0}
-                    zIndex={1}
-                >
-                    <CircularProgress size="90px"/>
-                </FCCC>
-            </Zoom>
+            <CircularProgressZoomify in={loading} size="90px"/>
 
             {/* ---------------- Список лицензий ---------------- */}
             {licenses.length > 0 &&

--- a/frontend/src/Modules/Software/Softwares.tsx
+++ b/frontend/src/Modules/Software/Softwares.tsx
@@ -1,6 +1,6 @@
 import React, {useEffect, useState} from 'react';
 import {useNavigate} from 'react-router-dom';
-import CircularProgress from 'Core/components/elements/CircularProgress';
+import CircularProgressZoomify from 'Core/components/elements/CircularProgressZoomify';
 import {FRCC} from 'wide-containers';
 import {useTheme} from 'Theme/ThemeContext';
 import {ISoftware} from './Types/Software';
@@ -8,7 +8,6 @@ import {useApi} from 'Api/useApi';
 import SoftwareCard from './SoftwareCard';
 import {useTranslation} from 'react-i18next';
 import Collapse from '@mui/material/Collapse';
-import Zoom from '@mui/material/Zoom'; // ← NEW
 
 const Softwares: React.FC = () => {
     const [softwares, setSoftwares] = useState<ISoftware[]>([]);
@@ -39,25 +38,7 @@ const Softwares: React.FC = () => {
     return (
         <FRCC g={2} wrap position="relative" w="100%">
             {/* ---------------- Лоадер ---------------- */}
-            <Zoom
-                in={loading}
-                appear
-                mountOnEnter
-                unmountOnExit
-                timeout={{enter: 300, exit: 300}}
-            >
-                <FRCC
-                    mt={5}
-                    w="100%"
-                    position="absolute"
-                    top={0}
-                    left={0}
-                    right={0}
-                    zIndex={1}
-                >
-                    <CircularProgress size="90px"/>
-                </FRCC>
-            </Zoom>
+            <CircularProgressZoomify in={loading} size="90px"/>
 
             {/* ---------------- Список ПО ---------------- */}
             {softwares.length > 0 &&


### PR DESCRIPTION
## Summary
- add a reusable `CircularProgressZoomify` component for loaders
- use it in Softwares, Licenses and Orders modules

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*
- `npm test --silent` *(fails: craco: not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e5d2ded94833090c79a0d3613988b