### PR TITLE
Refactor order/product services

### DIFF
--- a/backend/apps/ckassa/controllers/api.py
+++ b/backend/apps/ckassa/controllers/api.py
@@ -58,7 +58,7 @@ async def notification(request):
     await order.asave()
 
     try:
-        await order.execute()
+        await order.service.execute()
     except Exception:  # noqa
         log.warning('CKassa payment for order %s failed', order_id, exc_info=True)
 

--- a/backend/apps/cloudpayments/controllers/api.py
+++ b/backend/apps/cloudpayments/controllers/api.py
@@ -60,7 +60,7 @@ async def success(request):
         await payment.asave()
 
         try:
-            await order.execute()
+            await order.service.execute()
         except _OrderException.AlreadyExecuted:
             pass
 

--- a/backend/apps/commerce/admin/order.py
+++ b/backend/apps/commerce/admin/order.py
@@ -71,8 +71,11 @@ class OrderAdmin(ImportExportModelAdmin, PolymorphicParentModelAdmin):
             detail = getattr(e, 'detail', None)
             if detail and isinstance(detail, dict) and 'message' in detail:
                 # Если есть detail и в нем есть message, используем его
-                self.message_user(request, f'Ошибка при обработке заказа {order.id}: {detail['message']}',
-                                  level=messages.ERROR)
+                self.message_user(
+                    request,
+                    f"Ошибка при обработке заказа {order.id}: {detail['message']}",
+                    level=messages.ERROR,
+                )
                 return
         # Если нет detail или message - используем текст исключения
         self.message_user(request, f'Ошибка при обработке заказа {order.id}: {str(e)}', level=messages.ERROR)
@@ -116,7 +119,7 @@ class OrderAdmin(ImportExportModelAdmin, PolymorphicParentModelAdmin):
             for order in queryset:
                 log.info(f'Отмена заказа {order.id}')
                 try:
-                    async_to_sync(order.get_real_instance().safe_cancel)(request, '')
+                    async_to_sync(order.get_real_instance().service.safe_cancel)(request, '')
                 except Exception as e:
                     self._handle_exception_message(request, order, e)
             self.message_user(request, 'Заказы успешно отменены.')

--- a/backend/apps/commerce/controllers/order.py
+++ b/backend/apps/commerce/controllers/order.py
@@ -97,7 +97,7 @@ async def order_detail(request, id):
 async def order_execute(_request, id):
     order = await Order.objects.agetorn(_OrderException.NotFound, id=id)
     async with AsyncAtomicContextManager():
-        await order.execute()
+        await order.service.execute()
     serializer_class = get_order_serializer(order, 'full')
     return Response(await serializer_class(order).adata, status=HTTP_200_OK)
 
@@ -117,7 +117,7 @@ async def order_delete(_request, id):
 async def order_init(request, id, init_payment):
     order = await Order.objects.agetorn(_OrderException.NotFound, id=id)
     async with AsyncAtomicContextManager():
-        await order.init(request, init_payment=bool(init_payment))
+        await order.service.init(request, init_payment=bool(init_payment))
     serializer_class = get_order_serializer(order, 'full')
     return Response(await serializer_class(order).adata, status=HTTP_200_OK)
 
@@ -130,7 +130,7 @@ async def order_cancel(request, id):
         _OrderException.NotFound, id=id, user=request.user
     )
     async with AsyncAtomicContextManager():
-        await order.safe_cancel(request=request, reason='')
+        await order.service.safe_cancel(request=request, reason='')
         if isinstance(order, SoftwareOrder):
             return Response(await SoftwareOrderSerializer(order).adata, status=HTTP_200_OK)
         raise _OrderException.UnknownOrderInstance()

--- a/backend/apps/commerce/controllers/tbank/installment_notification.py
+++ b/backend/apps/commerce/controllers/tbank/installment_notification.py
@@ -56,7 +56,7 @@ async def installment_notification(request):
 
         try:
             log.info('Stage #16 (Installment) => order.execute()')
-            await order.execute()
+            await order.service.execute()
         except _OrderException.AlreadyExecuted:
             log.info('Stage #17 (Installment) => AlreadyExecuted pass')
 

--- a/backend/apps/commerce/controllers/tbank/notification.py
+++ b/backend/apps/commerce/controllers/tbank/notification.py
@@ -50,7 +50,7 @@ async def notification(request):
             await request.order.payment.asave()
             try:
                 log.info('Stage #22')
-                await request.order.execute()
+                await request.order.service.execute()
             except _OrderException.AlreadyExecuted:
                 log.info('Stage #23')
                 pass

