### PR TITLE
Replace CircularProgress with CircularProgressZoomify

### DIFF
--- a/frontend/src/Modules/Auth/Social/OAuthCallback.tsx
+++ b/frontend/src/Modules/Auth/Social/OAuthCallback.tsx
@@ -3,7 +3,7 @@ import {OAUTH_PROVIDERS} from 'Auth/Social/constants';
 import {useParams} from 'react-router-dom';
 import React, {useContext, useEffect} from "react";
 import {AuthContext, AuthContextType} from "Auth/AuthContext";
-import {CircularProgress} from "@mui/material";
+import CircularProgressZoomify from 'Core/components/elements/CircularProgressZoomify';
 import pprint from 'Utils/pprint';
 
 const OAuthCallback: React.FC = () => {
@@ -45,7 +45,7 @@ const OAuthCallback: React.FC = () => {
 
     return (
         <div className="h-70 frcc">
-            <CircularProgress size={'180px'}/>
+            <CircularProgressZoomify in size={'180px'}/>
         </div>
     );
 };

--- a/frontend/src/Modules/Auth/forms/SignUpForm.tsx
+++ b/frontend/src/Modules/Auth/forms/SignUpForm.tsx
@@ -9,7 +9,7 @@ import {SmartCaptcha} from '@yandex/smart-captcha';
 import {Button} from '@mui/material';
 import {isEmail, isPhone} from 'Utils/validator/base';
 import {FC, FCCC} from 'wide-containers';
-import CircularProgress from 'Core/components/elements/CircularProgress';
+import CircularProgressZoomify from 'Core/components/elements/CircularProgressZoomify';
 import TermsCheckboxes from "Core/components/TermsCheckboxes";
 import {useTheme} from "Theme/ThemeContext";
 import {debounce} from 'lodash';
@@ -219,7 +219,7 @@ const SignUpForm: React.FC<SignUpFormProps> = (
                     {!confirmationSent && (
                         <FC pos={'relative'} cls={'mb-2'}>
                             <FCCC w={'100%'} h={'100%'} pos={'absolute'} top={0} left={0}>
-                                <CircularProgress size={'3rem'}/>
+                                <CircularProgressZoomify in size={'3rem'}/>
                             </FCCC>
                             <FC sx={{
                                 transformOrigin: '0 0', width: '100%',

--- a/frontend/src/Modules/Cabinet/Cabinet.tsx
+++ b/frontend/src/Modules/Cabinet/Cabinet.tsx
@@ -23,7 +23,7 @@ import Logo from "Core/Logo";
 import OrderDetail from "Order/OrderDetail";
 import Licenses from "../Software/Licenses";
 import EarbudsRoundedIcon from '@mui/icons-material/EarbudsRounded';
-import CircularProgress from "Core/components/elements/CircularProgress";
+import CircularProgressZoomify from "Core/components/elements/CircularProgressZoomify";
 import {useErrorProcessing} from "Core/components/ErrorProvider";
 import DeveloperBoardRoundedIcon from '@mui/icons-material/DeveloperBoardRounded';
 import MinecraftVersionsManager from "../xLMine/MinecraftVersionsManager";
@@ -134,7 +134,7 @@ const Cabinet: React.FC = () => {
     }, [isAuthenticated]);
 
     if (isAuthenticated === null) return <FCCC h={'80%'}>
-        <CircularProgress size={'100px'}/>
+        <CircularProgressZoomify in size={'100px'}/>
     </FCCC>;
     if (!isAuthenticated) return <FCCC h={'80%'}>
         <span>{t('need_login')}</span>

--- a/frontend/src/Modules/Chat/Chat.tsx
+++ b/frontend/src/Modules/Chat/Chat.tsx
@@ -8,7 +8,7 @@ import {useErrorProcessing} from 'Core/components/ErrorProvider';
 import {AuthContext, AuthContextType} from 'Auth/AuthContext';
 import {useRooms} from './RoomsContext';
 import {IRoom} from "types/chat/models";
-import CircularProgress from "Core/components/elements/CircularProgress";
+import CircularProgressZoomify from "Core/components/elements/CircularProgressZoomify";
 import {FC, FCSC} from "wide-containers";
 import {useNavigation} from "Core/components/Header/HeaderProvider";
 
@@ -72,7 +72,7 @@ const Chat: React.FC = () => {
     return (
         <div className={`chat h-100 w-100 ${isMdOrLarger ? 'fr' : 'fc'}`}>
             {initialLoading
-                ? <CircularProgress size={'120px'}/>
+                ? <CircularProgressZoomify in size={'120px'}/>
                 : (isMdOrLarger || !isRoomView) && showRooms
                     ? <FC cls={'rooms'} g={1} minW={350} p={2} maxH={`calc(100vh - ${headerNavHeight}px)`}
                           scroll={'y-auto'} onScroll={handleScroll}>
@@ -95,5 +95,4 @@ const Chat: React.FC = () => {
         </div>
     );
 };
-
 export default Chat;

--- a/frontend/src/Modules/Chat/MessagesList.tsx
+++ b/frontend/src/Modules/Chat/MessagesList.tsx
@@ -1,7 +1,7 @@
 // Modules/Chat/MessagesList.tsx
 
 import React, {useContext} from 'react';
-import {CircularProgress} from '@mui/material';
+import CircularProgressZoomify from 'Core/components/elements/CircularProgressZoomify';
 import {FC, FCCC, FCE} from "wide-containers";
 import RoomMessage from "Chat/RoomMessage";
 import {IMessage, IRoom} from "types/chat/models";
@@ -55,7 +55,7 @@ const MessagesList: React.FC<MessagesListProps> = (
                     boxShadow={plt.shadows ? plt.shadows.SO005 : ''}
                     style={{display: 'flex', flexDirection: 'column'}}
                 >
-                    {isLoadingMore && <CircularProgress/>}
+                    {isLoadingMore && <CircularProgressZoomify in/>}
                     {messages.length > 0
                         ? messages.map((message, index) => (
                             <React.Fragment key={message.id || index}>
@@ -73,7 +73,7 @@ const MessagesList: React.FC<MessagesListProps> = (
                     <div ref={messagesEndRef}></div>
                 </FCE>
             ) : (
-                <CircularProgress/>
+                <CircularProgressZoomify in/>
             )}
         </FC>
     );

--- a/frontend/src/Modules/Chat/RoomHeader.tsx
+++ b/frontend/src/Modules/Chat/RoomHeader.tsx
@@ -1,7 +1,8 @@
 // Modules/Chat/RoomHeader.tsx
 
 import React, {useContext, useMemo} from 'react';
-import {CircularProgress, IconButton, useMediaQuery} from '@mui/material';
+import {IconButton, useMediaQuery} from '@mui/material';
+import CircularProgressZoomify from 'Core/components/elements/CircularProgressZoomify';
 import ArrowBackIosNewRoundedIcon from '@mui/icons-material/ArrowBackIosNewRounded';
 import UserAvatar from "User/UserAvatar";
 import {Link, useNavigate} from 'react-router-dom';
@@ -68,14 +69,14 @@ const RoomHeader: React.FC<RoomHeaderProps> = ({room}) => {
                 </Link>
                 : room ?
                     ''
-                    : <CircularProgress/>
+                    : <CircularProgressZoomify in/>
             }
             <Link className={'tdn'} style={{
                 color: plt.text.primary
             }} to={room && roomName === t('favorites')
                 ? '/profile' : profileLink}>
                 <h4 className={'m-0 ps-1'}>
-                    {room ? roomName : <CircularProgress/>}
+                    {room ? roomName : <CircularProgressZoomify in/>}
                 </h4>
             </Link>
         </FRSC>

--- a/frontend/src/Modules/Company/CompanyDocumentDetail.tsx
+++ b/frontend/src/Modules/Company/CompanyDocumentDetail.tsx
@@ -3,7 +3,7 @@ import React, {useEffect, useState} from 'react';
 import {useTranslation} from 'react-i18next';
 import {useParams} from 'react-router-dom';
 import {Message} from 'Core/components/Message';
-import CircularProgress from 'Core/components/elements/CircularProgress';
+import CircularProgressZoomify from 'Core/components/elements/CircularProgressZoomify';
 import ReactMarkdown from 'react-markdown';
 import {Link, Typography} from '@mui/material';
 import {FC} from "wide-containers";
@@ -30,7 +30,7 @@ const CompanyDocumentDetail: React.FC = () => {
         }
     }, [id]);
 
-    if (loading) return <CircularProgress size="60px"/>;
+    if (loading) return <CircularProgressZoomify in size="60px"/>;
 
     if (!document) return <Typography variant="body1">Документ не найден.</Typography>;
 

--- a/frontend/src/Modules/Company/CompanyPage.tsx
+++ b/frontend/src/Modules/Company/CompanyPage.tsx
@@ -3,7 +3,7 @@ import React, {useEffect, useState} from 'react';
 import {useTranslation} from 'react-i18next';
 import {useNavigate, useParams} from 'react-router-dom';
 import {Message} from 'Core/components/Message';
-import CircularProgress from 'Core/components/elements/CircularProgress';
+import CircularProgressZoomify from 'Core/components/elements/CircularProgressZoomify';
 import {FC, FCSS, FR} from "wide-containers";
 import {Company} from "Company/Types";
 import {useTheme} from "Theme/ThemeContext";
@@ -35,7 +35,7 @@ const CompanyPage: React.FC = () => {
     }, [name, api]);
 
     if (loading) {
-        return <CircularProgress size="60px"/>;
+        return <CircularProgressZoomify in size="60px"/>;
     }
 
     if (!company) {

--- a/frontend/src/Modules/Confirmation/ConfirmationCode.tsx
+++ b/frontend/src/Modules/Confirmation/ConfirmationCode.tsx
@@ -9,7 +9,7 @@ import DynamicForm from 'Core/components/elements/DynamicForm';
 import {SmartCaptcha} from '@yandex/smart-captcha';
 import {useTheme} from 'Theme/ThemeContext';
 import {FC, FCCC} from 'wide-containers';
-import CircularProgress from 'Core/components/elements/CircularProgress';
+import CircularProgressZoomify from 'Core/components/elements/CircularProgressZoomify';
 import {isEmail, isPhone} from 'Utils/validator/base';
 import pprint from 'Utils/pprint';
 import {useApi} from "../Api/useApi";
@@ -169,7 +169,7 @@ const ConfirmationCode: React.FC<ConfirmationCodeProps> = (
                     {!initialCodeSent && !disableCaptcha && (
                         <>
                             <FCCC w="100%" h="100%" pos="absolute" top={0} left={0}>
-                                <CircularProgress size="3rem"/>
+                                <CircularProgressZoomify in size="3rem"/>
                             </FCCC>
                             <SmartCaptcha
                                 sitekey={YANDEX_RECAPTCHA_SITE_KEY}

--- a/frontend/src/Modules/Core/SettingsTool.tsx
+++ b/frontend/src/Modules/Core/SettingsTool.tsx
@@ -9,7 +9,7 @@ import pprint from "Utils/pprint";
 import {AuthContext, AuthContextType} from 'Auth/AuthContext';
 import {FC, FCCC, FCSC} from "wide-containers";
 import {useTheme} from "Theme/ThemeContext";
-import CircularProgress from "Core/components/elements/CircularProgress";
+import CircularProgressZoomify from "Core/components/elements/CircularProgressZoomify";
 import {useApi} from "../Api/useApi";
 
 interface BackendConfigResponse {
@@ -110,7 +110,7 @@ const SettingsTool: React.FC = () => {
                         </FCSC>
                     ) : (
                         <FCCC>
-                            <CircularProgress size={'120px'}/>
+                            <CircularProgressZoomify in size={'120px'}/>
                         </FCCC>
                     )}
                 </DialogContent>
@@ -118,5 +118,4 @@ const SettingsTool: React.FC = () => {
         </FCCC>
     );
 };
-
 export default SettingsTool;

--- a/frontend/src/Modules/Core/components/Header/Header.tsx
+++ b/frontend/src/Modules/Core/components/Header/Header.tsx
@@ -13,7 +13,7 @@ import LogsLink from "Core/components/LogsLink";
 import DesktopNavigationMenu from "Core/components/Header/DesktopNavigationMenu";
 import {FRBC, FRCC} from "wide-containers";
 import LogoutRoundedIcon from '@mui/icons-material/LogoutRounded';
-import CircularProgress from "Core/components/elements/CircularProgress";
+import CircularProgressZoomify from "Core/components/elements/CircularProgressZoomify";
 import {IconButton} from "@mui/material";
 import ArrowBackIosNewRoundedIcon from '@mui/icons-material/ArrowBackIosNewRounded';
 import LanguageSwitcher from "../../../../UI/LanguageSwitcher";
@@ -78,7 +78,7 @@ const Header: React.FC = () => {
                 )}
                 <FRCC g={1}>
                     <LanguageSwitcher/>
-                    {isAuthenticated === null && <CircularProgress size={'35px'}/>}
+                    {isAuthenticated === null && <CircularProgressZoomify in size={'35px'}/>}
                     {profileBtnVisible && !location.pathname.includes('/profile') && (
                         <Link to={'/profile'}> <UserAvatar
                             size={user?.avatar ? '37px' : '30px'}

--- a/frontend/src/Modules/Core/components/elements/PaginatedList.tsx
+++ b/frontend/src/Modules/Core/components/elements/PaginatedList.tsx
@@ -2,7 +2,7 @@
 
 import React, {useCallback, useEffect, useRef, useState} from 'react';
 import {FC as FCContainer, FCCC} from "wide-containers";
-import CircularProgress from "Core/components/elements/CircularProgress";
+import CircularProgressZoomify from "Core/components/elements/CircularProgressZoomify";
 
 interface PaginatedListProps<T> {
     loadData: (page: number) => Promise<T[]>;
@@ -101,7 +101,7 @@ const PaginatedList = <T extends unknown>(
                 </React.Fragment>
             ))}
             {!loadMoreAtTop && hasMore && <div ref={targetRef}></div>}
-            {loading && <FCCC mt={4}><CircularProgress size={'120px'}/></FCCC>}
+            {loading && <FCCC mt={4}><CircularProgressZoomify in size={'120px'}/></FCCC>}
         </Component>
     );
 };

--- a/frontend/src/Modules/Order/BalanceTopUpDialog.tsx
+++ b/frontend/src/Modules/Order/BalanceTopUpDialog.tsx
@@ -1,7 +1,7 @@
 import React, {useContext, useEffect, useState} from 'react';
 import {useTranslation} from 'react-i18next';
 import {Button, Dialog, DialogContent, DialogTitle, TextField} from '@mui/material';
-import CircularProgress from 'Core/components/elements/CircularProgress';
+import CircularProgressZoomify from 'Core/components/elements/CircularProgressZoomify';
 import {FC, FR} from 'wide-containers';
 import PaymentSystemInfo from './PaymentSystemInfo';
 
@@ -75,7 +75,7 @@ const BalanceTopUpDialog: React.FC<BalanceTopUpDialogProps> = ({open, onClose}) 
             <DialogTitle sx={{pb: 1.5}}>{t('top_up_balance')}</DialogTitle>
             <DialogContent>
                 {!product ? (
-                    <CircularProgress size="40px"/>
+                    <CircularProgressZoomify in size="40px"/>
                 ) : (
                     <FC g={.7} maxW={400}>
                         <TextField
@@ -98,7 +98,7 @@ const BalanceTopUpDialog: React.FC<BalanceTopUpDialogProps> = ({open, onClose}) 
                             freekassaExtra={<FR mb={0.5}>{t('freekassa_help_desc')}</FR>}
                         />
                         <Button onClick={handleCreate} disabled={loading} sx={{fontWeight: 'bold'}}>
-                            {loading ? <CircularProgress size="20px"/> : t('next')}
+                            {loading ? <CircularProgressZoomify in size="20px"/> : t('next')}
                         </Button>
                     </FC>
                 )}
@@ -106,5 +106,4 @@ const BalanceTopUpDialog: React.FC<BalanceTopUpDialogProps> = ({open, onClose}) 
         </Dialog>
     );
 };
-
 export default BalanceTopUpDialog;

--- a/frontend/src/Modules/Order/OrderDetail.tsx
+++ b/frontend/src/Modules/Order/OrderDetail.tsx
@@ -1,7 +1,7 @@
 // Modules/Order/OrderDetail.tsx
 import React, {useContext, useEffect, useState} from 'react';
 import {useNavigate, useParams} from 'react-router-dom';
-import CircularProgress from "Core/components/elements/CircularProgress";
+import CircularProgressZoomify from "Core/components/elements/CircularProgressZoomify";
 import {useErrorProcessing} from "Core/components/ErrorProvider";
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import copyToClipboard from "Utils/clipboard";
@@ -50,7 +50,7 @@ const OrderDetail: React.FC<OrderDetailProps> = ({className}) => {
         if (!loading) setAnimate(true);
     }, [loading]);
 
-    if (loading) return <FCCC w={'100%'} mt={5}><CircularProgress size="90px"/></FCCC>;
+    if (loading) return <FCCC w={'100%'} mt={5}><CircularProgressZoomify in size="90px"/></FCCC>;
     if (orderNotFound || !order) return <div className={'p-3 text-center mt-2'}>Заказ не найден.</div>;
 
     return (
@@ -127,7 +127,7 @@ const OrderDetail: React.FC<OrderDetailProps> = ({className}) => {
                         width="100%"
                         height="100%"
                     >
-                        <CircularProgress size="3rem"/>
+                        <CircularProgressZoomify in size="3rem"/>
                     </FCCC>
                 )}
             </FC>

--- a/frontend/src/Modules/Order/OrderItem.tsx
+++ b/frontend/src/Modules/Order/OrderItem.tsx
@@ -8,7 +8,7 @@ import {IOrder} from "types/commerce/shop";
 import OrderStatus from "Order/OrderStatus";
 import {FC, FCCC, FR, FRBC, FRSC} from "wide-containers";
 import {useTheme} from "Theme/ThemeContext";
-import CircularProgress from "Core/components/elements/CircularProgress";
+import CircularProgressZoomify from "Core/components/elements/CircularProgressZoomify";
 import {useTranslation} from "react-i18next";
 
 interface OrderItemProps {
@@ -91,7 +91,7 @@ const OrderItem: React.FC<OrderItemProps> = (
                 <FCCC pos={'absolute'} className={'backdrop-blur-10'}
                       top={0} left={0} zIndex={8} rounded={3}
                       w={'100%'} h={'100%'}>
-                    <CircularProgress size={'3rem'}/>
+                    <CircularProgressZoomify in size={'3rem'}/>
                 </FCCC>
             )}
         </FRBC>

--- a/frontend/src/Modules/Order/OrderTemplate.tsx
+++ b/frontend/src/Modules/Order/OrderTemplate.tsx
@@ -5,7 +5,7 @@ import {Outlet, useLocation, useNavigate} from 'react-router-dom';
 import {Message} from 'Core/components/Message';
 import {useTheme} from 'Theme/ThemeContext';
 import {AuthContext, AuthContextType} from 'Auth/AuthContext';
-import CircularProgress from 'Core/components/elements/CircularProgress';
+import CircularProgressZoomify from 'Core/components/elements/CircularProgressZoomify';
 import {FC} from "wide-containers";
 import {useNavigation} from "Core/components/Header/HeaderProvider";
 import {redirectWithNextBack} from 'Utils/redirectNext';
@@ -28,7 +28,7 @@ const OrderTemplate: React.FC = () => {
     }, [isAuthenticated, navigate, location]);
 
 
-    if (loading) return <CircularProgress size={'150px'}/>;
+    if (loading) return <CircularProgressZoomify in size={'150px'}/>;
 
     return (
         <FC px={2} mx={'auto'} pos={'relative'} maxW={'800px'}

--- a/frontend/src/Modules/Order/PaymentTypePicker.tsx
+++ b/frontend/src/Modules/Order/PaymentTypePicker.tsx
@@ -12,7 +12,7 @@ import RadioCustomLine from 'Core/components/elements/RadioCustomLine';
 import {FC, FR, FRCC} from 'wide-containers';
 import {useTheme} from 'Theme/ThemeContext';
 import {useApi} from 'Api/useApi';
-import CircularProgress from 'Core/components/elements/CircularProgress';
+import CircularProgressZoomify from 'Core/components/elements/CircularProgressZoomify';
 import pprint from 'Utils/pprint';
 import {useTranslation} from 'react-i18next';
 import PaymentTypeButton from './PaymentTypeButton'; // ⭐️ новинка
@@ -237,7 +237,7 @@ const PaymentTypePicker: React.FC<PaymentTypePickerProps> = (
             )}
 
             {/* ---------- Лоадер ---------- */}
-            {loading && <FR mt={1}> <CircularProgress size={'40px'}/> </FR>}
+            {loading && <FR mt={1}> <CircularProgressZoomify in size={'40px'}/> </FR>}
 
             {/* ---------- Платёжные системы ---------- */}
             {selectedCurrency && filteredPaymentTypes.length > 0 && (

--- a/frontend/src/Modules/Order/PaymentTypePickerModal.tsx
+++ b/frontend/src/Modules/Order/PaymentTypePickerModal.tsx
@@ -9,7 +9,7 @@ import PaymentSystemInfo from './PaymentSystemInfo';
 import {ICurrencyWithPrice, IOrder, IPaymentSystem} from 'types/commerce/shop';
 import {Button} from '@mui/material';
 import {Message} from 'Core/components/Message';
-import CircularProgress from 'Core/components/elements/CircularProgress';
+import CircularProgressZoomify from 'Core/components/elements/CircularProgressZoomify';
 import {useApi} from 'Api/useApi';
 import {FC, FRE} from "wide-containers";
 
@@ -64,7 +64,7 @@ const PaymentTypePickerModal: React.FC<Props> = ({open, onClose, order, onPaymen
                     <FRE g={1}>
                         <Button variant="outlined" onClick={onClose}>{t('cancel')}</Button>
                         <Button variant="contained" disabled={loading} onClick={confirm}>
-                            {loading ? <CircularProgress size="20px"/> : t('next')}
+                            {loading ? <CircularProgressZoomify in size="20px"/> : t('next')}
                         </Button>
                     </FRE>
                 </FC>

--- a/frontend/src/Modules/Order/PromoCodeField.tsx
+++ b/frontend/src/Modules/Order/PromoCodeField.tsx
@@ -3,7 +3,7 @@ import React, {useEffect, useRef, useState} from 'react';
 import {useTranslation} from 'react-i18next';
 import debounce from 'lodash.debounce';
 import {FC} from "wide-containers";
-import CircularProgress from "Core/components/elements/CircularProgress";
+import CircularProgressZoomify from "Core/components/elements/CircularProgressZoomify";
 import {TextField} from "@mui/material";
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 import HighlightOffIcon from '@mui/icons-material/HighlightOff';
@@ -100,7 +100,7 @@ const PromoCodeField: React.FC<PromoCodeFieldProps> = (
                 inputRef={promoCodeRef}
             />
             {status === 'checking' && (
-                <CircularProgress size={'2rem'} sx={{
+                <CircularProgressZoomify in size={'2rem'} sx={{
                     color: theme.colors.secondary.main,
                     position: 'absolute',
                     top: 'calc(50% - 1rem)',

--- a/frontend/src/Modules/Software/Macros/MacroFormDialog.tsx
+++ b/frontend/src/Modules/Software/Macros/MacroFormDialog.tsx
@@ -1,6 +1,7 @@
 // Modules/Software/Macros/MacroFormDialog.tsx
 import React, {useEffect, useState} from 'react';
-import {Button, CircularProgress, Dialog, DialogActions, DialogContent, DialogTitle, TextField} from '@mui/material';
+import {Button, Dialog, DialogActions, DialogContent, DialogTitle, TextField} from '@mui/material';
+import CircularProgressZoomify from 'Core/components/elements/CircularProgressZoomify';
 import {Message} from 'Core/components/Message';
 import {useApi} from "../../Api/useApi";
 import {WirelessMacro} from "../Types/Software";
@@ -90,7 +91,7 @@ const MacroFormDialog: React.FC<Props> = ({open, onClose, onSaved, macro}) => {
             <DialogActions>
                 <Button onClick={onClose} disabled={saving}>{t('cancel')}</Button>
                 <Button onClick={handleSave} variant="contained" disabled={saving}>
-                    {saving ? <CircularProgress size="1.2rem"/> : t('save')}
+                    {saving ? <CircularProgressZoomify in size="1.2rem"/> : t('save')}
                 </Button>
             </DialogActions>
         </Dialog>

--- a/frontend/src/Modules/Software/Macros/MacrosExecutorForm.tsx
+++ b/frontend/src/Modules/Software/Macros/MacrosExecutorForm.tsx
@@ -3,7 +3,7 @@ import React, {useContext, useState} from 'react';
 import {AuthContext, AuthContextType} from 'Auth/AuthContext';
 import {Message} from 'Core/components/Message';
 import {Button} from '@mui/material';
-import CircularProgress from 'Core/components/elements/CircularProgress';
+import CircularProgressZoomify from 'Core/components/elements/CircularProgressZoomify';
 import TextField from '@mui/material/TextField';
 import {FC, FR} from 'wide-containers';
 import {useMacroControl} from './MacroControlProvider';
@@ -61,7 +61,7 @@ const MacrosExecutorForm: React.FC<Props> = ({onExecuted, className}) => {
                     <Button type="submit" disabled={loading} sx={{
                         fontSize: '1rem', fontWeight: 600,
                     }}>
-                        {loading ? <CircularProgress size="1.6rem"/> : t('execute')}
+                        {loading ? <CircularProgressZoomify in size="1.6rem"/> : t('execute')}
                     </Button>
                 </FR>
             </FC>

--- a/frontend/src/Modules/Software/Macros/MacrosWirelessDashboard.tsx
+++ b/frontend/src/Modules/Software/Macros/MacrosWirelessDashboard.tsx
@@ -1,6 +1,7 @@
 // Modules/Software/Macros/MacrosWirelessDashboard.tsx
 import React, {useEffect, useState} from 'react';
-import {Box, CircularProgress, IconButton, List, ListItem, ListItemText, Tooltip,} from '@mui/material';
+import {Box, IconButton, List, ListItem, ListItemText, Tooltip,} from '@mui/material';
+import CircularProgressZoomify from 'Core/components/elements/CircularProgressZoomify';
 import DeleteIcon from '@mui/icons-material/Delete';
 import EditIcon from '@mui/icons-material/Edit';
 import AddIcon from '@mui/icons-material/AddRounded';
@@ -47,7 +48,7 @@ const MacrosWirelessDashboard: React.FC = () => {
         setMacros(prev => [...prev!.filter(o => o.id !== m.id), m]
             .sort((a, b) => a.priority - b.priority || a.name.localeCompare(b.name)));
 
-    if (macros === null) return <FRC mt={3}><CircularProgress/></FRC>;
+    if (macros === null) return <FRC mt={3}><CircularProgressZoomify in/></FRC>;
 
     return (
         <FC>

--- a/frontend/src/Modules/Software/Macros/ScreenViewer.tsx
+++ b/frontend/src/Modules/Software/Macros/ScreenViewer.tsx
@@ -5,7 +5,7 @@ import {useMacroControl} from './MacroControlProvider';
 import FloatingToolbar from './FloatingToolbar';
 import FloatingKeyboard from './FloatingKeyboard';
 import {FCCC, FRCC} from 'wide-containers';
-import CircularProgress from 'Core/components/elements/CircularProgress';
+import CircularProgressZoomify from 'Core/components/elements/CircularProgressZoomify';
 import {useTheme} from 'Theme/ThemeContext';
 import MonitorIcon from '@mui/icons-material/Monitor';
 
@@ -127,7 +127,7 @@ const ScreenViewer: React.FC<Props> = ({className, style}) => {
     if (state === 'pending')
         return (
             <FCCC cls={className} style={style}>
-                <CircularProgress size="90px"/>
+                <CircularProgressZoomify in size="90px"/>
             </FCCC>
         );
 

--- a/frontend/src/Modules/Software/SoftwareDetail.tsx
+++ b/frontend/src/Modules/Software/SoftwareDetail.tsx
@@ -2,7 +2,7 @@
 import React, {memo, useContext, useEffect, useState} from 'react';
 import {useTranslation} from 'react-i18next';
 import {useNavigate, useParams} from 'react-router-dom';
-import CircularProgress from 'Core/components/elements/CircularProgress';
+import CircularProgressZoomify from 'Core/components/elements/CircularProgressZoomify';
 import {Button, IconButton} from '@mui/material';
 import DownloadRoundedIcon from '@mui/icons-material/DownloadRounded';
 import YouTubeIcon from '@mui/icons-material/YouTube';
@@ -114,7 +114,7 @@ const SoftwareDetailComponent: React.FC = () => {
                     h="60%"
                     zIndex={2}
                 >
-                    <CircularProgress size="80px"/>
+                    <CircularProgressZoomify in size="80px"/>
                 </FRCC>
             </Zoom>
 
@@ -126,7 +126,7 @@ const SoftwareDetailComponent: React.FC = () => {
                         {isAuthenticated && (
                             <FRE w={'100%'} p={1} pos="absolute" top={0} left={0}>
                                 {isTested === null && licenseLoading
-                                    ? <CircularProgress size="20px"/>
+                                    ? <CircularProgressZoomify in size="20px"/>
                                     : isTested
                                         ? <FR opacity={60} bg={plt.text.primary + '0b'} rounded={2} p={1} lh="1rem">
                                             {t('hours_left', {hours: licenseHours ?? 0})}

--- a/frontend/src/Modules/Software/SoftwareOrder.tsx
+++ b/frontend/src/Modules/Software/SoftwareOrder.tsx
@@ -3,7 +3,7 @@ import React, {useContext, useEffect, useState} from 'react';
 import {useTranslation} from 'react-i18next';
 import {Button, Collapse, Dialog, DialogContent, DialogTitle, IconButton, Slider, useMediaQuery} from '@mui/material';
 import {Message} from 'Core/components/Message';
-import CircularProgress from 'Core/components/elements/CircularProgress';
+import CircularProgressZoomify from 'Core/components/elements/CircularProgressZoomify';
 import {FC, FCC, FR, FRC, FRSC} from 'wide-containers';
 import {ICurrencyWithPrice, IPaymentSystem} from 'types/commerce/shop';
 import {ISoftware} from './Types/Software';
@@ -197,7 +197,7 @@ const SoftwareOrder: React.FC<SoftwareOrderProps> = ({software, onSuccess}) => {
                 />
             </Collapse>
 
-            {creatingOrder && <CircularProgress size="60px"/>}
+            {creatingOrder && <CircularProgressZoomify in size="60px"/>}
 
             <Dialog
                 open={payModal}
@@ -223,7 +223,7 @@ const SoftwareOrder: React.FC<SoftwareOrderProps> = ({software, onSuccess}) => {
                                 fontWeight: 'bold', width: '100%',
                             }}>
                                 {creatingOrder
-                                    ? <CircularProgress size="20px"/>
+                                    ? <CircularProgressZoomify in size="20px"/>
                                     : t('next')
                                 }
                             </Button>

--- a/frontend/src/Modules/User/UserAvatar.tsx
+++ b/frontend/src/Modules/User/UserAvatar.tsx
@@ -1,7 +1,7 @@
 // Modules/User/UserAvatar.tsx
 import React, {useState} from 'react';
 import Avatar from '@mui/material/Avatar';
-import CircularProgress from "Core/components/elements/CircularProgress";
+import CircularProgressZoomify from "Core/components/elements/CircularProgressZoomify";
 import PersonRoundedIcon from '@mui/icons-material/PersonRounded';
 import {FC, FCCC} from "wide-containers";
 import {useTheme} from "Theme/ThemeContext";
@@ -48,7 +48,7 @@ const UserAvatar: React.FC<UserAvatarProps> = (
             <FC cls={`${className} ratio-1-1 ftrans-300-eio`} w={'min-content'}
                 pos={'relative'} onClick={onClick} style={avatarStyle}>
                 {loading && <FCCC pos={'absolute'} top={0} w={'100%'} h={'100%'} zIndex={zIndex + 1}>
-                    <CircularProgress size={`calc(${size} - 35%)`}/>
+                    <CircularProgressZoomify in size={`calc(${size} - 35%)`}/>
                 </FCCC>}
                 <img
                     className={`object-fit-cover ${roundedClassName ? roundedClassName : 'rounded-circle'} transition-all transition-d-300 transition-tf-l`}

--- a/frontend/src/Modules/User/UserAvatarEditable.tsx
+++ b/frontend/src/Modules/User/UserAvatarEditable.tsx
@@ -8,7 +8,7 @@ import {AuthContext, AuthContextType} from 'Auth/AuthContext';
 import './UserAvatarEditable.sass';
 import {useTheme} from 'Theme/ThemeContext';
 import {FC, FCCC} from 'wide-containers';
-import CircularProgress from 'Core/components/elements/CircularProgress';
+import CircularProgressZoomify from 'Core/components/elements/CircularProgressZoomify';
 import {useApi} from '../Api/useApi';
 
 interface UserAvatarEditableProps {
@@ -51,7 +51,7 @@ const UserAvatarEditable: React.FC<UserAvatarEditableProps> = ({size, sx, classN
             />
             <label htmlFor="avatar-upload" className="user-avatar-editable position-relative">
                 {isLoading
-                    ? <CircularProgress size={size}/>
+                    ? <CircularProgressZoomify in size={size}/>
                     : <UserAvatar avatar={user?.avatar} size={size} sx={sx} className={className}/>
                 }
                 <FCCC

--- a/frontend/src/Modules/xLMine/Donate/DonateModal.tsx
+++ b/frontend/src/Modules/xLMine/Donate/DonateModal.tsx
@@ -11,7 +11,7 @@ import {Button, Slider} from "@mui/material";
 import {AuthContext, AuthContextType} from "Auth/AuthContext";
 import {useApi} from "Modules/Api/useApi";
 import {Message} from "Core/components/Message";
-import CircularProgress from "Core/components/elements/CircularProgress";
+import CircularProgressZoomify from "Core/components/elements/CircularProgressZoomify";
 import {FC, FCSC, FR, FRBC, FRSC} from "wide-containers";
 import {useErrorProcessing} from "Core/components/ErrorProvider";
 import {IDonate} from "./types";
@@ -129,7 +129,7 @@ const DonateModal: React.FC<IDonateModalProps> = ({isOpen, onClose}) => {
                 <FC g={2} px={2}>
                     <FCSC>
                         {!donateProduct ? (
-                            <CircularProgress size="40px"/>
+                            <CircularProgressZoomify in size="40px"/>
                         ) : (
                             <>
                                 <FR maxW={250} pr={3}>

--- a/frontend/src/Modules/xLMine/LauncherManager.tsx
+++ b/frontend/src/Modules/xLMine/LauncherManager.tsx
@@ -3,7 +3,6 @@ import {useTranslation} from 'react-i18next';
 import {
     Box,
     Button,
-    CircularProgress,
     Dialog,
     DialogActions,
     DialogContent,
@@ -16,6 +15,7 @@ import {
     TableHead,
     TableRow,
 } from '@mui/material';
+import CircularProgressZoomify from 'Core/components/elements/CircularProgressZoomify';
 import {Message} from 'Core/components/Message';
 import DeleteIcon from '@mui/icons-material/Delete';
 import {useApi} from "../Api/useApi";
@@ -149,7 +149,7 @@ const LauncherManager: React.FC = () => {
                             >
                                 {t('upload')}
                             </Button>
-                            {isUploading && <FCCC><CircularProgress size={32}/></FCCC>}
+                            {isUploading && <FCCC><CircularProgressZoomify in size={32}/></FCCC>}
                         </FC>
                     </FC>
                 </Paper>
@@ -157,7 +157,7 @@ const LauncherManager: React.FC = () => {
                 <Paper sx={{p: 2, pt: 1}}>
                     {loading ? (
                         <Box sx={{display: 'flex', justifyContent: 'center', p: 2}}>
-                            <CircularProgress/>
+                            <CircularProgressZoomify in/>
                         </Box>
                     ) : (
                         <Table>
@@ -187,7 +187,7 @@ const LauncherManager: React.FC = () => {
                                                 disabled={deletingId === item.id}
                                             >
                                                 {deletingId === item.id ? (
-                                                    <CircularProgress size={24}/>
+                                                    <CircularProgressZoomify in size={24}/>
                                                 ) : (
                                                     <DeleteIcon/>
                                                 )}
@@ -218,7 +218,7 @@ const LauncherManager: React.FC = () => {
                             disabled={deletingId === confirmDeleteId}
                         >
                             {deletingId === confirmDeleteId ? (
-                                <CircularProgress size={24}/>
+                                <CircularProgressZoomify in size={24}/>
                             ) : (
                                 'Удалить'
                             )}

--- a/frontend/src/Modules/xLMine/Privilege/PrivilegesView.tsx
+++ b/frontend/src/Modules/xLMine/Privilege/PrivilegesView.tsx
@@ -2,7 +2,7 @@
 import React, {useEffect, useState} from 'react';
 import {useApi} from "Modules/Api/useApi";
 import {Message} from "Core/components/Message";
-import CircularProgress from "Core/components/elements/CircularProgress";
+import CircularProgressZoomify from "Core/components/elements/CircularProgressZoomify";
 import {useTheme} from "Theme/ThemeContext";
 import {IPrivilege} from "../types/base";
 import {FC, FCCC, FRSC} from "wide-containers";
@@ -45,7 +45,7 @@ const PrivilegesView: React.FC = () => {
             .finally(() => setLoading(false));
     }, [api]);
 
-    if (loading) return <FCCC><CircularProgress size="60px"/></FCCC>;
+    if (loading) return <FCCC><CircularProgressZoomify in size="60px"/></FCCC>;
     if (!privileges || privileges.length === 0) return null; // Привилегий нет у юзера
     if (totalDonate === null) return null;
 

--- a/frontend/src/Modules/xLMine/Privilege/UserPrivilege.tsx
+++ b/frontend/src/Modules/xLMine/Privilege/UserPrivilege.tsx
@@ -2,7 +2,7 @@
 import React, {useEffect, useState} from 'react';
 import {useApi} from '../../Api/useApi';
 import {FC, FR, FRCC} from 'wide-containers';
-import CircularProgress from 'Core/components/elements/CircularProgress';
+import CircularProgressZoomify from 'Core/components/elements/CircularProgressZoomify';
 import {Message} from 'Core/components/Message';
 import Tooltip from '@mui/material/Tooltip';
 import {IPrivilege} from '../types/base';
@@ -48,7 +48,7 @@ const UserPrivilege: React.FC = () => {
     if (privilege === undefined) {
         return (
             <FRCC>
-                <CircularProgress size={22}/>
+                <CircularProgressZoomify in size={22}/>
             </FRCC>
         );
     }

--- a/frontend/src/Modules/xLMine/ReleaseManager.tsx
+++ b/frontend/src/Modules/xLMine/ReleaseManager.tsx
@@ -3,7 +3,6 @@ import {useTranslation} from 'react-i18next';
 import {
     Box,
     Button,
-    CircularProgress,
     Dialog,
     DialogActions,
     DialogContent,
@@ -17,6 +16,7 @@ import {
     TableHead,
     TableRow,
 } from '@mui/material';
+import CircularProgressZoomify from 'Core/components/elements/CircularProgressZoomify';
 import {Message} from 'Core/components/Message';
 import DeleteIcon from '@mui/icons-material/Delete';
 import {useApi} from "../Api/useApi";
@@ -217,7 +217,7 @@ const ReleaseManager: React.FC = () => {
                 <Paper sx={{p: 2, pt: 1}}>
                     {loading ? (
                         <Box sx={{display: 'flex', justifyContent: 'center', p: 2}}>
-                            <CircularProgress/>
+                            <CircularProgressZoomify in/>
                         </Box>
                     ) : (
                         <Table>
@@ -240,7 +240,7 @@ const ReleaseManager: React.FC = () => {
                                         <TableCell>
                                             <IconButton onClick={() => openConfirmDelete(r.id)}
                                                         disabled={deletingId === r.id}>
-                                                {deletingId === r.id ? <CircularProgress size={24}/> : <DeleteIcon/>}
+                                                {deletingId === r.id ? <CircularProgressZoomify in size={24}/> : <DeleteIcon/>}
                                             </IconButton>
                                         </TableCell>
                                     </TableRow>
@@ -256,7 +256,7 @@ const ReleaseManager: React.FC = () => {
                     <DialogActions>
                         <Button onClick={closeConfirmDelete}>Отмена</Button>
                         <Button onClick={handleConfirmDelete} disabled={deletingId === confirmDeleteId}>
-                            {deletingId === confirmDeleteId ? <CircularProgress size={24}/> : 'Удалить'}
+                            {deletingId === confirmDeleteId ? <CircularProgressZoomify in size={24}/> : 'Удалить'}
                         </Button>
                     </DialogActions>
                 </Dialog>

--- a/frontend/src/Modules/xLMine/SkinCape/SkinCapeView.tsx
+++ b/frontend/src/Modules/xLMine/SkinCape/SkinCapeView.tsx
@@ -2,7 +2,7 @@
 import React, {useEffect, useState} from 'react';
 // import ReactSkinview3d from 'react-skinview3d';
 // import {FunctionAnimation, SkinViewer} from 'skinview3d';
-import CircularProgress from 'Core/components/elements/CircularProgress';
+import CircularProgressZoomify from 'Core/components/elements/CircularProgressZoomify';
 
 interface SkinCapeViewProps {
     skinUrl?: string | null;
@@ -62,7 +62,7 @@ const SkinCapeView: React.FC<SkinCapeViewProps> = ({
             }}
         >
             {!loaded ? (
-                <CircularProgress size="40px"/>
+                <CircularProgressZoomify in size="40px"/>
             ) : null}
         </div>
     );

--- a/frontend/src/Modules/xLMine/XLMineLanding.tsx
+++ b/frontend/src/Modules/xLMine/XLMineLanding.tsx
@@ -7,7 +7,7 @@ import minecraftHero from 'Static/img/xlmine/hero-bg.webp';
 import {useNavigation} from "Core/components/Header/HeaderProvider";
 import {Button, useMediaQuery} from "@mui/material";
 import DownloadRoundedIcon from "@mui/icons-material/DownloadRounded";
-import CircularProgress from "Core/components/elements/CircularProgress";
+import CircularProgressZoomify from "Core/components/elements/CircularProgressZoomify";
 import {useDispatch} from 'react-redux';
 import {hideBackgroundFlicker, showBackgroundFlicker} from 'Redux/visibilitySlice';
 import {useTranslation} from 'react-i18next';
@@ -154,7 +154,7 @@ const XLMineLanding: React.FC = () => {
                                 }}>
                             <FRCC fontWeight={'bold'} g={1} opacity={70}>
                                 {loading
-                                    ? <FR mr={1}><CircularProgress size="2.1rem"/></FR>
+                                    ? <FR mr={1}><CircularProgressZoomify in size="2.1rem"/></FR>
                                     : <DownloadRoundedIcon sx={{fontSize: '2.1rem'}}/>}
                                 <span>{t('download_launcher')}</span>
                             </FRCC>


### PR DESCRIPTION
## Summary
- switch imports from `CircularProgress` to `CircularProgressZoomify`
- update all spinners to use new component

## Testing
- `git diff --stat`


------
https://chatgpt.com/codex/tasks/task_e_686e5feb5cc08330a769132ea3df1475