### PR TITLE
Fix instance attribute errors

### DIFF
--- a/backend/apps/confirmation/services/base.py
+++ b/backend/apps/confirmation/services/base.py
@@ -52,6 +52,7 @@ async def get_confirmation_code_instance(
 
 
 class ConfirmationCodeService:
+    is_used: bool
     @classmethod
     def get_confirmation_method(cls) -> str:
         raise NotImplementedError
@@ -147,7 +148,7 @@ class ConfirmationCodeService:
     async def make_action(self: 'ConfirmationCode', **kwargs) -> ConfirmationResult:
         async with AsyncAtomicContextManager():
             func = self.get_action_func()
-            self.is_used = True  # TODO: Instance attribute is_used defined outside __init__
+            self.is_used = True
             await self.asave()
             result = await func(self, **kwargs)
             return ConfirmationResult(result=result, action=self.action)

--- a/backend/apps/notify/services/notify.py
+++ b/backend/apps/notify/services/notify.py
@@ -18,6 +18,9 @@ if TYPE_CHECKING:
 
 
 class NotifyService:
+    status: str
+    sent_time: timezone.datetime | None
+
     def send(self: 'Notify') -> None:
         from apps.notify.registry import NOTIFY_CONFIGS, Notifies
         from apps.notify.providers.base import INotifyProvider
@@ -53,13 +56,13 @@ class NotifyService:
                     )
 
             self.status = self.Status.SENT
-            self.sent_time = timezone.now()  # TODO: Instance attribute sent_time defined outside __init__
+            self.sent_time = timezone.now()
             self.save(update_fields=['status', 'sent_time'])
             log.info(f'Notification id={self.id} sent successfully')
 
         except Exception as e:
             log.error(f'Failed to send notification {self.id}: {traceback_str(e)}')
-            self.status = self.Status.FAILED  # TODO: Instance attribute status defined outside __init__
+            self.status = self.Status.FAILED
             self.save(update_fields=['status'])
 
     async def asend(self: 'Notify') -> None:

--- a/backend/apps/tbank/services/installment.py
+++ b/backend/apps/tbank/services/installment.py
@@ -27,6 +27,9 @@ class TBankInstallmentService:
     реализует методы Create / Commit / Cancel / Info
     по API Тинькофф Формы.
     """
+    status: str
+    payment_url: str | None
+    committed: bool
 
     @property
     def shop_id(self) -> str:
@@ -122,8 +125,8 @@ class TBankInstallmentService:
           'id' = ID заявки в TCB
           'link' = ссылка на форму
         """
-        self.status = TBankInstallmentStatus.NEW  # TODO: Instance attribute status defined outside __init__
-        self.payment_url = response_data.get('link')  # TODO: Instance attribute payment_url defined outside __init__
+        self.status = TBankInstallmentStatus.NEW
+        self.payment_url = response_data.get('link')
         await self.asave()
         return response_data  # может пригодиться
 
@@ -139,9 +142,9 @@ class TBankInstallmentService:
         resp = await self._post_json(url, data={}, headers=headers)
 
         # resp содержит {'status': '...', 'committed': ..., ...}
-        self.status = resp.get('status', self.status)  # TODO: Instance attribute status defined outside __init__
+        self.status = resp.get('status', self.status)
         self.committed = bool(
-            resp.get('committed', False))  # TODO: Instance attribute committed defined outside __init__
+            resp.get('committed', False))
         await self.asave()
         return resp
 
@@ -156,9 +159,9 @@ class TBankInstallmentService:
         headers = self._basic_auth_headers()
         resp = await self._post_json(url, data={}, headers=headers)
 
-        self.status = resp.get('status', self.status)  # TODO: Instance attribute status defined outside __init__
+        self.status = resp.get('status', self.status)
         self.committed = bool(
-            resp.get('committed', False))  # TODO: Instance attribute committed defined outside __init__
+            resp.get('committed', False))
         await self.asave()
         return resp
 
@@ -173,8 +176,8 @@ class TBankInstallmentService:
         headers = self._basic_auth_headers()
         resp = await self._get_json(url, headers=headers)
 
-        self.status = resp.get('status', self.status)  # TODO: Instance attribute status defined outside __init__
+        self.status = resp.get('status', self.status)
         self.committed = bool(
-            resp.get('committed', False))  # TODO: Instance attribute committed defined outside __init__
+            resp.get('committed', False))
         await self.asave()
         return resp

--- a/backend/apps/tbank/services/payment.py
+++ b/backend/apps/tbank/services/payment.py
@@ -11,6 +11,7 @@ class TBankPaymentService(BasePaymentService):
     """
     Логика TBank‑платежей, приведена к унифицированному контракту.
     """
+    status: str
 
     @staticmethod
     async def actual_status(payment_id: int) -> str | None:
@@ -23,7 +24,7 @@ class TBankPaymentService(BasePaymentService):
         if self.status == self.Status.CANCELED:
             raise PaymentAlreadyCanceled()
         await TBank().Cancel(payment_id=str(self.id))
-        self.status = self.Status.CANCELED  # TODO: Instance attribute status defined outside __init__
+        self.status = self.Status.CANCELED
         await self.asave()
         log.info('[TBank] Payment %s canceled', self.id)
 

--- a/backend/apps/xlmine/consumers/eco.py
+++ b/backend/apps/xlmine/consumers/eco.py
@@ -14,24 +14,30 @@ class BalanceConsumer(AsyncJsonWebsocketConsumer):
     далее слушает изменения по монетам.
     """
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.jwt_token: str | None = None
+        self.user: User | None = None
+        self.group_name: str | None = None
+
     async def connect(self):
         # Пример: ждём токен в query string: ?token=<JWT_ACCESS>
         self.jwt_token = self.scope['query_string'].decode('utf-8').replace('token=',
-                                                                            '')  # TODO: Instance attribute jwt_token defined outside __init__
+                                                                            '')
         if not self.jwt_token:
             await self.close()
             return
 
         # Проверяем JWT
         try:
-            self.user = await self._get_user(self.jwt_token)  # TODO: Instance attribute user defined outside __init__
+            self.user = await self._get_user(self.jwt_token)
         except AuthenticationFailed:
             await self.close()
             return
 
         # Подключаемся
         await self.accept()
-        self.group_name = f'user_{self.user.id}'  # TODO: Instance attribute group_name defined outside __init__
+        self.group_name = f'user_{self.user.id}'
         await self.channel_layer.group_add(self.group_name, self.channel_name)
         # Можно отправить initial-сообщение
         await self.send_json({


### PR DESCRIPTION
## Summary
- define missing instance attributes in consumers and services
- remove TODO comments and initialize attributes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686f6dfa54e483308b43f64e075d021d