--- a/backend/apps/commerce/managers/order.py
+++ b/backend/apps/commerce/managers/order.py
@@ -14,4 +14,5 @@ class OrderBaseManager(APolymorphicManager):
                 is_inited=False, is_executed=False,
                 is_paid=False, is_cancelled=False,
                 is_refunded=False
-        ): await order.safe_cancel()
+        ):
+            await order.service.safe_cancel()

--- a/backend/apps/commerce/models/balance.py
+++ b/backend/apps/commerce/models/balance.py
@@ -6,7 +6,7 @@ from apps.commerce.models.product import Product
 from apps.commerce.services.balance import BalanceProductService, BalanceProductOrderService
 
 
-class BalanceProduct(Product, BalanceProductService):
+class BalanceProduct(Product):
     class Meta:
         verbose_name = _('Balance product')
         verbose_name_plural = _('Balance products')
@@ -14,11 +14,19 @@ class BalanceProduct(Product, BalanceProductService):
     def __str__(self):
         return 'Balance top up'
 
+    @property
+    def service(self) -> BalanceProductService:
+        return BalanceProductService(self)
 
-class BalanceProductOrder(Order, BalanceProductOrderService):
+
+class BalanceProductOrder(Order):
     product = ForeignKey(BalanceProduct, CASCADE, 'balance_orders', verbose_name=_('Product'))
     requested_amount = DecimalField(_('Requested amount'), max_digits=10, decimal_places=2)
 
     class Meta:
         verbose_name = _('Balance product order')
         verbose_name_plural = _('Balance product orders')
+
+    @property
+    def service(self) -> BalanceProductOrderService:
+        return BalanceProductOrderService(self)

--- a/backend/apps/commerce/models/gift_certificate.py
+++ b/backend/apps/commerce/models/gift_certificate.py
@@ -12,7 +12,7 @@ from .product import Product
 from ..services.gift_certificate import GiftCertificateService, GiftCertificateOrderService
 
 
-class GiftCertificate(Product, GiftCertificateService):
+class GiftCertificate(Product):
     product = ForeignKey('commerce.Product', CASCADE, related_name='gift_certificates')
 
     class Meta:
@@ -22,14 +22,22 @@ class GiftCertificate(Product, GiftCertificateService):
     def __str__(self):
         return f'Gift Certificate for Product:{self.product_id}'
 
+    @property
+    def service(self) -> GiftCertificateService:
+        return GiftCertificateService(self)
 
-class GiftCertificateOrder(Order, GiftCertificateOrderService):
+
+class GiftCertificateOrder(Order):
     key = UUIDField(default=uuid.uuid4, editable=False, unique=True)
     product = ForeignKey(GiftCertificate, CASCADE, verbose_name=_('Product'))
 
     class Meta:
         verbose_name = _('Gift certificate order')
         verbose_name_plural = _('Gift certificate orders')
+
+    @property
+    def service(self) -> GiftCertificateOrderService:
+        return GiftCertificateOrderService(self)
 
 
 class GiftCertificateUsage(ACreatedAtIndexedMixin):

--- a/backend/apps/commerce/providers/balance.py
+++ b/backend/apps/commerce/providers/balance.py
@@ -25,7 +25,7 @@ class BalanceProvider(BasePaymentProvider):
         self.order.is_paid = True
         await self.order.asave()
         await payment.asave()
-        await self.order.execute()
+        await self.order.service.execute()
         return payment
 
     async def sync(self, payment: BalancePayment) -> None:

--- a/backend/apps/commerce/services/balance.py
+++ b/backend/apps/commerce/services/balance.py
@@ -19,25 +19,24 @@ class BalanceService:
 
 
 class BalanceProductService(ProductBaseService['BalanceProduct', 'BalanceProductOrder']):
-    @staticmethod
-    async def new_order(request: 'AsyncRequest') -> 'BalanceProductOrder':
+    async def new_order(self, request: 'AsyncRequest') -> 'BalanceProductOrder':
         from apps.commerce.serializers.balance import BalanceProductOrderCreateSerializer
         s = BalanceProductOrderCreateSerializer(data=request.data, context={'request': request})
         await s.ais_valid(raise_exception=True)
         order: 'BalanceProductOrder' = await s.asave()
-        await order.init(request)
+        await order.service.init(request)
         return order
 
     async def cancel_given(self, request, order: 'BalanceProductOrder', reason: str):
         pass
 
-    async def can_pregive(self: 'BalanceProduct', order: 'BalanceProductOrder', raise_exceptions=False) -> bool:
+    async def can_pregive(self, order: 'BalanceProductOrder', raise_exceptions: bool = False) -> bool:
         return True
 
-    async def pregive(self: 'BalanceProduct', order: 'BalanceProductOrder'):
+    async def pregive(self, order: 'BalanceProductOrder'):
         pass
 
