### PR TITLE
Add related manager type hints

### DIFF
--- a/backend/apps/commerce/models/product.py
+++ b/backend/apps/commerce/models/product.py
@@ -4,6 +4,7 @@ from decimal import Decimal
 from adjango.models import APolymorphicModel
 from adjango.models.mixins import ACreatedUpdatedAtIndexedMixin
 from django.db.models import CharField, TextField, ForeignKey, CASCADE, BooleanField, DecimalField
+from typing import TYPE_CHECKING
 from django.utils.translation import gettext_lazy as _
 from imagekit.models import ProcessedImageField
 from pilkit.processors import ResizeToFit
@@ -11,8 +12,13 @@ from pilkit.processors import ResizeToFit
 from apps.commerce.models.payment import ACurrencyAmountMixin
 from utils.pictures import CorrectOrientation
 
+if TYPE_CHECKING:
+    from django.db.models.manager import RelatedManager
+    from apps.commerce.models.product import ProductPrice
+
 
 class Product(APolymorphicModel, ACreatedUpdatedAtIndexedMixin):
+    prices: RelatedManager['ProductPrice']
     name = CharField(verbose_name=_('Name'), max_length=255, db_index=True)
     pic = ProcessedImageField(
         verbose_name=_('Picture'),

--- a/backend/apps/core/models/user.py
+++ b/backend/apps/core/models/user.py
@@ -1,5 +1,6 @@
 # core/models/user.py
 import uuid
+from typing import TYPE_CHECKING
 
 from adjango.fields import AManyToManyField
 from adjango.models.base import AAbstractUser, AModel
@@ -22,6 +23,10 @@ from apps.xlmine.services.donate import UserDonateService
 from apps.xlmine.services.privilege import UserPrivilegeService
 from apps.xlmine.services.user import UserXLMineService
 from utils.pictures import CorrectOrientation
+
+if TYPE_CHECKING:
+    from django.db.models.manager import RelatedManager
+    from apps.commerce.models.payment import Payment
 
 
 def generate_custom_key() -> str: return uuid.uuid4().hex[:20]
@@ -52,6 +57,8 @@ class User(
         EN = 'en', _('English')
 
     objects = UserManager()
+
+    payments: RelatedManager['Payment']
 
     password = CharField(_('Password'), max_length=128, blank=True)
     email = EmailField(_('Email'), blank=True, null=True, db_index=True)

--- a/backend/apps/software/models/software.py
+++ b/backend/apps/software/models/software.py
@@ -1,5 +1,6 @@
 # software/models/software.py
 import logging
+from typing import TYPE_CHECKING
 
 from adjango.models.mixins import ACreatedUpdatedAtIndexedMixin, ACreatedAtIndexedMixin
 from django.db.models import (
@@ -17,6 +18,10 @@ from apps.software.services.license import SoftwareLicenseService
 from apps.software.services.order import SoftwareOrderService
 from apps.software.services.software import SoftwareService
 
+if TYPE_CHECKING:
+    from django.db.models.manager import RelatedManager
+    from apps.commerce.models.product import ProductPrice
+
 log = logging.getLogger('global')
 
 
@@ -33,6 +38,7 @@ class SoftwareFile(ACreatedAtIndexedMixin):
 
 
 class Software(Product, SoftwareService, SoftwareException):
+    prices: RelatedManager['ProductPrice']
     file = OneToOneField(
         'software.SoftwareFile', SET_NULL,
         null=True, blank=True, verbose_name=_('File')


### PR DESCRIPTION
## Summary
- add `payments` related manager for User model
- add `prices` related manager for Product model
- type annotate Software with ProductPrice related manager

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686f4e5b49dc83309c851134c88b6124