### PR TITLE
Implement custom output filenames for converter

### DIFF
--- a/backend/apps/converter/migrations/0003_add_output_name.py
+++ b/backend/apps/converter/migrations/0003_add_output_name.py
@@ -1,0 +1,17 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('converter', '0002_parameter_default_value'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='conversion',
+            name='output_name',
+            field=models.CharField(max_length=100, null=True, blank=True, verbose_name='Output name'),
+        ),
+    ]
+

--- a/backend/apps/converter/models/conversion.py
+++ b/backend/apps/converter/models/conversion.py
@@ -9,6 +9,7 @@ class Conversion(ACreatedUpdatedAtIndexedMixin, AModel):
     ip = CharField(max_length=64, verbose_name=_('IP'))
     input_file = FileField(upload_to='converter/input/', verbose_name=_('Input file'))
     output_file = FileField(upload_to='converter/output/', null=True, blank=True, verbose_name=_('Output file'))
+    output_name = CharField(max_length=100, null=True, blank=True, verbose_name=_('Output name'))
     source_format = ForeignKey('converter.Format', CASCADE, related_name='+', verbose_name=_('Source format'))
     target_format = ForeignKey('converter.Format', CASCADE, related_name='+', verbose_name=_('Target format'))
     params = JSONField(blank=True, null=True, verbose_name=_('Parameters'))

--- a/backend/apps/converter/routes/api.py
+++ b/backend/apps/converter/routes/api.py
@@ -6,6 +6,7 @@ from apps.converter.controllers.base import (
     parameters,
     convert,
     conversion_status,
+    download,
 )
 
 app_name = 'converter'
@@ -16,4 +17,5 @@ urlpatterns = [
     path('converter/formats/<int:format_id>/parameters/', parameters),
     path('converter/convert/', convert),
     path('converter/conversion/<int:conversion_id>/', conversion_status),
+    path('converter/download/<int:conversion_id>/', download),
 ]

--- a/backend/apps/converter/services/converter.py
+++ b/backend/apps/converter/services/converter.py
@@ -144,6 +144,7 @@ class ConversionService:
             source_format: Format,
             target_format: Format,
             params: dict | None = None,
+            output_name: str | None = None,
     ) -> Conversion:
         if not await cls.check_rate_limit(user, ip):
             raise ValueError('Rate limit exceeded')
@@ -154,6 +155,7 @@ class ConversionService:
             source_format=source_format,
             target_format=target_format,
             params=params or {},
+            output_name=output_name,
         )
         from apps.converter.tasks import process_conversion_task
         process_conversion_task.delay(conversion.id)

--- a/frontend/src/Modules/Converter/Converter.tsx
+++ b/frontend/src/Modules/Converter/Converter.tsx
@@ -157,7 +157,7 @@ const Converter: React.FC = () => {
                 <FileDropZone file={file} onChange={setFile}/>
                 {conversion?.is_done && conversion.output_file && (
                     <Box mt={1}>
-                        <Typography>{conversion.output_file.split('/').pop()}</Typography>
+                        <Typography>{conversion.output_name ?? conversion.output_file.split('/')?.pop()}</Typography>
                         {typeof conversion.size === 'number' && (
                             <Typography variant="caption">
                                 {formatFileSize(conversion.size)}
@@ -165,7 +165,7 @@ const Converter: React.FC = () => {
                         )}
                         <Box mt={1}>
                             <Button variant="contained"
-                                    href={conversion.output_file}
+                                    href={`/api/v1/converter/download/${conversion.id}/`}
                                     download>
                                 Download
                             </Button>

--- a/frontend/src/Types/converter/index.ts
+++ b/frontend/src/Types/converter/index.ts
@@ -17,6 +17,7 @@ export interface IConversion {
     id: number;
     input_file: string;
     output_file?: string | null;
+    output_name?: string | null;
     size?: number | null;
     source_format: number;
     target_format: number;


### PR DESCRIPTION
## Summary
- add `output_name` field for conversions
- expose download API with Content-Disposition
- support custom names in service, controller, and routes
- show file name from API in frontend and update download link

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68747bf6ac00833098525f829c12b3d8