-    async def postgive(self: 'BalanceProduct', order: 'BalanceProductOrder'):
+    async def postgive(self, order: 'BalanceProductOrder'):
         user = await order.arelated('user')
         user.balance = (user.balance or Decimal('0')) + order.requested_amount
         await user.asave()
@@ -45,5 +44,5 @@ class BalanceProductService(ProductBaseService['BalanceProduct', 'BalanceProduct
 
 class BalanceProductOrderService(OrderService['BalanceProductOrder', 'BalanceProduct']):
     @property
-    async def receipt_price(self: 'BalanceProductOrder') -> Decimal:
-        return self.requested_amount
+    async def receipt_price(self) -> Decimal:
+        return self.order.requested_amount

--- a/backend/apps/commerce/services/product.py
+++ b/backend/apps/commerce/services/product.py
@@ -9,32 +9,29 @@ if TYPE_CHECKING:
 
 
 class ProductBaseService(Generic[ProductT, OrderT]):
-    """
-    Интерфейс-сервис для работы с продуктами, который реализует общие шаги
-    для выдачи продуктов. Создания заказа под продукт и т.д. Этот класс должен быть унаследован конкретными
-    сервисами продуктов, которые реализуют свою логику для подготовки
-    и завершения выдачи продукта.
-    """
+    """Base service for working with product instances."""
 
-    @staticmethod
+    def __init__(self, product: ProductT) -> None:
+        self.product = product
+
     @abstractmethod
-    async def new_order(request) -> OrderT:
+    async def new_order(self, request) -> OrderT:
         pass
 
     @abstractmethod
-    async def cancel_given(self: ProductT, request, order: OrderT, reason: str):
+    async def cancel_given(self, request, order: OrderT, reason: str):
         """Отменяем выдачу товара"""
         pass
 
     @abstractmethod
-    async def can_pregive(self: ProductT, order: OrderT, raise_exceptions=False) -> bool:
+    async def can_pregive(self, order: OrderT, raise_exceptions: bool = False) -> bool:
         """
         Можем ли мы сделать начальную инициализацию продукта у клиента?
         """
         pass
 
     @abstractmethod
-    async def pregive(self: ProductT, order: OrderT):
+    async def pregive(self, order: OrderT):
         """
         Подготовка к выдаче продукта до завершения оплаты.
         Выполняет все начальные действия перед оплатой.
@@ -42,7 +39,7 @@ class ProductBaseService(Generic[ProductT, OrderT]):
         pass
 
     @abstractmethod
-    async def postgive(self: ProductT, order: OrderT):
+    async def postgive(self, order: OrderT):
         """
         Завершение выдачи продукта после оплаты.
         Выполняет действия для завершения процесса выдачи.
@@ -50,5 +47,5 @@ class ProductBaseService(Generic[ProductT, OrderT]):
         pass
 
     @property
-    async def type(self: 'Product'):
-        return (await self.arelated('polymorphic_ctype')).model
+    async def type(self) -> str:
+        return (await self.product.arelated('polymorphic_ctype')).model

--- a/backend/apps/freekassa/controllers/api.py
+++ b/backend/apps/freekassa/controllers/api.py
@@ -50,7 +50,7 @@ async def notification(request):
     await order.asave()
 
     try:
-        await order.execute()
+        await order.service.execute()
     except Exception:  # noqa
         log.warning('FreeKassa payment for order %s failed', order_id, exc_info=True)
 

--- a/backend/apps/software/models/software.py
+++ b/backend/apps/software/models/software.py
@@ -37,7 +37,7 @@ class SoftwareFile(ACreatedAtIndexedMixin):
         return f'SoftwareFile: (v{self.version})'
 
 
-class Software(Product, SoftwareService, SoftwareException):
+class Software(Product, SoftwareException):
     prices: Manager['ProductPrice']
     file = OneToOneField(
         'software.SoftwareFile', SET_NULL,
@@ -56,8 +56,12 @@ class Software(Product, SoftwareService, SoftwareException):
     def __str__(self):
         return f'{self.name} (v{self.file.version})' if self.file else self.name
 
+    @property
+    def service(self) -> SoftwareService:
+        return SoftwareService(self)
 
-class SoftwareOrder(Order, SoftwareOrderService):
+
+class SoftwareOrder(Order):
     product = ForeignKey(Software, CASCADE, 'orders', verbose_name=_('Software Product'))
     license_hours = PositiveIntegerField(
         _('License Hours'), default=1,
@@ -68,8 +72,12 @@ class SoftwareOrder(Order, SoftwareOrderService):
         verbose_name = _('Software Order')
         verbose_name_plural = _('Software Orders')
 
+    @property
+    def service(self) -> SoftwareOrderService:
+        return SoftwareOrderService(self)
 
-class SoftwareLicense(ACreatedUpdatedAtIndexedMixin, SoftwareLicenseService, SoftwareLicenseException):
+
+class SoftwareLicense(ACreatedUpdatedAtIndexedMixin, SoftwareLicenseException):
     user = ForeignKey(User, CASCADE, 'software_licenses', verbose_name=_('User'))
     software = ForeignKey(Software, CASCADE, 'licenses', verbose_name=_('Software'))
     license_ends_at = DateTimeField(_('License ends at'), blank=True, null=True)
@@ -82,6 +90,10 @@ class SoftwareLicense(ACreatedUpdatedAtIndexedMixin, SoftwareLicenseService, Sof
 
     def __str__(self):
         return f'{self.user} -> {self.software} (until {self.license_ends_at})'
+
+    @property
+    def service(self) -> SoftwareLicenseService:
+        return SoftwareLicenseService(self)
 
     def is_active(self) -> bool:
         if not self.license_ends_at:

--- a/backend/apps/software/tests/test_services.py
+++ b/backend/apps/software/tests/test_services.py
@@ -27,7 +27,7 @@ async def test_postgive_creates_license_and_extends():
         license_hours=2,
     )
 
-    await software.postgive(order)
+    await software.service.postgive(order)
     license_obj = await SoftwareLicense.objects.aget(user=user, software=software)
     assert license_obj.license_ends_at is not None
     assert abs((license_obj.license_ends_at - timezone.now()) - timedelta(hours=2)) < timedelta(seconds=5)
@@ -40,7 +40,7 @@ async def test_postgive_creates_license_and_extends():
         payment_system=PaymentSystem.HandMade,
         license_hours=3,
     )
-    await software.postgive(order2)
+    await software.service.postgive(order2)
     await license_obj.arefresh_from_db()
     assert abs((license_obj.license_ends_at - prev_end) - timedelta(hours=3)) < timedelta(seconds=5)
 
@@ -58,12 +58,12 @@ async def test_can_pregive_checks():
         payment_system=PaymentSystem.HandMade,
         license_hours=4,
     )
-    assert await software.can_pregive(order) is False
+    assert await software.service.can_pregive(order) is False
     with pytest.raises(Exception):
-        await software.can_pregive(order, raise_exceptions=True)
+        await software.service.can_pregive(order, raise_exceptions=True)
 
     order.license_hours = 6
-    assert await software.can_pregive(order) is True
+    assert await software.service.can_pregive(order) is True
 
 
 @pytest.mark.django_db
@@ -97,4 +97,4 @@ async def test_receipt_price_uses_license_hours():
         )
     )
 
