### PR TITLE
Refine converter models

### DIFF
--- a/backend/apps/converter/apps.py
+++ b/backend/apps/converter/apps.py
@@ -1,0 +1,8 @@
+from django.apps import AppConfig
+from django.utils.translation import gettext_lazy as _
+
+
+class ConverterConfig(AppConfig):
+    default_auto_field = 'django.db.models.BigAutoField'
+    name = 'apps.converter'
+    verbose_name = _('Converter')

--- a/backend/apps/converter/controllers/base.py
+++ b/backend/apps/converter/controllers/base.py
@@ -1,0 +1,77 @@
+import logging
+
+from adjango.adecorators import acontroller
+from adrf.decorators import api_view
+from apps.converter.models import (Conversion, ConversionVariant, Format,
+                                   Parameter)
+from apps.converter.serializers import (ConversionSerializer, FormatSerializer,
+                                        ParameterSerializer)
+from apps.converter.services import ConversionService
+from django.http import HttpRequest
+from rest_framework.decorators import permission_classes
+from rest_framework.permissions import AllowAny, IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.status import HTTP_200_OK, HTTP_201_CREATED
+
+log = logging.getLogger("global")
+
+
+@acontroller("List formats")
+@api_view(("GET",))
+@permission_classes((AllowAny,))
+async def list_formats(_request: HttpRequest):
+    data = [await FormatSerializer(f).adata async for f in Format.objects.all()]
+    return Response(data, status=HTTP_200_OK)
+
+
+@acontroller("Parameters for format")
+@api_view(("GET",))
+@permission_classes((AllowAny,))
+async def format_parameters(_request: HttpRequest, format_id: int):
+    fmt = await Format.objects.aget(id=format_id)
+    data = [await ParameterSerializer(p).adata async for p in fmt.parameters.all()]
+    return Response(data, status=HTTP_200_OK)
+
+
+@acontroller("Conversion variants")
+@api_view(("GET",))
+@permission_classes((AllowAny,))
+async def conversion_variants(_request: HttpRequest, format_id: int):
+    targets = Format.objects.filter(target_variants__source_id=format_id).distinct()
+    data = [await FormatSerializer(fmt).adata async for fmt in targets]
+    return Response(data, status=HTTP_200_OK)
+
+
+@acontroller("Create conversion")
+@api_view(("POST",))
+@permission_classes((AllowAny,))
+async def create_conversion(request: HttpRequest):
+    file = request.FILES.get("file")
+    source_id = request.data.get("source_format")
+    target_id = request.data.get("target_format")
+    params = request.data.get("params", {})
+    if not all([file, source_id, target_id]):
+        return Response({"detail": "Invalid request"}, status=HTTP_200_OK)
+    source = await Format.objects.aget(id=source_id)
+    target = await Format.objects.aget(id=target_id)
+    user = request.user if request.user.is_authenticated else None
+    ip = request.META.get("REMOTE_ADDR", "")
+    conversion = await ConversionService.create(
+        user=user,
+        ip=ip,
+        input_file=file,
+        source_format=source,
+        target_format=target,
+        params=params,
+    )
+    return Response(
+        await ConversionSerializer(conversion).adata, status=HTTP_201_CREATED
+    )
+
+
+@acontroller("Conversion status")
+@api_view(("GET",))
+@permission_classes((AllowAny,))
+async def conversion_status(_request: HttpRequest, conversion_id: int):
+    conversion = await Conversion.objects.aget(id=conversion_id)
+    return Response(await ConversionSerializer(conversion).adata, status=HTTP_200_OK)

--- a/backend/apps/converter/models/__init__.py
+++ b/backend/apps/converter/models/__init__.py
@@ -1,0 +1,6 @@
+from .format import Format
+from .parameter import Parameter, ParameterOption, ParameterType
+from .conversion_variant import ConversionVariant
+from .conversion import Conversion
+
+__all__ = ['Format', 'Parameter', 'ParameterOption', 'ParameterType', 'ConversionVariant', 'Conversion']

