### PR TITLE
Implement credential existence service

### DIFF
--- a/backend/apps/core/controllers/user/base.py
+++ b/backend/apps/core/controllers/user/base.py
@@ -12,6 +12,7 @@ from apps.commerce.models import Client
 from apps.commerce.serializers.client import ClientPublicSerializer, ClientUpdateSerializer
 from apps.core.exceptions.user import UserException
 from apps.core.models import User
+from apps.core.services.credential import check_credential_exists
 from apps.core.serializers.user.base import (
     UserSelfSerializer, UserUsernameSerializer,
     UserUpdateSerializer, UserAvatarSerializer
@@ -112,10 +113,8 @@ async def user_auth_methods(request):
 @permission_classes((AllowAny,))
 async def check_email_exists(request):
     email = request.data.get('email')
-    if not is_email(email):
-        raise UserException.WrongCredential()
-    exists = await User.objects.aby_creds(email)
-    return Response({'exists': bool(exists)}, status=200)
+    exists = await check_credential_exists(email)
+    return Response({'exists': exists}, status=200)
 
 
 @acontroller('Check if phone exists')
@@ -123,6 +122,5 @@ async def check_email_exists(request):
 @permission_classes((AllowAny,))
 async def check_phone_exists(request):
     phone = request.data.get('phone')
-    if not is_phone(phone): raise UserException.WrongCredential()
-    exists = await User.objects.aby_creds(phone)
-    return Response({'exists': bool(exists)}, status=200)
+    exists = await check_credential_exists(phone)
+    return Response({'exists': exists}, status=200)

--- a/backend/apps/core/services/credential.py
+++ b/backend/apps/core/services/credential.py
@@ -1,0 +1,12 @@
+from adjango.utils.base import is_email, is_phone
+
+from apps.core.exceptions.user import UserException
+from apps.core.models import User
+
+
+async def check_credential_exists(credential: str) -> bool:
+    """Return ``True`` if a user with given email or phone exists."""
+    if not any((is_email(credential), is_phone(credential))):
+        raise UserException.WrongCredential()
+    user = await User.objects.aby_creds(credential)
+    return bool(user)


### PR DESCRIPTION
## Summary
- add `check_credential_exists` service for unified email/phone checks
- use the new service in `check_email_exists` and `check_phone_exists` controllers

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6874c8266498833081bb6e6d0d5e428c