-    assert await order.receipt_price == expected
+    assert await order.service.receipt_price == expected

--- a/backend/apps/xlmine/models/product.py
+++ b/backend/apps/xlmine/models/product.py
@@ -7,7 +7,7 @@ from apps.commerce.models import Product, Order
 from apps.xlmine.services.donate import DonateService, DonateOrderService
 
 
-class Donate(Product, DonateService, ModelApiBaseException):
+class Donate(Product, ModelApiBaseException):
     """
     Продукт «Донат». При покупке данного продукта пользователю начисляются
     внутриигровые коины (coins_amount).
@@ -19,8 +19,12 @@ class Donate(Product, DonateService, ModelApiBaseException):
 
     def __str__(self): return 'Donate'
 
+    @property
+    def service(self) -> DonateService:
+        return DonateService(self)
 
-class DonateOrder(Order, DonateOrderService):
+
+class DonateOrder(Order):
     """
     Заказ на покупку Donate (донат).
     """
@@ -32,3 +36,7 @@ class DonateOrder(Order, DonateOrderService):
 
     def __str__(self):
         return f'DonateOrder:{self.id} [user={self.user_id}]'
+
+    @property
+    def service(self) -> DonateOrderService:
+        return DonateOrderService(self)

--- a/backend/apps/xlmine/tests/test_donate_service.py
+++ b/backend/apps/xlmine/tests/test_donate_service.py
@@ -27,8 +27,8 @@ async def test_postgive_adds_coins_and_recalculates_privilege():
         payment_system=PaymentSystem.HandMade,
     )
 
-    await donate.pregive(order)
-    await donate.postgive(order)
+    await donate.service.pregive(order)
+    await donate.service.postgive(order)
 
     xlm_user = await UserXLMine.objects.aget(user=user)
     assert xlm_user.coins == Decimal('10')


### PR DESCRIPTION
## Summary
- separate `OrderService` and `ProductBaseService` from models
- introduce `.service` property on product and order models
- update services and tests to use new style
- adjust controllers, providers and admin code to call service methods

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for Django and other modules)*

------
https://chatgpt.com/codex/tasks/task_e_6872fcf797bc83308afb59a0902b42d9