### PR TITLE
Implement software order pricing override

### DIFF
--- a/backend/apps/software/services/order.py
+++ b/backend/apps/software/services/order.py
@@ -1,6 +1,30 @@
 # software/services/order.py
+from decimal import Decimal
+
 from apps.commerce.services.order.base import OrderService
+from apps.software.services.license import SoftwareLicenseService
 
 
 class SoftwareOrderService(OrderService):
-    pass
+    @property
+    async def receipt_price(self: 'SoftwareOrder') -> Decimal:
+        price_row = await self.product.prices.agetorn(currency=self.currency)  # noqa
+        if not price_row:
+            return Decimal('0')
+
+        amount = float(price_row.amount)
+        exponent = float(price_row.exponent or 1.0)
+        offset = float(price_row.offset or 0.0)
+
+        final_cost_int = SoftwareLicenseService.calculate_price(
+            hours=self.license_hours,
+            amount=amount,
+            exponent=exponent,
+            offset=offset,
+        )
+        price = Decimal(str(final_cost_int))
+
+        if self.promocode:
+            price = await self.promocode.calc_price_for_order(order=self)
+
+        return price


### PR DESCRIPTION
## Summary
- simplify default order service receipt price calculation
- add software-specific pricing logic in `SoftwareOrderService`
- test software license order pricing

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686ec1ab9dc08330b84a48cfc67a5e8c