### PR TITLE
Auto register order serializers

### DIFF
--- a/backend/apps/commerce/serializers/order.py
+++ b/backend/apps/commerce/serializers/order.py
@@ -2,6 +2,8 @@
 from adjango.aserializers import AModelSerializer
 from rest_framework.fields import SerializerMethodField
 
+from apps.commerce.serializers.order_registry import RegisterOrderSerializerMeta
+
 from apps.ckassa.models import CKassaPayment
 from apps.ckassa.serializers import CKassaPaymentSmallPublicSerializer
 from apps.cloudpayments.models import CloudPaymentPayment
@@ -27,7 +29,7 @@ class BalancePaymentSmallPublicSerializer(BasePaymentSerializer):
         fields = BasePaymentSerializer.Meta.fields
 
 
-class BaseOrderSerializer(AModelSerializer):
+class BaseOrderSerializer(AModelSerializer, metaclass=RegisterOrderSerializerMeta):
     payment = SerializerMethodField()
     promocode = PromocodeSerializer(read_only=True)
 

--- a/backend/apps/commerce/serializers/order_registry.py
+++ b/backend/apps/commerce/serializers/order_registry.py
@@ -2,29 +2,22 @@
 from collections import OrderedDict
 
 from apps.commerce.exceptions.order import OrderException
-from apps.commerce.models import BalanceProductOrder
-from apps.commerce.serializers.balance import BalanceProductOrderSerializer
-from apps.software.models import SoftwareOrder
-from apps.software.serializers import SoftwareOrderSerializer
 
-ORDER_SERIALIZERS = OrderedDict([
-    (SoftwareOrder, {
-        'small': SoftwareOrderSerializer,
-        'full': SoftwareOrderSerializer,
-    }),
-    (BalanceProductOrder, {
-        'small': BalanceProductOrderSerializer,
-        'full': BalanceProductOrderSerializer,
-    }),
-    # (DonateOrder, {
-    #     'small': DonateOrderSerializer,
-    #     'full': DonateOrderSerializer,
-    # }),
-    # (GiftCertificateOrder, {
-    #     'small': SoftwareOrderSerializer,
-    #     'full': SoftwareOrderSerializer,
-    # }),
-])
+
+ORDER_SERIALIZERS: dict = OrderedDict()
+
+
+class RegisterOrderSerializerMeta(type):
+    """Metaclass that automatically registers order serializers."""
+
+    def __new__(mcls, name, bases, attrs):
+        cls = super().__new__(mcls, name, bases, attrs)
+        meta = attrs.get('Meta')
+        model = getattr(meta, 'model', None)
+        if model:
+            ORDER_SERIALIZERS.setdefault(model, {})['small'] = cls
+            ORDER_SERIALIZERS.setdefault(model, {})['full'] = cls
+        return cls
 
 
 def get_order_serializer(order_instance, serializer_type='small'):


### PR DESCRIPTION
## Summary
- add a registration metaclass for order serializers
- use the metaclass in BaseOrderSerializer

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686e9e1cae2483308ae05ce9a46e4eff