### PR TITLE
Improve converter defaults and UI

### DIFF
--- a/backend/apps/converter/migrations/0002_add_default_value.py
+++ b/backend/apps/converter/migrations/0002_add_default_value.py
@@ -1,0 +1,15 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('converter', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='parameter',
+            name='default_value',
+            field=models.CharField(blank=True, null=True, max_length=100, verbose_name='Default value'),
+        ),
+    ]

--- a/backend/apps/converter/models/parameter.py
+++ b/backend/apps/converter/models/parameter.py
@@ -23,6 +23,7 @@ class Parameter(ACreatedUpdatedAtIndexedMixin, AModel):
     unit = CharField(max_length=20, blank=True, null=True, verbose_name=_("Unit"))
     min_value = IntegerField(blank=True, null=True, verbose_name=_("Min value"))
     max_value = IntegerField(blank=True, null=True, verbose_name=_("Max value"))
+    default_value = CharField(max_length=100, blank=True, null=True, verbose_name=_("Default value"))
 
     class Meta:
         verbose_name = _("Parameter")

--- a/backend/apps/converter/services/generator.py
+++ b/backend/apps/converter/services/generator.py
@@ -42,17 +42,20 @@ AUDIO_PARAMS = [
         "type": "select",
         "unit": "kbps",
         "options": [64, 96, 128, 192, 256, 320],
+        "default_value": None,
     },
     {
         "name": "sample_rate",
         "type": "select",
         "unit": "Hz",
         "options": [22050, 44100, 48000],
+        "default_value": None,
     },
     {
         "name": "channels",
         "type": "select",
         "options": [1, 2],
+        "default_value": None,
     },
 ]
 
@@ -62,12 +65,14 @@ IMAGE_PARAMS = [
         "type": "int",
         "unit": "px",
         "min_value": 1,
+        "default_value": None,
     },
     {
         "name": "height",
         "type": "int",
         "unit": "px",
         "min_value": 1,
+        "default_value": None,
     },
     {
         "name": "quality",
@@ -75,6 +80,7 @@ IMAGE_PARAMS = [
         "unit": "%",
         "min_value": 1,
         "max_value": 100,
+        "default_value": None,
     },
 ]
 
@@ -84,18 +90,21 @@ VIDEO_PARAMS = [
         "type": "int",
         "unit": "px",
         "min_value": 1,
+        "default_value": None,
     },
     {
         "name": "height",
         "type": "int",
         "unit": "px",
         "min_value": 1,
+        "default_value": None,
     },
     {
         "name": "framerate",
         "type": "select",
         "unit": "fps",
         "options": [24, 30, 60],
+        "default_value": None,
     },
     {
         "name": "video_bitrate",
@@ -103,6 +112,7 @@ VIDEO_PARAMS = [
         "unit": "kbps",
         "min_value": 100,
         "max_value": 50000,
+        "default_value": None,
     },
 ]
 
@@ -152,6 +162,7 @@ def load_converter_data(data: dict) -> None:
                     "unit": p.get("unit"),
                     "min_value": p.get("min_value"),
                     "max_value": p.get("max_value"),
+                    "default_value": p.get("default_value"),
                 },
             )
             if "options" in p:

--- a/frontend/src/Modules/Converter/Converter.tsx
+++ b/frontend/src/Modules/Converter/Converter.tsx
@@ -1,6 +1,7 @@
 import React, {useEffect, useState} from 'react';
 import axios from 'axios';
-import {Box, Button, CircularProgress, Typography} from '@mui/material';
+import {Box, Button, CircularProgress, Typography, Accordion, AccordionSummary, AccordionDetails} from '@mui/material';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import FileDropZone from 'UI/FileDropZone';
 import FormatPicker from './FormatPicker';
 import ParameterForm from './ParameterForm';
@@ -34,6 +35,14 @@ const Converter: React.FC = () => {
         axios.get(`/api/v1/converter/formats/${source.id}/parameters/`)
             .then(r => setParams(r.data));
     }, [source]);
