### PR TITLE
Add generic typing for commerce services

### DIFF
--- a/backend/apps/commerce/services/balance.py
+++ b/backend/apps/commerce/services/balance.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from adrf.requests import AsyncRequest
 
 
-class BalanceProductService(IProductService):
+class BalanceProductService(IProductService['BalanceProduct', 'BalanceProductOrder']):
     @staticmethod
     async def new_order(request: 'AsyncRequest') -> 'BalanceProductOrder':
         from apps.commerce.serializers.balance import BalanceProductOrderCreateSerializer
@@ -34,7 +34,7 @@ class BalanceProductService(IProductService):
         await user.asave()
 
 
-class BalanceProductOrderService(OrderService):
+class BalanceProductOrderService(OrderService['BalanceProductOrder', 'BalanceProduct']):
     @property
     async def receipt_price(self: 'BalanceProductOrder') -> Decimal:
         return self.requested_amount

--- a/backend/apps/commerce/services/gift_certificate.py
+++ b/backend/apps/commerce/services/gift_certificate.py
@@ -7,7 +7,7 @@ if TYPE_CHECKING:
     from apps.commerce.models import GiftCertificate, GiftCertificateOrder
 
 
-class GiftCertificateService(IProductService):
+class GiftCertificateService(IProductService['GiftCertificate', 'GiftCertificateOrder']):
     @staticmethod
     async def new_order(
             request

--- a/backend/apps/commerce/services/product.py
+++ b/backend/apps/commerce/services/product.py
@@ -1,12 +1,15 @@
 # commerce/services/product.py
 from abc import abstractmethod
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Generic, TypeVar, Protocol
 
 if TYPE_CHECKING:
     from apps.commerce.models import Order, Product
 
+OrderT = TypeVar('OrderT', bound='Order')
+ProductT = TypeVar('ProductT', bound='Product')
 
-class IProductService:
+
+class IProductService(Protocol, Generic[ProductT, OrderT]):
     """
     Интерфейс-сервис для работы с продуктами, который реализует общие шаги
     для выдачи продуктов. Создания заказа под продукт и т.д. Этот класс должен быть унаследован конкретными
@@ -18,23 +21,23 @@ class IProductService:
     @abstractmethod
     async def new_order(
             request
-    ) -> 'Order': # Тут неверная типизация, потому что на самом деле мы получим одного оиз наследников Order, я не знаю как правильно протипизировать
+    ) -> OrderT:
         pass
 
     @abstractmethod
-    async def cancel_given(self, request, order: 'Order', reason: str):
+    async def cancel_given(self: ProductT, request, order: OrderT, reason: str):
         """Отменяем выдачу товара"""
         pass
 
     @abstractmethod
-    async def can_pregive(self: 'Product', order: 'Order', raise_exceptions=False) -> bool:
+    async def can_pregive(self: ProductT, order: OrderT, raise_exceptions=False) -> bool:
         """
         Можем ли мы сделать начальную инициализацию продукта у клиента?
         """
         pass
 
     @abstractmethod
-    async def pregive(self: 'Product', order: 'Order'):
+    async def pregive(self: ProductT, order: OrderT):
         """
         Подготовка к выдаче продукта до завершения оплаты.
         Выполняет все начальные действия перед оплатой.
@@ -42,7 +45,7 @@ class IProductService:
         pass
 
     @abstractmethod
-    async def postgive(self: 'Product', order: 'Order'):
+    async def postgive(self: ProductT, order: OrderT):
         """
         Завершение выдачи продукта после оплаты.
         Выполняет действия для завершения процесса выдачи.

--- a/backend/apps/software/services/order.py
+++ b/backend/apps/software/services/order.py
@@ -5,7 +5,7 @@ from apps.commerce.services.order.base import OrderService
 from apps.software.services.license import SoftwareLicenseService
 
 
-class SoftwareOrderService(OrderService):
+class SoftwareOrderService(OrderService['SoftwareOrder', 'Software']):
     @property
     async def receipt_price(self: 'SoftwareOrder') -> Decimal:
         price_row = await self.product.prices.agetorn(currency=self.currency)  # noqa

--- a/backend/apps/software/services/software.py
+++ b/backend/apps/software/services/software.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class SoftwareService(IProductService):
+class SoftwareService(IProductService['Software', 'SoftwareOrder']):
     async def new_order(self: 'Software', request) -> 'SoftwareOrder':
         from apps.software.serializers import SoftwareOrderCreateSerializer
         from apps.software.models import SoftwareOrder

--- a/backend/apps/xlmine/services/donate.py
+++ b/backend/apps/xlmine/services/donate.py
@@ -15,7 +15,10 @@ class UserDonateService:
         return (await self.donate_orders.aaggregate(total=Sum('payment__amount')))['total'] or Decimal(0)
 
 
-class DonateService:
+from apps.commerce.services.product import IProductService
+
+
+class DonateService(IProductService['Donate', 'DonateOrder']):
     """
      Логика для «донатного» продукта.
      """
@@ -84,5 +87,8 @@ class DonateService:
         pass
 
 
-class DonateOrderService:
+from apps.commerce.services.order.base import OrderService
+
+
+class DonateOrderService(OrderService['DonateOrder', 'Donate']):
     pass


### PR DESCRIPTION
## Summary
- declare generic protocol `IProductService`
- add generics to `OrderService`
- specialize service subclasses with concrete generic types

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686f3e75a8d08330a742a4661b60925b