### PR TITLE
Add converter models to dashboard

### DIFF
--- a/backend/config/modules/xl_dashboard.py
+++ b/backend/config/modules/xl_dashboard.py
@@ -123,6 +123,13 @@ XL_DASHBOARD = {
         'Message': 'chat.Message',
         'File': 'chat.File',
     },
+    'Converter': {
+        'Format': 'converter.Format',
+        'Parameter': 'converter.Parameter',
+        'Parameter option': 'converter.ParameterOption',
+        'Conversion variant': 'converter.ConversionVariant',
+        'Conversion': 'converter.Conversion',
+    },
     'xl-actions': {
         'Collect Static': 'run_collectstatic',
     }


### PR DESCRIPTION
## Summary
- show all converter models in the dashboard

## Testing
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6874333a310c8330bc4bd4aece87631e