+
+    useEffect(() => {
+        const defaults: Record<string, any> = {};
+        params.forEach(p => {
+            defaults[p.name] = p.default_value ?? null;
+        });
+        setValues(defaults);
+    }, [params]);
 
     useEffect(() => {
         if (!file || formats.length === 0) return;
@@ -121,11 +130,18 @@ const Converter: React.FC = () => {
                     />
                     <FC g={1} mt={1}>
                         {params.length > 0 && (
-                            <ParameterForm
-                                parameters={params}
-                                values={values}
-                                onChange={(n, v) => setValues(prev => ({...prev, [n]: v}))}
-                            />
+                            <Accordion defaultExpanded>
+                                <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                                    Параметры
+                                </AccordionSummary>
+                                <AccordionDetails>
+                                    <ParameterForm
+                                        parameters={params}
+                                        values={values}
+                                        onChange={(n, v) => setValues(prev => ({ ...prev, [n]: v }))}
+                                    />
+                                </AccordionDetails>
+                            </Accordion>
                         )}
                     </FC>
 
@@ -143,7 +159,7 @@ const Converter: React.FC = () => {
                             disabled={loading}
                             onClick={handleConvert}
                         >
-                            {!loading ? <CircularProgressZoomify h={'100%'} in size={44}/> : 'CONVERT'}
+                            {loading ? <CircularProgressZoomify h={'100%'} in size={44}/> : `Convert to ${targets.find(t => t.id === targetId)?.name ?? ''}`}
                         </Button>
                     </Box>
                 </FC>

--- a/frontend/src/Modules/Converter/ParameterForm.tsx
+++ b/frontend/src/Modules/Converter/ParameterForm.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Checkbox, FormControlLabel, MenuItem, TextField, InputAdornment} from '@mui/material';
+import {MenuItem, TextField, InputAdornment} from '@mui/material';
 import {IParameter} from 'types/converter';
 
 interface Props {
@@ -16,11 +16,21 @@ const ParameterForm: React.FC<Props> = ({parameters, values, onChange}) => {
                 switch (p.type) {
                     case 'bool':
                         return (
-                            <FormControlLabel
+                            <TextField
+                                select
                                 key={p.name}
-                                control={<Checkbox checked={!!value} onChange={e => onChange(p.name, e.target.checked)}/>}
                                 label={p.name}
-                            />
+                                value={value === true ? 'true' : value === false ? 'false' : ''}
+                                onChange={e => {
+                                    const v = e.target.value;
+                                    onChange(p.name, v === '' ? null : v === 'true');
+                                }}
+                                fullWidth size={'small'}
+                            >
+                                <MenuItem value="">Like source</MenuItem>
+                                <MenuItem value="true">True</MenuItem>
+                                <MenuItem value="false">False</MenuItem>
+                            </TextField>
                         );
                     case 'int':
                         return (
@@ -28,8 +38,12 @@ const ParameterForm: React.FC<Props> = ({parameters, values, onChange}) => {
                                 key={p.name}
                                 type="number"
                                 label={p.name}
-                                value={value || ''}
-                                onChange={e => onChange(p.name, Number(e.target.value))}
+                                value={value ?? ''}
+                                onChange={e => {
+                                    const v = e.target.value;
+                                    onChange(p.name, v === '' ? null : Number(v));
+                                }}
+                                placeholder="Like source"
                                 InputProps={{
                                     endAdornment: p.unit ? (
                                         <InputAdornment position="end">{p.unit}</InputAdornment>
@@ -44,10 +58,11 @@ const ParameterForm: React.FC<Props> = ({parameters, values, onChange}) => {
                                 select
                                 key={p.name}
                                 label={p.name}
-                                value={value || ''}
-                                onChange={e => onChange(p.name, e.target.value)}
+                                value={value ?? ''}
+                                onChange={e => onChange(p.name, e.target.value || null)}
                                 fullWidth size={'small'}
                             >
+                                <MenuItem value="">Like source</MenuItem>
                                 {p.options?.map(opt => (
                                     <MenuItem key={opt} value={opt}>{opt}</MenuItem>
                                 ))}
@@ -58,8 +73,9 @@ const ParameterForm: React.FC<Props> = ({parameters, values, onChange}) => {
                             <TextField
                                 key={p.name}
                                 label={p.name}
-                                value={value || ''}
-                                onChange={e => onChange(p.name, e.target.value)}
+                                value={value ?? ''}
+                                onChange={e => onChange(p.name, e.target.value || null)}
+                                placeholder="Like source"
                                 InputProps={{
                                     endAdornment: p.unit ? (
                                         <InputAdornment position="end">{p.unit}</InputAdornment>

--- a/frontend/src/Types/converter/index.ts
+++ b/frontend/src/Types/converter/index.ts
@@ -10,6 +10,7 @@ export interface IParameter {
     type: 'bool' | 'int' | 'str' | 'select';
     unit?: string | null;
     options?: string[] | null;
+    default_value?: string | null;
 }
 
 export interface IConversion {


### PR DESCRIPTION
## Summary
- add `default_value` field for converter parameters
- generate converter data with default values
- expose parameter defaults to frontend types
- show converter parameters inside a "Параметры" accordion with "Like source" defaults
- display target format name on convert button

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68744d3a91348330abc7a6f9e6c7556c