### PR TITLE
Implement pagination helper

### DIFF
--- a/backend/apps/filehost/controllers/files.py
+++ b/backend/apps/filehost/controllers/files.py
@@ -9,6 +9,8 @@ from rest_framework.decorators import permission_classes
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
+from apps.filehost.utils import parse_pagination
+
 from apps.filehost.exceptions.base import IdWasNotProvided, StorageLimitExceeded
 from apps.filehost.models import File
 from apps.filehost.serializers import (
@@ -32,9 +34,7 @@ async def get_file_by_id(request) -> Response:
 @api_view(('GET',))
 @permission_classes((IsAuthenticated,))
 async def get_all_files(request) -> Response:
-    page = int(request.query_params.get('page', 1))
-    page_size = int(request.query_params.get('page_size', 10))
-    offset = (page - 1) * page_size
+    page, page_size, offset = parse_pagination(request)
     files_qs = File.objects.filter(user=request.user).order_by('-created_at')[offset:offset + page_size]
     files = []
     async for f in files_qs:
@@ -65,9 +65,7 @@ async def add_file(request) -> Response:
 @api_view(('GET',))
 @permission_classes((IsAuthenticated,))
 async def get_favorite_files(request) -> Response:
-    page = int(request.query_params.get('page', 1))
-    page_size = int(request.query_params.get('page_size', 10))
-    offset = (page - 1) * page_size
+    page, page_size, offset = parse_pagination(request)
     files_qs = File.objects.filter(user=request.user, is_favorite=True).order_by('-created_at')[
                offset:offset + page_size]
     files = []

--- a/backend/apps/filehost/tests/test_utils.py
+++ b/backend/apps/filehost/tests/test_utils.py
@@ -1,0 +1,21 @@
+import pytest
+from django.test import RequestFactory
+
+from apps.filehost.utils import parse_pagination
+
+@pytest.mark.django_db
+def test_parse_pagination_defaults():
+    request = RequestFactory().get('/files/')
+    page, page_size, offset = parse_pagination(request)
+    assert page == 1
+    assert page_size == 10
+    assert offset == 0
+
+
+@pytest.mark.django_db
+def test_parse_pagination_custom():
+    request = RequestFactory().get('/files/', {'page': '3', 'page_size': '5'})
+    page, page_size, offset = parse_pagination(request)
+    assert page == 3
+    assert page_size == 5
+    assert offset == 10

--- a/backend/apps/filehost/utils.py
+++ b/backend/apps/filehost/utils.py
@@ -1,0 +1,10 @@
+"""Utility functions for filehost app."""
+from rest_framework.request import Request
+
+
+def parse_pagination(request: Request) -> tuple[int, int, int]:
+    """Return page, page_size and offset from request query params."""
+    page = int(request.query_params.get("page", 1))
+    page_size = int(request.query_params.get("page_size", 10))
+    offset = (page - 1) * page_size
+    return page, page_size, offset


### PR DESCRIPTION
## Summary
- add `parse_pagination` helper for filehost app
- use the helper in the files controller
- test pagination logic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686e95efd5448330a65276c4a226ea7e