### PR TITLE
Add generic typing for order services

### DIFF
--- a/backend/apps/commerce/services/balance.py
+++ b/backend/apps/commerce/services/balance.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from adrf.requests import AsyncRequest
 
 
-class BalanceProductService(IProductService):
+class BalanceProductService(IProductService['BalanceProductOrder']):
     @staticmethod
     async def new_order(request: 'AsyncRequest') -> 'BalanceProductOrder':
         from apps.commerce.serializers.balance import BalanceProductOrderCreateSerializer
@@ -34,7 +34,7 @@ class BalanceProductService(IProductService):
         await user.asave()
 
 
-class BalanceProductOrderService(OrderService):
+class BalanceProductOrderService(OrderService['BalanceProductOrder']):
     @property
     async def receipt_price(self: 'BalanceProductOrder') -> Decimal:
         return self.requested_amount

--- a/backend/apps/commerce/services/gift_certificate.py
+++ b/backend/apps/commerce/services/gift_certificate.py
@@ -7,12 +7,12 @@ if TYPE_CHECKING:
     from apps.commerce.models import GiftCertificate, GiftCertificateOrder
 
 
-class GiftCertificateService(IProductService):
+class GiftCertificateService(IProductService['GiftCertificateOrder']):
     @staticmethod
     async def new_order(
             request
     ) -> 'GiftCertificateOrder':
-        pass
+        raise NotImplementedError
         # from apps.serializers.gift_certificate import GiftCertificateOrderCreateSerializer
         # s = GiftCertificateOrderCreateSerializer(
         #     data=request.data, context={'request': request}
@@ -37,7 +37,8 @@ class GiftCertificateService(IProductService):
 
     async def can_pregive(self: 'GiftCertificate',
                           order: 'GiftCertificateOrder',
-                          raise_exceptions=False) -> bool: pass
+                          raise_exceptions=False) -> bool:
+        raise NotImplementedError
 
     async def pregive(self: 'GiftCertificate', order: 'GiftCertificateOrder'):
         pass

--- a/backend/apps/commerce/services/product.py
+++ b/backend/apps/commerce/services/product.py
@@ -1,12 +1,16 @@
 # commerce/services/product.py
+from __future__ import annotations
+
 from abc import abstractmethod
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Protocol, TypeVar
 
 if TYPE_CHECKING:
     from apps.commerce.models import Order, Product
 
+O = TypeVar('O', bound='Order')
 
-class IProductService:
+
+class IProductService(Protocol[O]):
     """
     Интерфейс-сервис для работы с продуктами, который реализует общие шаги
     для выдачи продуктов. Этот класс должен быть унаследован конкретными
@@ -18,23 +22,23 @@ class IProductService:
     @abstractmethod
     async def new_order(
             request
-    ) -> 'Order':
+    ) -> O:
         pass
 
     @abstractmethod
-    async def cancel_given(self, request, order: 'Order', reason: str):
+    async def cancel_given(self, request, order: O, reason: str):
         """Отменяем выдачу товара"""
         pass
 
     @abstractmethod
-    async def can_pregive(self: 'Product', order: 'Order', raise_exceptions=False) -> bool:
+    async def can_pregive(self: 'Product', order: O, raise_exceptions=False) -> bool:
         """
         Можем ли мы сделать начальную инициализацию продукта у клиента?
         """
         pass
 
     @abstractmethod
-    async def pregive(self: 'Product', order: 'Order'):
+    async def pregive(self: 'Product', order: O):
         """
         Подготовка к выдаче продукта до завершения оплаты.
         Выполняет все начальные действия перед оплатой.
@@ -42,7 +46,7 @@ class IProductService:
         pass
 
     @abstractmethod
-    async def postgive(self: 'Product', order: 'Order'):
+    async def postgive(self: 'Product', order: O):
         """
         Завершение выдачи продукта после оплаты.
         Выполняет действия для завершения процесса выдачи.

--- a/backend/apps/software/services/order.py
+++ b/backend/apps/software/services/order.py
@@ -1,6 +1,10 @@
 # software/services/order.py
 from apps.commerce.services.order.base import OrderService
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from apps.software.models import SoftwareOrder
 
 
-class SoftwareOrderService(OrderService):
+class SoftwareOrderService(OrderService['SoftwareOrder']):
     pass

--- a/backend/apps/software/services/software.py
+++ b/backend/apps/software/services/software.py
@@ -3,6 +3,8 @@ import logging
 from datetime import timedelta
 from typing import TYPE_CHECKING
 
+from apps.commerce.services.product import IProductService
+
 from django.utils import timezone
 
 if TYPE_CHECKING:
@@ -11,7 +13,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class SoftwareService:
+class SoftwareService(IProductService['SoftwareOrder']):
     async def new_order(self: 'Software', request) -> 'SoftwareOrder':
         from apps.software.serializers import SoftwareOrderCreateSerializer
         from apps.software.models import SoftwareOrder

--- a/backend/apps/xlmine/services/donate.py
+++ b/backend/apps/xlmine/services/donate.py
@@ -2,6 +2,9 @@
 from decimal import Decimal
 from typing import TYPE_CHECKING
 
+from apps.commerce.services.product import IProductService
+from apps.commerce.services.order.base import OrderService
+
 from django.db.models import Sum
 
 if TYPE_CHECKING:
@@ -15,7 +18,7 @@ class UserDonateService:
         return (await self.donate_orders.aaggregate(total=Sum('payment__amount')))['total'] or Decimal(0)
 
 
-class DonateService:
+class DonateService(IProductService['DonateOrder']):
     """
      Логика для «донатного» продукта.
      """
@@ -84,5 +87,5 @@ class DonateService:
         pass
 
 
-class DonateOrderService:
+class DonateOrderService(OrderService['DonateOrder']):
     pass


### PR DESCRIPTION
## Summary
- add `TypeVar` for order types
- make `OrderService` and `IProductService` generic
- apply generics to product/order service mixins
- update stubs for gift certificates
- adjust imports for typing

## Testing
- `poetry run mypy --ignore-missing-imports backend/apps/commerce/services/product.py backend/apps/commerce/services/order/base.py backend/apps/commerce/services/balance.py backend/apps/software/services/software.py backend/apps/software/services/order.py backend/apps/xlmine/services/donate.py backend/apps/commerce/services/gift_certificate.py`

------
https://chatgpt.com/codex/tasks/task_e_686ec1ab59bc8330a28e79c267be59b0