### PR TITLE
Refactor websocket routing

### DIFF
--- a/backend/apps/chat/routes/ws.py
+++ b/backend/apps/chat/routes/ws.py
@@ -3,6 +3,6 @@ from django.urls import re_path
 
 from apps.chat.consumers.chat import ChatConsumer
 
-ws_urlpatterns = [
+websocket_urlpatterns = [
     re_path(r'ws/chat/(?P<room_id>\w+)/$', ChatConsumer.as_asgi()),
 ]

--- a/backend/apps/core/routes/ws.py
+++ b/backend/apps/core/routes/ws.py
@@ -1,0 +1,12 @@
+# core/routes/ws.py
+
+from apps.software.routes.ws import websocket_urlpatterns as software_ws
+from apps.converter.routes.ws import websocket_urlpatterns as converter_ws
+from apps.xlmine.routes.ws import websocket_urlpatterns as xlmine_ws
+from apps.chat.routes.ws import websocket_urlpatterns as chat_ws
+
+websocket_urlpatterns = []
+websocket_urlpatterns += software_ws
+websocket_urlpatterns += converter_ws
+websocket_urlpatterns += chat_ws
+websocket_urlpatterns += xlmine_ws

--- a/backend/apps/software/routes/ws.py
+++ b/backend/apps/software/routes/ws.py
@@ -3,11 +3,9 @@ from django.urls import re_path
 
 from apps.software.consumers.macros import MacroControlConsumer
 from apps.software.consumers.screen import ScreenStreamConsumer
-from apps.converter.routes.ws import websocket_urlpatterns as converter_ws
 
 websocket_urlpatterns = [
     re_path(r'^ws/macro-control/$', MacroControlConsumer.as_asgi()),
     re_path(r'^ws/screen-stream/$', ScreenStreamConsumer.as_asgi()),
 ]
 
-websocket_urlpatterns += converter_ws

--- a/backend/config/asgi.py
+++ b/backend/config/asgi.py
@@ -5,7 +5,7 @@ from channels.routing import ProtocolTypeRouter, URLRouter
 from django.core.asgi import get_asgi_application
 
 from apps.core.middleware.auth import JWTAuthMiddleware
-from apps.software.routes.ws import websocket_urlpatterns
+from apps.core.routes.ws import websocket_urlpatterns
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'xl.settings')
 


### PR DESCRIPTION
## Summary
- centralize websocket routes in core app
- keep software routes self-contained
- rename chat routes variable for consistency

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68746b56ebd48330b073842a8fd9b771