### PR TITLE
Refactor theme setup

### DIFF
--- a/frontend/src/Modules/Theme/ThemeContext.tsx
+++ b/frontend/src/Modules/Theme/ThemeContext.tsx
@@ -1,7 +1,7 @@
 // Modules/Theme/ThemeContext.tsx
 import React, {createContext, ReactNode, useContext, useEffect, useState} from 'react';
 import {Palette, ThemeProvider as MuiThemeProvider} from '@mui/material/styles';
-import darkTheme, {lightTheme} from "./themeConfig";
+import {darkTheme, lightTheme} from "../../theme";
 import {useApi} from "Api/useApi";
 
 interface ThemeContextType {

--- a/frontend/src/theme/componentOverrides.ts
+++ b/frontend/src/theme/componentOverrides.ts
@@ -1,46 +1,6 @@
-// Modules/Theme/themeConfig.ts
-import {createTheme} from '@mui/material/styles';
-import {Grow} from "@mui/material";
+import { ThemeOptions } from "@mui/material/styles";
 
-export const lightTheme = createTheme({});
-
-export const darkTheme = createTheme({
-    // @ts-ignore
-    colors: {
-        primary: {
-            dark: '#a81f2e',
-            main: '#ff2e46',
-            light: '#ff7484',
-            lighter: '#fff3f2',
-        },
-        secondary: {
-            dark: '#303189',
-            main: '#4e4fdb',
-            light: '#8485c4',
-            lighter: '#f0f0fa',
-        },
-        error: {
-            dark: '#b34452',
-            main: '#ff6a7d',
-            light: '#ff8796',
-        },
-        warning: {
-            main: '#ffa000',
-            light: '#ffb74d',
-            dark: '#f57c00',
-        },
-        info: {
-            main: '#0288d1',
-            light: '#4fc3f7',
-            dark: '#01579b',
-        },
-        success: {
-            main: '#65ff6c',
-            light: '#81c784',
-            dark: '#2e7d32',
-        },
-    },
-    components: {
+const componentOverrides: ThemeOptions["components"] = {
         MuiPaper: {
             styleOverrides: {
                 root: {
@@ -306,47 +266,6 @@ export const darkTheme = createTheme({
                 },
             },
         },
-    },
-    palette: {
-        mode: 'dark',
-        primary: {
-            main: '#f7f7f7',
-            light: '#f0f0f0',
-            dark: '#e9e9e9',
-            contrastText: '#000000',
-        },
-        secondary: {
-            main: '#6d9bff',
-            light: '#f8bbd0',
-            dark: '#c2185b',
-            contrastText: '#000',
-        },
-        text: {
-            primary: '#ffffff',
-            secondary: '#8e8e8e',
-        },
-        background: {default: '#000000', paper: '#363636'},
-        error: {
-            main: '#ff6a7d',
-            light: '#e57373',
-            dark: '#d32f2f',
-        },
-        warning: {
-            main: '#ffa726',
-            light: '#ffb74d',
-            dark: '#f57c00',
-        },
-        info: {
-            main: '#3c74e3',
-            light: '#4b91ff',
-            dark: '#1e5abb',
-        },
-        success: {
-            main: '#77ff7d',
-            light: '#74c978',
-            dark: '#31a136',
-        },
-    },
-});
+};
 
-export default darkTheme;
+export default componentOverrides;

--- a/frontend/src/theme/darkTheme.ts
+++ b/frontend/src/theme/darkTheme.ts
@@ -1,0 +1,81 @@
+import { ThemeOptions } from '@mui/material/styles';
+
+const darkThemeOptions: ThemeOptions = {
+  // @ts-ignore
+  colors: {
+    primary: {
+      dark: '#a81f2e',
+      main: '#ff2e46',
+      light: '#ff7484',
+      lighter: '#fff3f2',
+    },
+    secondary: {
+      dark: '#303189',
+      main: '#4e4fdb',
+      light: '#8485c4',
+      lighter: '#f0f0fa',
+    },
+    error: {
+      dark: '#b34452',
+      main: '#ff6a7d',
+      light: '#ff8796',
+    },
+    warning: {
+      main: '#ffa000',
+      light: '#ffb74d',
+      dark: '#f57c00',
+    },
+    info: {
+      main: '#0288d1',
+      light: '#4fc3f7',
+      dark: '#01579b',
+    },
+    success: {
+      main: '#65ff6c',
+      light: '#81c784',
+      dark: '#2e7d32',
+    },
+  },
+  palette: {
+    mode: 'dark',
+    primary: {
+      main: '#f7f7f7',
+      light: '#f0f0f0',
+      dark: '#e9e9e9',
+      contrastText: '#000000',
+    },
+    secondary: {
+      main: '#6d9bff',
+      light: '#f8bbd0',
+      dark: '#c2185b',
+      contrastText: '#000',
+    },
+    text: {
+      primary: '#ffffff',
+      secondary: '#8e8e8e',
+    },
+    background: { default: '#000000', paper: '#363636' },
+    error: {
+      main: '#ff6a7d',
+      light: '#e57373',
+      dark: '#d32f2f',
+    },
+    warning: {
+      main: '#ffa726',
+      light: '#ffb74d',
+      dark: '#f57c00',
+    },
+    info: {
+      main: '#3c74e3',
+      light: '#4b91ff',
+      dark: '#1e5abb',
+    },
+    success: {
+      main: '#77ff7d',
+      light: '#74c978',
+      dark: '#31a136',
+    },
+  },
+};
+
+export default darkThemeOptions;

--- a/frontend/src/theme/index.ts
+++ b/frontend/src/theme/index.ts
@@ -1,0 +1,16 @@
+import { createTheme } from '@mui/material/styles';
+import componentOverrides from './componentOverrides';
+import darkThemeOptions from './darkTheme';
+import lightThemeOptions from './lightTheme';
+
+export const lightTheme = createTheme({
+  ...lightThemeOptions,
+  components: componentOverrides,
+});
+
+export const darkTheme = createTheme({
+  ...darkThemeOptions,
+  components: componentOverrides,
+});
+
+export default darkTheme;

--- a/frontend/src/theme/lightTheme.ts
+++ b/frontend/src/theme/lightTheme.ts
@@ -1,0 +1,9 @@
+import { ThemeOptions } from '@mui/material/styles';
+
+const lightThemeOptions: ThemeOptions = {
+  palette: {
+    mode: 'light',
+  },
+};
+
+export default lightThemeOptions;


### PR DESCRIPTION
## Summary
- split dark and light theme options
- share component overrides
- expose final themes from a single index
- update ThemeContext to use new theme exports

## Testing
- `npm test --silent -- -u` *(fails: craco not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874ad09be5883309e714e564fbe2bb4