--- a/backend/apps/converter/models/conversion.py
+++ b/backend/apps/converter/models/conversion.py
@@ -1,0 +1,22 @@
+from adjango.models import AModel
+from adjango.models.mixins import ACreatedUpdatedAtIndexedMixin
+from django.db.models import FileField, ForeignKey, CASCADE, CharField, BooleanField, JSONField
+from django.utils.translation import gettext_lazy as _
+
+
+class Conversion(AModel, ACreatedUpdatedAtIndexedMixin):
+    user = ForeignKey('core.User', CASCADE, related_name='conversions', null=True, blank=True, verbose_name=_('User'))
+    ip = CharField(max_length=64, verbose_name=_('IP'))
+    input_file = FileField(upload_to='converter/input/', verbose_name=_('Input file'))
+    output_file = FileField(upload_to='converter/output/', null=True, blank=True, verbose_name=_('Output file'))
+    source_format = ForeignKey('converter.Format', CASCADE, related_name='+', verbose_name=_('Source format'))
+    target_format = ForeignKey('converter.Format', CASCADE, related_name='+', verbose_name=_('Target format'))
+    params = JSONField(blank=True, null=True, verbose_name=_('Parameters'))
+    is_done = BooleanField(default=False, verbose_name=_('Is done'))
+
+    class Meta:
+        verbose_name = _('Conversion')
+        verbose_name_plural = _('Conversions')
+
+    def __str__(self) -> str:
+        return f'{self.input_file.name} -> {self.target_format.name}'

--- a/backend/apps/converter/models/conversion_variant.py
+++ b/backend/apps/converter/models/conversion_variant.py
@@ -1,0 +1,25 @@
+from adjango.models import AModel
+from django.db.models import CASCADE, ForeignKey, ManyToManyField
+from django.utils.translation import gettext_lazy as _
+
+
+class ConversionVariant(AModel):
+    source = ForeignKey(
+        "converter.Format",
+        CASCADE,
+        related_name="source_variants",
+        verbose_name=_("Source format"),
+    )
+    targets = ManyToManyField(
+        "converter.Format",
+        related_name="target_variants",
+        verbose_name=_("Target formats"),
+    )
+
+    class Meta:
+        verbose_name = _("Conversion variant")
+        verbose_name_plural = _("Conversion variants")
+
+    def __str__(self) -> str:
+        targets = ", ".join(t.name for t in self.targets.all())
+        return f"{self.source} -> [{targets}]"

--- a/backend/apps/converter/models/format.py
+++ b/backend/apps/converter/models/format.py
@@ -1,0 +1,16 @@
+from adjango.models import AModel
+from adjango.models.mixins import ACreatedUpdatedAtIndexedMixin
+from django.db.models import CharField, ImageField
+from django.utils.translation import gettext_lazy as _
+
+
+class Format(AModel, ACreatedUpdatedAtIndexedMixin):
+    name = CharField(max_length=50, unique=True, verbose_name=_('Name'))
+    icon = ImageField(upload_to='converter/icons/', null=True, blank=True, verbose_name=_('Icon'))
+
+    class Meta:
+        verbose_name = _('Format')
+        verbose_name_plural = _('Formats')
+
+    def __str__(self) -> str:
+        return self.name

