### PR TITLE
Improve converter page UX

### DIFF
--- a/frontend/src/Modules/Converter/Converter.tsx
+++ b/frontend/src/Modules/Converter/Converter.tsx
@@ -101,46 +101,48 @@ const Converter: React.FC = () => {
             </Grid>
 
             {/* Правая колонка: выбор форматов и параметров */}
-            <Grid size={{xs: 12, md: 6}}>
-                <FormatPicker
-                    formats={formats}
-                    value={source?.id}
-                    onChange={id => {
-                        const f = formats.find(f => f.id === id) || null;
-                        setSource(f);
-                    }}
-                />
+            {file && (
+                <Grid size={{xs: 12, md: 6}}>
+                    <FormatPicker
+                        formats={formats}
+                        value={source?.id}
+                        onChange={id => {
+                            const f = formats.find(f => f.id === id) || null;
+                            setSource(f);
+                        }}
+                    />
 
-                {source && (
-                    <>
-                        <Box mt={2}>
-                            <FormatPicker
-                                formats={targets}
-                                value={targetId ?? undefined}
-                                onChange={setTargetId}
-                            />
-                        </Box>
+                    {source && (
+                        <>
+                            <Box mt={2}>
+                                <FormatPicker
+                                    formats={targets}
+                                    value={targetId ?? undefined}
+                                    onChange={setTargetId}
+                                />
+                            </Box>
 
-                        {params.length > 0 && (
-                            <ParameterForm
-                                parameters={params}
-                                values={values}
-                                onChange={(n, v) => setValues(prev => ({...prev, [n]: v}))}
-                            />
-                        )}
+                            {params.length > 0 && (
+                                <ParameterForm
+                                    parameters={params}
+                                    values={values}
+                                    onChange={(n, v) => setValues(prev => ({...prev, [n]: v}))}
+                                />
+                            )}
 
-                        <Box mt={2}>
-                            <Button
-                                variant="contained"
-                                disabled={loading}
-                                onClick={handleConvert}
-                            >
-                                {loading ? <CircularProgress size={24}/> : 'Convert'}
-                            </Button>
-                        </Box>
-                    </>
-                )}
-            </Grid>
+                            <Box mt={2}>
+                                <Button
+                                    variant="contained"
+                                    disabled={loading}
+                                    onClick={handleConvert}
+                                >
+                                    {loading ? <CircularProgress size={24}/> : 'Convert'}
+                                </Button>
+                            </Box>
+                        </>
+                    )}
+                </Grid>
+            )}
         </Grid>
     );
 };

--- a/frontend/src/UI/FileDropZone.tsx
+++ b/frontend/src/UI/FileDropZone.tsx
@@ -24,7 +24,7 @@ const FileDropZone: React.FC<Props> = ({file, onChange, label = 'Select file'}) 
                 display: 'flex',
                 alignItems: 'center',
                 justifyContent: 'center',
-                minHeight: 100,
+                minHeight: file ? 100 : 200,
                 border: over ? '2px dashed' : '1px solid',
                 borderColor: 'grey.400',
                 borderRadius: 1,


### PR DESCRIPTION
## Summary
- hide format pickers until a file is selected
- enlarge drag/drop zone when no file is selected

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_687432d59dd483308fb49bcca5885222