### PR TITLE
Refactor TBank requests and add unit test

### DIFF
--- a/backend/apps/tbank/tests/test_request.py
+++ b/backend/apps/tbank/tests/test_request.py
@@ -1,0 +1,24 @@
+import pytest
+
+from apps.tbank.classes.TBank import TBank
+
+
+@pytest.mark.asyncio
+async def test_request_adds_terminal_and_token(monkeypatch, settings):
+    settings.TBANK_PASSWORD = "pass"
+    tb = TBank(terminal_key="terminal", password="pass")
+    captured = {}
+
+    async def fake_post(endpoint, data):
+        captured['endpoint'] = endpoint
+        captured['data'] = data
+        return {"ok": True}
+
+    monkeypatch.setattr(tb, "_post", fake_post)
+
+    result = await tb._request("SomeEndpoint", {"foo": "bar"})
+
+    assert result == {"ok": True}
+    assert captured['endpoint'] == "SomeEndpoint"
+    assert captured['data']['TerminalKey'] == "terminal"
+    assert captured['data']['Token'] == tb._generate_token(captured['data'])


### PR DESCRIPTION
## Summary
- implement a private `_request` helper in `TBank`
- update payment methods to use the new helper
- add basic test coverage for `_request`

## Testing
- `pytest backend/apps/tbank/tests/test_request.py -q` *(fails: ModuleNotFoundError: No module named 'apps')*

------
https://chatgpt.com/codex/tasks/task_e_686e95ee63408330add0ca3dafecf7fd