--- a/backend/apps/converter/models/parameter.py
+++ b/backend/apps/converter/models/parameter.py
@@ -1,0 +1,48 @@
+from adjango.models import AModel
+from adjango.models.mixins import ACreatedUpdatedAtIndexedMixin
+from django.db.models import (CASCADE, CharField, ForeignKey, IntegerField,
+                              TextChoices)
+from django.utils.translation import gettext_lazy as _
+
+
+class ParameterType(TextChoices):
+    BOOL = "bool", _("Boolean")
+    INT = "int", _("Integer")
+    STR = "str", _("String")
+    SELECT = "select", _("Select")
+
+
+class Parameter(AModel, ACreatedUpdatedAtIndexedMixin):
+    format = ForeignKey(
+        "converter.Format", CASCADE, related_name="parameters", verbose_name=_("Format")
+    )
+    name = CharField(max_length=50, verbose_name=_("Name"))
+    type = CharField(
+        max_length=10, choices=ParameterType.choices, verbose_name=_("Type")
+    )
+    unit = CharField(max_length=20, blank=True, null=True, verbose_name=_("Unit"))
+    min_value = IntegerField(blank=True, null=True, verbose_name=_("Min value"))
+    max_value = IntegerField(blank=True, null=True, verbose_name=_("Max value"))
+
+    class Meta:
+        verbose_name = _("Parameter")
+        verbose_name_plural = _("Parameters")
+        unique_together = ("format", "name")
+
+    def __str__(self) -> str:
+        return f"{self.format.name}: {self.name}"
+
+
+class ParameterOption(AModel):
+    parameter = ForeignKey(
+        Parameter, CASCADE, related_name="options", verbose_name=_("Parameter")
+    )
+    value = CharField(max_length=100, verbose_name=_("Value"))
+
+    class Meta:
+        verbose_name = _("Parameter option")
+        verbose_name_plural = _("Parameter options")
+        unique_together = ("parameter", "value")
+
+    def __str__(self) -> str:
+        return self.value

--- a/backend/apps/converter/routes/api.py
+++ b/backend/apps/converter/routes/api.py
@@ -1,0 +1,19 @@
+from django.urls import path
+
+from apps.converter.controllers.base import (
+    list_formats,
+    conversion_variants,
+    format_parameters,
+    create_conversion,
+    conversion_status,
+)
+
+app_name = 'converter'
+
+urlpatterns = [
+    path('converter/formats/', list_formats),
+    path('converter/formats/<int:format_id>/variants/', conversion_variants),
+    path('converter/formats/<int:format_id>/parameters/', format_parameters),
+    path('converter/convert/', create_conversion),
+    path('converter/conversion/<int:conversion_id>/', conversion_status),
+]

--- a/backend/apps/converter/serializers.py
+++ b/backend/apps/converter/serializers.py
@@ -1,0 +1,27 @@
+from adjango.aserializers import AModelSerializer
+from apps.converter.models import Conversion, Format, Parameter
+from rest_framework.fields import SerializerMethodField
+
+
+class FormatSerializer(AModelSerializer):
+    class Meta:
+        model = Format
+        fields = "__all__"
+
+
+class ParameterSerializer(AModelSerializer):
+    options = SerializerMethodField()
+
+    class Meta:
+        model = Parameter
+        fields = "__all__"
+
+    @staticmethod
+    def get_options(obj):
+        return [opt.value for opt in obj.options.all()]
+
+
+class ConversionSerializer(AModelSerializer):
+    class Meta:
+        model = Conversion
+        fields = "__all__"

--- a/backend/apps/converter/services/__init__.py
+++ b/backend/apps/converter/services/__init__.py
@@ -1,0 +1,3 @@
+from .converter import ConversionService, BaseConverter
+
+__all__ = ['ConversionService', 'BaseConverter']

