### PR TITLE
Implement audio and image converters

### DIFF
--- a/backend/apps/converter/tests/test_services.py
+++ b/backend/apps/converter/tests/test_services.py
@@ -1,0 +1,33 @@
+import pytest
+from django.core.files.uploadedfile import SimpleUploadedFile
+
+from apps.converter.models import Format, Conversion
+from apps.converter.services.converter import ConversionService, AudioConverter, ImageConverter
+
+
+@pytest.mark.django_db
+async def test_detect_audio_converter():
+    src = await Format.objects.acreate(name='wav')
+    dst = await Format.objects.acreate(name='mp3')
+    conv = Conversion(
+        ip='0.0.0.0',
+        input_file=SimpleUploadedFile('f.wav', b'data'),
+        source_format=src,
+        target_format=dst,
+    )
+    service = ConversionService(conv)
+    assert service.detect_converter() is AudioConverter
+
+
+@pytest.mark.django_db
+async def test_detect_image_converter():
+    src = await Format.objects.acreate(name='png')
+    dst = await Format.objects.acreate(name='jpg')
+    conv = Conversion(
+        ip='0.0.0.0',
+        input_file=SimpleUploadedFile('f.png', b'data'),
+        source_format=src,
+        target_format=dst,
+    )
+    service = ConversionService(conv)
+    assert service.detect_converter() is ImageConverter

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ celery-singleton = "0.3.1"
 django-tinymce = "4.1.0"
 
 Pillow = "11.0.0"
+pydub = "0.25.1"
 psycopg2-binary = "2.9.10"
 requests = "2.32.4"
 xlwt = "1.3.0"


### PR DESCRIPTION
## Summary
- add pydub dependency
- implement `AudioConverter` and `ImageConverter`
- detect converter type automatically
- tests for converter detection

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_687460d442d08330a1acea36583dc77e