### PR TITLE
Add helper for root folders

### DIFF
--- a/backend/apps/filehost/controllers/folders.py
+++ b/backend/apps/filehost/controllers/folders.py
@@ -10,6 +10,7 @@ from rest_framework.response import Response
 from apps.filehost.exceptions.base import IdWasNotProvided
 from apps.filehost.models import Folder, File
 from apps.filehost.serializers import FolderSerializer, FileSerializer
+from apps.filehost.services.base import get_root_folder
 
 
 @acontroller('Get Folder By ID')
@@ -37,9 +38,7 @@ async def get_all_folders(request) -> Response:
 async def get_folder_content(request) -> Response:
     folder_id = request.data.get('id')
     if not folder_id:
-        folder, _ = await Folder.objects.aget_or_create(
-            name='root', user=request.user, parent=None
-        )
+        folder, _ = await get_root_folder(request.user)
     else:
         folder = await aget_object_or_404(Folder, id=folder_id, user=request.user)
     subfolders = await Folder.objects.afilter(parent=folder)
@@ -67,7 +66,7 @@ async def add_folder(request) -> Response:
     if parent_id:
         parent = await aget_object_or_404(Folder, id=parent_id, user=request.user)
     else:
-        parent, _ = await Folder.objects.aget_or_create(name='root', user=request.user, parent=None)
+        parent, _ = await get_root_folder(request.user)
     folder = await Folder.objects.acreate(name=name, parent=parent, user=request.user)
 
     return Response(

--- a/backend/apps/filehost/services/base.py
+++ b/backend/apps/filehost/services/base.py
@@ -10,6 +10,13 @@ from apps.filehost.models import File, Folder
 from apps.filehost.serializers import FileSerializer, FolderSerializer, TagSerializer
 
 
+async def get_root_folder(user):
+    """Return user's root folder, creating it if necessary."""
+    return await Folder.objects.aget_or_create(
+        name='root', user=user, parent=None
+    )
+
+
 async def get_files(*args, **kwargs):
     """
     This function asynchronously retrieves and serializes files for a given folder.


### PR DESCRIPTION
## Summary
- add `get_root_folder` helper in filehost service
- use `get_root_folder` in controllers

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686e95f80100833098495c4d4b329b41