--- a/backend/apps/converter/services/converter.py
+++ b/backend/apps/converter/services/converter.py
@@ -1,0 +1,83 @@
+import shutil
+from abc import ABC, abstractmethod
+from datetime import timedelta
+from typing import Optional, Type
+
+from django.utils import timezone
+
+from apps.converter.models import Conversion, Format
+from apps.core.models import User
+
+
+class BaseConverter(ABC):
+    format: Format
+
+    def __init__(self, conversion: Conversion) -> None:
+        self.conversion = conversion
+
+    @abstractmethod
+    async def convert(self) -> None:
+        """Perform conversion and save result to conversion.output_file"""
+        pass
+
+
+class DummyConverter(BaseConverter):
+    async def convert(self) -> None:
+        # just copy input to output
+        src = self.conversion.input_file.path
+        dst = src + f'.{self.conversion.target_format.name}'
+        shutil.copy(src, dst)
+        self.conversion.output_file.name = dst
+        self.conversion.is_done = True
+        await self.conversion.asave()
+
+
+class ConversionService:
+    RATE_LIMIT_ANON = 10
+    RATE_LIMIT_AUTH = 50
+
+    def __init__(self, conversion: Conversion):
+        self.conversion = conversion
+
+    @classmethod
+    async def check_rate_limit(cls, user: Optional[User], ip: str) -> bool:
+        time_threshold = timezone.now() - timedelta(hours=1)
+        qs = Conversion.objects.filter(created_at__gte=time_threshold, ip=ip)
+        if user:
+            qs = qs.filter(user=user)
+            limit = cls.RATE_LIMIT_AUTH
+        else:
+            qs = qs.filter(user__isnull=True)
+            limit = cls.RATE_LIMIT_ANON
+        count = await qs.acount()
+        return count < limit
+
+    @classmethod
+    async def create(
+        cls,
+        *,
+        user: Optional[User],
+        ip: str,
+        input_file,
+        source_format: Format,
+        target_format: Format,
+        params: dict | None = None,
+    ) -> Conversion:
+        if not await cls.check_rate_limit(user, ip):
+            raise ValueError('Rate limit exceeded')
+        conversion = await Conversion.objects.acreate(
+            user=user,
+            ip=ip,
+            input_file=input_file,
+            source_format=source_format,
+            target_format=target_format,
+            params=params or {},
+        )
+        from apps.converter.tasks import process_conversion_task
+        process_conversion_task.delay(conversion.id)
+        return conversion
+
+    async def perform(self, converter_cls: Type[BaseConverter] | None = None) -> None:
+        converter_cls = converter_cls or DummyConverter
+        converter = converter_cls(self.conversion)
+        await converter.convert()

--- a/backend/apps/converter/tasks/__init__.py
+++ b/backend/apps/converter/tasks/__init__.py
@@ -1,0 +1,12 @@
+from celery import shared_task
+
+
+@shared_task
+def process_conversion_task(conversion_id: int) -> None:
+    from apps.converter.models import Conversion
+    from apps.converter.services import ConversionService
+
+    conversion = Conversion.objects.get(id=conversion_id)
+    service = ConversionService(conversion)
+    import asyncio
+    asyncio.run(service.perform())

--- a/backend/apps/core/routes/root.py
+++ b/backend/apps/core/routes/root.py
@@ -34,6 +34,7 @@ urlpatterns = [
     path('api/v1/', include('apps.software.routes.api')),
     path('api/v1/', include('apps.software.legacy.desktop_software_urls')),
     path('api/v1/', include('apps.filehost.routes.api')),
+    path('api/v1/', include('apps.converter.routes.api')),
     path('api/v1/xlmine/', include('apps.xlmine.routes.api')),
     path('api/v1/confirmation-code/', include('apps.confirmation.routes.api')),
 

--- a/backend/config/modules/apps.py
+++ b/backend/config/modules/apps.py
@@ -52,6 +52,7 @@ INSTALLED_APPS = [
     'apps.theme',
     'apps.surveys',
     'apps.filehost',
+    'apps.converter',
     'apps.xlmine',
 
 ]

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -33,6 +33,7 @@ import Softwares from "./Modules/Software/Softwares";
 import {useTranslation} from 'react-i18next';
 import SoftwareDetail from "./Modules/Software/SoftwareDetail";
 import XLMineLanding from "./Modules/xLMine/XLMineLanding";
+import {Converter} from "Converter";
 import BackgroundFlicker from "Core/BackgroundFlicker";
 import {LangProvider} from "Core/LanguageContext";
 
@@ -133,6 +134,7 @@ const App: React.FC = () => {
                             </FC>}/>
                         </>}
                         <Route path='/xlmine' element={<XLMineLanding/>}/>
