### PR TITLE
Add configurable storage limit

### DIFF
--- a/backend/apps/filehost/controllers/base.py
+++ b/backend/apps/filehost/controllers/base.py
@@ -14,7 +14,7 @@ from rest_framework.decorators import permission_classes
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
-from apps.filehost.controllers.files import STORAGE_LIMIT
+from django.conf import settings
 from apps.filehost.exceptions.base import IdWasNotProvided, StorageLimitExceeded
 from apps.filehost.models import Folder, File
 from apps.filehost.serializers import FileSerializer, FolderSerializer
@@ -116,7 +116,7 @@ async def upload_files(request) -> Response:
         if f.file:
             total += f.file.size
     incoming = sum(f.size for f in files)
-    if total + incoming > STORAGE_LIMIT:
+    if total + incoming > settings.STORAGE_LIMIT:
         raise StorageLimitExceeded()
     uploaded_files = []
     for file in files:

--- a/backend/apps/filehost/controllers/files.py
+++ b/backend/apps/filehost/controllers/files.py
@@ -3,8 +3,7 @@ from adjango.adecorators import acontroller
 from adrf.decorators import api_view
 from adrf.generics import aget_object_or_404
 from rest_framework import status
-
-STORAGE_LIMIT = 300 * 1024 * 1024
+from django.conf import settings
 from rest_framework.decorators import permission_classes
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
@@ -52,7 +51,7 @@ async def add_file(request) -> Response:
     async for f in File.objects.filter(user=user):
         if f.file:
             total += f.file.size
-    if total + file_size > STORAGE_LIMIT:
+    if total + file_size > settings.STORAGE_LIMIT:
         raise StorageLimitExceeded()
     request.data['user'] = user.id
     serializer = FileSerializer(data=request.data)
@@ -100,4 +99,4 @@ async def get_storage_usage(request) -> Response:
     async for f in File.objects.filter(user=request.user):
         if f.file:
             total += f.file.size
-    return Response({'used': total, 'limit': STORAGE_LIMIT}, status=status.HTTP_200_OK)
+    return Response({'used': total, 'limit': settings.STORAGE_LIMIT}, status=status.HTTP_200_OK)

--- a/backend/apps/filehost/tests/test_storage_limit.py
+++ b/backend/apps/filehost/tests/test_storage_limit.py
@@ -1,0 +1,25 @@
+import pytest
+from django.core.files.uploadedfile import SimpleUploadedFile
+from rest_framework.test import APIRequestFactory
+from django.conf import settings
+
+from apps.filehost.controllers.base import upload_files
+from apps.filehost.exceptions.base import StorageLimitExceeded
+from apps.core.models import User
+from apps.filehost.models import File
+
+
+@pytest.mark.django_db
+@pytest.mark.asyncio
+async def test_upload_files_respects_limit():
+    settings.STORAGE_LIMIT = 10
+    user = await User.objects.acreate(username='u1')
+    await File.objects.acreate(
+        file=SimpleUploadedFile('f1.txt', b'12345'), user=user
+    )
+    factory = APIRequestFactory()
+    upload = SimpleUploadedFile('f2.txt', b'1234567')
+    request = factory.post('/filehost/files/upload/', {'files': [upload]}, format='multipart')
+    request.user = user
+    with pytest.raises(StorageLimitExceeded):
+        await upload_files(request)

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -23,6 +23,9 @@ from config.modules.third_party_services import *
 from config.modules.ws import *
 from config.modules.xl_dashboard import *
 
+# Maximum total storage allowed for user file uploads (in bytes)
+STORAGE_LIMIT = 300 * 1024 * 1024  # 300 MB
+
 log = logging.getLogger('global')
 log.info('#####################################')
 log.info('########## Server Settings ##########')


### PR DESCRIPTION
## Summary
- define `STORAGE_LIMIT` in configuration
- use `settings.STORAGE_LIMIT` in filehost controllers
- add a regression test for upload limit

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686e95fd3004833094fc6b7d72a24d6f