### PR TITLE
Add helper for linking OAuth accounts

### DIFF
--- a/backend/apps/social_oauth/providers/discord/provider.py
+++ b/backend/apps/social_oauth/providers/discord/provider.py
@@ -19,13 +19,12 @@ class DiscordOAuthProvider(OAuthProviderMixin, OAuthProvider):
     @staticmethod
     async def link_user_account(user, user_data):
         discord_id = user_data['id']
-        existing_link = await DiscordUser.objects.select_related('user').filter(discord_id=discord_id).afirst()
-        if existing_link and existing_link.user != user:
-            raise SocialOAuthException.AccountAlreadyLinkedAnotherUser()
-        discord_user, _ = await DiscordUser.objects.aget_or_create(user=user)
-        discord_user.discord_id = discord_id
-        # Обновляем другие поля при необходимости
-        await discord_user.asave()
+        await OAuthProviderMixin.link_user_account_model(
+            user,
+            DiscordUser,
+            'discord_id',
+            discord_id,
+        )
 
     async def get_user_data(self, code: str) -> dict[str, Any]:
         """

--- a/backend/apps/social_oauth/providers/google/provider.py
+++ b/backend/apps/social_oauth/providers/google/provider.py
@@ -19,14 +19,12 @@ class GoogleOAuthProvider(OAuthProviderMixin, OAuthProvider):
     @staticmethod
     async def link_user_account(user, user_data):
         google_id = user_data['sub']
-        existing_link = await GoogleUser.objects.select_related('user').filter(google_id=google_id).afirst()
-        if existing_link and existing_link.user != user:
-            raise SocialOAuthException.AccountAlreadyLinkedAnotherUser()
-        google_user, _ = await GoogleUser.objects.aget_or_create(user=user)
-        google_user.google_id = google_id
-        # Обновляем другие поля при необходимости
-
-        await google_user.asave()
+        await OAuthProviderMixin.link_user_account_model(
+            user,
+            GoogleUser,
+            'google_id',
+            google_id,
+        )
 
     async def get_user_data(self, code: str) -> dict[str, Any]:
         """

--- a/backend/apps/social_oauth/providers/vk/provider.py
+++ b/backend/apps/social_oauth/providers/vk/provider.py
@@ -20,12 +20,12 @@ class VKOAuthProvider(OAuthProviderMixin, OAuthProvider):
     @staticmethod
     async def link_user_account(user, user_data):
         vk_id = user_data['id']
-        existing_link = await VKUser.objects.select_related('user').filter(vk_id=vk_id).afirst()
-        if existing_link and existing_link.user != user:
-            raise SocialOAuthException.AccountAlreadyLinkedAnotherUser()
-        vk_user, _ = await VKUser.objects.aget_or_create(user=user)
-        vk_user.vk_id = vk_id
-        await vk_user.asave()
+        await OAuthProviderMixin.link_user_account_model(
+            user,
+            VKUser,
+            'vk_id',
+            str(vk_id),
+        )
 
     async def get_user_data(self, code: str) -> dict[str, Any]:
         """

--- a/backend/apps/social_oauth/providers/yandex/provider.py
+++ b/backend/apps/social_oauth/providers/yandex/provider.py
@@ -19,13 +19,12 @@ class YandexOAuthProvider(OAuthProviderMixin, OAuthProvider):
     @staticmethod
     async def link_user_account(user, user_data):
         yandex_id = user_data['id']
-        existing_link = await YandexUser.objects.select_related('user').filter(yandex_id=yandex_id).afirst()
-        if existing_link and existing_link.user != user:
-            raise SocialOAuthException.AccountAlreadyLinkedAnotherUser()
-        yandex_user, _ = await YandexUser.objects.aget_or_create(user=user)
-        yandex_user.yandex_id = yandex_id
-        # Обновляем другие поля при необходимости
-        await yandex_user.asave()
+        await OAuthProviderMixin.link_user_account_model(
+            user,
+            YandexUser,
+            'yandex_id',
+            yandex_id,
+        )
 
     async def get_user_data(self, code: str) -> dict[str, Any]:
         """


### PR DESCRIPTION
## Summary
- provide `link_user_account_model` helper in `OAuthProviderMixin`
- use the helper in Google, Discord, VK and Yandex OAuth providers

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686e9664783c83309e463d9cc046ff94