### PR TITLE
Add abstract methods to ConfirmationCodeService

### DIFF
--- a/backend/apps/confirmation/services/base.py
+++ b/backend/apps/confirmation/services/base.py
@@ -2,6 +2,7 @@
 import logging
 from datetime import timedelta
 from typing import TYPE_CHECKING, Union
+from abc import ABC, abstractmethod
 
 from adjango.utils.base import AsyncAtomicContextManager, diff_by_timedelta
 from adrf.requests import AsyncRequest
@@ -51,7 +52,19 @@ async def get_confirmation_code_instance(
     return confirmation_models[method]
 
 
-class ConfirmationCodeService:
+class ConfirmationCodeService(ABC):
+    @classmethod
+    @abstractmethod
+    def get_confirmation_method(cls) -> str:
+        ...
+
+    @classmethod
+    @abstractmethod
+    async def send_code(
+        cls, code: str, action: ConfirmationAction,
+        user: 'User', extra_data: dict | None = None
+    ) -> None:
+        ...
     @staticmethod
     async def create_and_send(
             request: AsyncRequest | WSGIRequest | ASGIRequest,

--- a/backend/apps/confirmation/services/email.py
+++ b/backend/apps/confirmation/services/email.py
@@ -11,14 +11,16 @@ if TYPE_CHECKING: pass
 
 
 class EmailConfirmationCodeService(ConfirmationCodeService):
-    @staticmethod
-    def get_confirmation_method() -> str:
+    @classmethod
+    def get_confirmation_method(cls) -> str:
         return 'email'
 
-    @staticmethod
-    async def send_code(code: str, action: ConfirmationAction,
-                        user: settings.AUTH_USER_MODEL,
-                        extra_data: dict = None) -> None:
+    @classmethod
+    async def send_code(
+        cls, code: str, action: ConfirmationAction,
+        user: settings.AUTH_USER_MODEL,
+        extra_data: dict | None = None
+    ) -> None:
         from apps.confirmation.tasks.tasks import send_confirmation_code_to_email_task
         if not user.email: raise UserException.EmailDoesNotExists()
         if extra_data:

--- a/backend/apps/confirmation/services/phone.py
+++ b/backend/apps/confirmation/services/phone.py
@@ -11,14 +11,16 @@ if TYPE_CHECKING: pass
 
 
 class PhoneConfirmationCodeService(ConfirmationCodeService):
-    @staticmethod
-    def get_confirmation_method() -> str:
+    @classmethod
+    def get_confirmation_method(cls) -> str:
         return 'phone'
 
-    @staticmethod
-    async def send_code(code: str, action: ConfirmationAction,
-                        user: settings.AUTH_USER_MODEL,
-                        extra_data: dict = None) -> None:
+    @classmethod
+    async def send_code(
+        cls, code: str, action: ConfirmationAction,
+        user: settings.AUTH_USER_MODEL,
+        extra_data: dict | None = None
+    ) -> None:
         from apps.confirmation.tasks.tasks import send_confirmation_code_to_phone_task
         if not user.phone: raise UserException.PhoneDoesNotExists()
         if extra_data:


### PR DESCRIPTION
## Summary
- define ConfirmationCodeService as an abstract base class
- declare abstract `get_confirmation_method` and `send_code`
- update email and phone services to implement these class methods

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686f4e5bb3048330b8458f801d9b5ef6