+                        <Route path='/converter' element={<Converter/>}/>
                         <Route path='/*' element={<Cabinet/>}/>
                     </Routes>
                 </main>

--- a/frontend/src/Modules/Converter/Converter.tsx
+++ b/frontend/src/Modules/Converter/Converter.tsx
@@ -1,0 +1,59 @@
+import React, {useEffect, useState} from 'react';
+import axios from 'axios';
+import {Button, CircularProgress} from '@mui/material';
+import FormatPicker from './FormatPicker';
+import ParameterForm from './ParameterForm';
+import {IFormat, IParameter} from 'types/converter';
+
+const Converter: React.FC = () => {
+    const [source, setSource] = useState<IFormat | null>(null);
+    const [targetId, setTargetId] = useState<number | null>(null);
+    const [targets, setTargets] = useState<IFormat[]>([]);
+    const [params, setParams] = useState<IParameter[]>([]);
+    const [values, setValues] = useState<Record<string, any>>({});
+    const [file, setFile] = useState<File | null>(null);
+    const [loading, setLoading] = useState(false);
+    const [formats, setFormats] = useState<IFormat[]>([]);
+
+    useEffect(() => {
+        axios.get('/api/v1/converter/formats/').then(r => setFormats(r.data));
+    }, []);
+
+    useEffect(() => {
+        if (source) {
+            axios.get(`/api/v1/converter/formats/${source.id}/variants/`).then(r => setTargets(r.data));
+            axios.get(`/api/v1/converter/formats/${source.id}/parameters/`).then(r => setParams(r.data));
+        }
+    }, [source]);
+
+    const handleConvert = () => {
+        if (!file || !source || !targetId) return;
+        const formData = new FormData();
+        formData.append('file', file);
+        formData.append('source_format', String(source.id));
+        formData.append('target_format', String(targetId));
+        formData.append('params', JSON.stringify(values));
+        setLoading(true);
+        axios.post('/api/v1/converter/convert/', formData).then(r => {
+            const url = r.data.output_file;
+            if (url) window.location.href = url;
+        }).finally(() => setLoading(false));
+    };
+
+    return (
+        <div>
+            <input type="file" onChange={e => setFile(e.target.files?.[0] || null)}/>
+            <FormatPicker formats={formats} value={source?.id} onChange={id => {
+                const f = formats.find(f => f.id === id) || null;
+                setSource(f);
+            }}/>
+            {source && <FormatPicker formats={targets} value={targetId || undefined} onChange={setTargetId}/>} 
+            {params.length > 0 && <ParameterForm parameters={params} values={values} onChange={(n, v) => setValues(prev => ({...prev, [n]: v}))}/>} 
+            <Button variant="contained" disabled={loading} onClick={handleConvert}>
+                {loading ? <CircularProgress size={24}/> : 'Convert'}
+            </Button>
+        </div>
+    );
+};
+
+export default Converter;

--- a/frontend/src/Modules/Converter/FormatPicker.tsx
+++ b/frontend/src/Modules/Converter/FormatPicker.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import {Button, Grid, Typography} from '@mui/material';
+import {IFormat} from 'types/converter';
+
+interface Props {
+    formats: IFormat[];
+    value?: number;
+    onChange: (id: number) => void;
+}
+
+const FormatPicker: React.FC<Props> = ({formats, value, onChange}) => {
+    return (
+        <Grid container spacing={2}>
+            {formats.map(fmt => (
+                <Grid item key={fmt.id}>
+                    <Button
+                        variant={value === fmt.id ? 'contained' : 'outlined'}
+                        onClick={() => onChange(fmt.id)}
+                    >
+                        {fmt.icon && <img src={fmt.icon} alt={fmt.name} width={24} style={{marginRight: 4}}/>}
+                        <Typography variant="body2">{fmt.name}</Typography>
+                    </Button>
+                </Grid>
+            ))}
+        </Grid>
+    );
+};
+
+export default FormatPicker;

