### PR TITLE
UI defaults for converter

### DIFF
--- a/frontend/src/Modules/Converter/Converter.tsx
+++ b/frontend/src/Modules/Converter/Converter.tsx
@@ -1,6 +1,6 @@
 import React, {useEffect, useState} from 'react';
 import axios from 'axios';
-import {Box, Button, CircularProgress, Typography, Accordion, AccordionSummary, AccordionDetails} from '@mui/material';
+import {Box, Button, CircularProgress, Typography, Accordion, AccordionSummary, AccordionDetails, Collapse} from '@mui/material';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import FileDropZone from 'UI/FileDropZone';
 import FormatPicker from './FormatPicker';
@@ -145,8 +145,9 @@ const Converter: React.FC = () => {
                         )}
                     </FC>
 
-                    <Box mt={2}>
-                        <Button
+                    <Collapse in={Boolean(targetId)}>
+                        <Box mt={2}>
+                            <Button
                             sx={{
                                 fontWeight: '900',
                                 letterSpacing: '.2rem',
@@ -161,7 +162,8 @@ const Converter: React.FC = () => {
                         >
                             {loading ? <CircularProgressZoomify h={'100%'} in size={44}/> : `Convert to ${targets.find(t => t.id === targetId)?.name ?? ''}`}
                         </Button>
-                    </Box>
+                        </Box>
+                    </Collapse>
                 </FC>
             )}
         </FC>

--- a/frontend/src/Modules/Converter/ParameterForm.tsx
+++ b/frontend/src/Modules/Converter/ParameterForm.tsx
@@ -18,6 +18,7 @@ const ParameterForm: React.FC<Props> = ({parameters, values, onChange}) => {
                         return (
                             <TextField
                                 select
+                                SelectProps={{displayEmpty: true}}
                                 key={p.name}
                                 label={p.name}
                                 value={value === true ? 'true' : value === false ? 'false' : ''}
@@ -56,6 +57,7 @@ const ParameterForm: React.FC<Props> = ({parameters, values, onChange}) => {
                         return (
                             <TextField
                                 select
+                                SelectProps={{displayEmpty: true}}
                                 key={p.name}
                                 label={p.name}
                                 value={value ?? ''}


### PR DESCRIPTION
## Summary
- show the placeholder option in converter parameter selects
- hide the convert button until an output format is chosen

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6874509357008330b7a45eeb4e030dc5