### PR TITLE
Refactor payment sync architecture

### DIFF
--- a/backend/apps/ckassa/providers.py
+++ b/backend/apps/ckassa/providers.py
@@ -63,3 +63,14 @@ class CKassaProvider(BasePaymentProvider):
         )
 
         return payment
+
+    async def sync(self, payment: CKassaPayment) -> None:
+        from .services.payment import CKassaPaymentService
+
+        if not isinstance(payment, CKassaPayment):
+            return
+
+        status = await CKassaPaymentService.actual_status(payment.reg_pay_num)
+        if status and status != payment.status:
+            payment.status = status
+            await payment.asave()

--- a/backend/apps/commerce/providers/balance.py
+++ b/backend/apps/commerce/providers/balance.py
@@ -27,3 +27,6 @@ class BalanceProvider(BasePaymentProvider):
         await payment.asave()
         await self.order.execute()  # noqa
         return payment
+
+    async def sync(self, payment: BalancePayment) -> None:
+        return None

--- a/backend/apps/commerce/providers/handmade.py
+++ b/backend/apps/commerce/providers/handmade.py
@@ -28,3 +28,6 @@ class HandMadeProvider(BasePaymentProvider):
         except Exception as exc:
             raise PaymentException.InitError(f'HandMade init error: {exc}') from exc
         return payment
+
+    async def sync(self, payment: HandMadePayment) -> None:
+        return None


### PR DESCRIPTION
## Summary
- move payment system branching out of `OrderService.sync_with_payment_system`
- implement `sync` for payment providers

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686f35ea68a88330b38ce3c352899148