--- a/frontend/src/Modules/Converter/ParameterForm.tsx
+++ b/frontend/src/Modules/Converter/ParameterForm.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import {Checkbox, FormControlLabel, MenuItem, TextField} from '@mui/material';
+import {IParameter} from 'types/converter';
+
+interface Props {
+    parameters: IParameter[];
+    values: Record<string, any>;
+    onChange: (name: string, value: any) => void;
+}
+
+const ParameterForm: React.FC<Props> = ({parameters, values, onChange}) => {
+    return (
+        <>
+            {parameters.map(p => {
+                const value = values[p.name];
+                switch (p.type) {
+                    case 'bool':
+                        return (
+                            <FormControlLabel
+                                key={p.name}
+                                control={<Checkbox checked={!!value} onChange={e => onChange(p.name, e.target.checked)}/>} 
+                                label={p.name}
+                            />
+                        );
+                    case 'int':
+                        return (
+                            <TextField
+                                key={p.name}
+                                type="number"
+                                label={p.name}
+                                value={value || ''}
+                                onChange={e => onChange(p.name, Number(e.target.value))}
+                                InputProps={{endAdornment: p.unit}}
+                                fullWidth
+                                margin="normal"
+                            />
+                        );
+                    case 'select':
+                        return (
+                            <TextField
+                                select
+                                key={p.name}
+                                label={p.name}
+                                value={value || ''}
+                                onChange={e => onChange(p.name, e.target.value)}
+                                fullWidth
+                                margin="normal"
+                            >
+                                {p.options?.map(opt => (
+                                    <MenuItem key={opt} value={opt}>{opt}</MenuItem>
+                                ))}
+                            </TextField>
+                        );
+                    default:
+                        return (
+                            <TextField
+                                key={p.name}
+                                label={p.name}
+                                value={value || ''}
+                                onChange={e => onChange(p.name, e.target.value)}
+                                fullWidth
+                                margin="normal"
+                            />
+                        );
+                }
+            })}
+        </>
+    );
+};
+
+export default ParameterForm;

--- a/frontend/src/Modules/Converter/index.ts
+++ b/frontend/src/Modules/Converter/index.ts
@@ -1,0 +1,3 @@
+export {default as Converter} from './Converter';
+export {default as FormatPicker} from './FormatPicker';
+export {default as ParameterForm} from './ParameterForm';

--- a/frontend/src/Types/converter/index.ts
+++ b/frontend/src/Types/converter/index.ts
@@ -1,0 +1,23 @@
+export interface IFormat {
+    id: number;
+    name: string;
+    icon?: string;
+}
+
+export interface IParameter {
+    id: number;
+    name: string;
+    type: 'bool' | 'int' | 'str' | 'select';
+    unit?: string | null;
+    options?: string[] | null;
+}
+
+export interface IConversion {
+    id: number;
+    input_file: string;
+    output_file?: string | null;
+    source_format: number;
+    target_format: number;
+    params: Record<string, any>;
+    is_done: boolean;
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -71,6 +71,9 @@
       "User/*": [
         "Modules/User/*"
       ],
+      "Converter/*": [
+        "Modules/Converter/*"
+      ],
       "xLMine/*": [
         "Modules/xLMine/*"
       ]


### PR DESCRIPTION
## Summary
- refactor ConversionVariant to hold ManyToMany targets
- split Parameter options into dedicated model
- expose options via ParameterSerializer
- adjust controller logic for new relations

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'adjango')*

------
https://chatgpt.com/codex/tasks/task_e_6873e020b8b083308d1c975f3d66dc9c