### PR TITLE
Fix donate postgive logic

### DIFF
--- a/backend/apps/xlmine/services/donate.py
+++ b/backend/apps/xlmine/services/donate.py
@@ -55,7 +55,7 @@ class DonateService:
 
         await UserXLMine.objects.aget_or_create(user_id=order.user_id)
 
-    async def postgive(self: 'Donate', order: 'DonateOrder'):  # noqa TODO: разобрать
+    async def postgive(self: 'Donate', order: 'DonateOrder'):  # noqa
         """
         Действия после успешной оплаты: начисляем пользователю коины.
         Берём стоимость заказа в рублях (order.receipt_price) и добавляем к user.xlmine.coins
@@ -64,7 +64,7 @@ class DonateService:
 
         # Получаем/создаём запись UserXLMine
         from apps.xlmine.models.user import UserXLMine
-        xlmine_user = await UserXLMine.objects.aget_or_create(user=user)
+        xlmine_user, _ = await UserXLMine.objects.aget_or_create(user=user)
         # Считаем стоимость заказа (финальная сумма, учтя промокод и т.д.)
         order_price = await order.receipt_price  # noqa
         if not order_price:

--- a/backend/apps/xlmine/tests/test_donate_service.py
+++ b/backend/apps/xlmine/tests/test_donate_service.py
@@ -4,16 +4,21 @@ from decimal import Decimal
 import pytest
 
 from apps.commerce.models.payment import Currency, PaymentSystem
+from apps.commerce.models.product import ProductPrice
 from apps.core.models import User
-from apps.xlmine.models import Donate, DonateOrder
+from apps.xlmine.models import Donate, DonateOrder, Privilege
 from apps.xlmine.models.user import UserXLMine
 
 
 @pytest.mark.django_db
 @pytest.mark.asyncio
-async def test_postgive_adds_coins_and_profile_created():
+async def test_postgive_adds_coins_and_recalculates_privilege():
     user = await User.objects.acreate(username='don')
     donate = await Donate.objects.acreate(name='Donate', is_available=True)
+    await ProductPrice.objects.acreate(product=donate, amount=10, currency=Currency.RUB)
+    privilege = await Privilege.objects.acreate(
+        name='Bronze', code_name='bronze', prefix='[B]', weight=1, threshold=0
+    )
 
     order = await DonateOrder.objects.acreate(
         user=user,
@@ -26,8 +31,5 @@ async def test_postgive_adds_coins_and_profile_created():
     await donate.postgive(order)
 
     xlm_user = await UserXLMine.objects.aget(user=user)
-    assert xlm_user.coins == Decimal('0')
-
-    await donate.postgive(order)
-    await xlm_user.arefresh_from_db()
-    assert xlm_user.coins >= Decimal('0')
+    assert xlm_user.coins == Decimal('10')
+    assert xlm_user.privilege_id == privilege.id


### PR DESCRIPTION
## Summary
- fix user creation in DonateService.postgive
- test that coins are credited and privilege recalculates

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686e9618c328833083943589f76f4c4f