### PR TITLE
Add helper for global logger

### DIFF
--- a/backend/apps/chat/services.py
+++ b/backend/apps/chat/services.py
@@ -1,5 +1,5 @@
 # chat/services.py
-import logging
+from utils.log import get_global_logger
 from typing import TYPE_CHECKING
 
 from adjango.utils.base import AsyncAtomicContextManager
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
     from apps.core.models import User
     from apps.chat.models import Room
 
-log = logging.getLogger('global')
+log = get_global_logger()
 
 
 class RoomService:

--- a/backend/apps/ckassa/controllers/api.py
+++ b/backend/apps/ckassa/controllers/api.py
@@ -1,5 +1,5 @@
 # ckassa/controllers/api.py
-import logging
+from utils.log import get_global_logger
 from typing import Any, Dict
 
 from adjango.adecorators import acontroller, aatomic
@@ -14,7 +14,7 @@ from apps.ckassa.consts import CKASSA_NOTIFICATION_ALLOWED_URLS
 from apps.ckassa.models import CKassaPayment
 from apps.commerce.models import Order
 
-log = logging.getLogger('global')
+log = get_global_logger()
 
 
 @acontroller('CKassa Notification')

--- a/backend/apps/cloudpayments/controllers/api.py
+++ b/backend/apps/cloudpayments/controllers/api.py
@@ -1,5 +1,5 @@
 # cloudpayments/controllers/api.py
-import logging
+from utils.log import get_global_logger
 from typing import Any, Dict
 
 from adjango.adecorators import acontroller, aatomic
@@ -15,7 +15,7 @@ from apps.cloudpayments.services.payment import CloudPaymentService
 from apps.commerce.models import Order
 from apps.commerce.services.order.base import OrderService
 
-log = logging.getLogger('global')
+log = get_global_logger()
 
 
 @acontroller('CloudPayments Success')

--- a/backend/apps/commerce/controllers/order.py
+++ b/backend/apps/commerce/controllers/order.py
@@ -1,5 +1,5 @@
 # commerce/controllers/order.py
-import logging
+from utils.log import get_global_logger
 
 from adjango.adecorators import acontroller
 from adjango.aserializers import ASerializer
@@ -23,7 +23,7 @@ from apps.software.models import SoftwareOrder
 from apps.software.serializers import SoftwareOrderSerializer
 from apps.tbank.models import TBankPayment
 
-log = logging.getLogger('global')
+log = get_global_logger()
 
 
 @acontroller('Create order')

--- a/backend/apps/commerce/controllers/tbank/notification.py
+++ b/backend/apps/commerce/controllers/tbank/notification.py
@@ -1,5 +1,5 @@
 # commerce/controllers/tbank/notification.py
-import logging
+from utils.log import get_global_logger
 
 from adjango.adecorators import acontroller, aforce_data, aatomic
 from adjango.utils.common import traceback_str
@@ -15,7 +15,7 @@ from rest_framework.status import HTTP_200_OK, HTTP_400_BAD_REQUEST
 from apps.commerce.services.order.base import OrderService
 from apps.tbank.decorators.base import async_tbank_payment_notification
 
-log = logging.getLogger('global')
+log = get_global_logger()
 
 
 @acontroller('TBank Notification', 'global')

--- a/backend/apps/commerce/services/employee.py
+++ b/backend/apps/commerce/services/employee.py
@@ -1,5 +1,5 @@
 # commerce/services/employee.py
-import logging
+from utils.log import get_global_logger
 from datetime import timedelta
 from typing import TYPE_CHECKING
 
@@ -7,7 +7,7 @@ from django.db import transaction
 from django.db.models import Max
 from django.utils import timezone
 
-log = logging.getLogger('global')
+log = get_global_logger()
 
 if TYPE_CHECKING:
     from apps.commerce.models import Employee

--- a/backend/apps/commerce/services/user.py
+++ b/backend/apps/commerce/services/user.py
@@ -1,5 +1,5 @@
 # commerce/services/user.py
-import logging
+from utils.log import get_global_logger
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Optional
 
@@ -9,7 +9,7 @@ from django.utils import timezone
 
 from apps.core.services.user.base import UserBaseService
 
-log = logging.getLogger('global')
+log = get_global_logger()
 
 if TYPE_CHECKING:
     from apps.core.models import User

--- a/backend/apps/commerce/tasks/employee_tasks.py
+++ b/backend/apps/commerce/tasks/employee_tasks.py
@@ -1,12 +1,12 @@
 # commerce/tasks/employee_tasks.py
-import logging
+from utils.log import get_global_logger
 
 from adjango.utils.common import traceback_str
 from celery import shared_task
 
 from apps.commerce.models import Employee
 
-log = logging.getLogger('global')
+log = get_global_logger()
 
 
 @shared_task

--- a/backend/apps/company/controllers.py
+++ b/backend/apps/company/controllers.py
@@ -1,5 +1,5 @@
 # company/controllers.py
-import logging
+from utils.log import get_global_logger
 
 from adjango.adecorators import acontroller
 from adrf.decorators import api_view
@@ -10,7 +10,7 @@ from rest_framework.response import Response
 from .models import CompanyDocument, Company
 from .serializers import CompanyDocumentSerializer, CompanySerializer
 
-log = logging.getLogger('global')
+log = get_global_logger()
 
 
 @acontroller('Get Company Details with Public Documents')

--- a/backend/apps/confirmation/confirmation_loader.py
+++ b/backend/apps/confirmation/confirmation_loader.py
@@ -1,6 +1,6 @@
 # confirmation/confirmation_loader.py
 import importlib
-import logging
+from utils.log import get_global_logger
 import os
 from typing import TYPE_CHECKING
 
@@ -9,7 +9,7 @@ from django.conf import settings
 
 if TYPE_CHECKING: from apps.confirmation.services.actions import ConfirmationAction
 
-log = logging.getLogger('global')
+log = get_global_logger()
 
 confirmation_actions: dict[str, 'ConfirmationAction'] = {}
 

--- a/backend/apps/confirmation/services/base.py
+++ b/backend/apps/confirmation/services/base.py
@@ -1,5 +1,5 @@
 # confirmation/services/base.py
-import logging
+from utils.log import get_global_logger
 from datetime import timedelta
 from typing import TYPE_CHECKING, Union
 
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
     )
     from apps.core.models import User
 
-log = logging.getLogger('global')
+log = get_global_logger()
 
 
 async def get_confirmation_code_instance(

--- a/backend/apps/converter/controllers/base.py
+++ b/backend/apps/converter/controllers/base.py
@@ -1,5 +1,5 @@
 # converter/controllers/base.py
-import logging
+from utils.log import get_global_logger
 
 from adjango.adecorators import acontroller
 from adrf.decorators import api_view
@@ -16,7 +16,7 @@ from apps.converter.serializers import (
 )
 from apps.converter.services import ConversionService
 
-log = logging.getLogger("global")
+log = get_global_logger()
 
 
 @acontroller("List formats")

--- a/backend/apps/core/admin/user.py
+++ b/backend/apps/core/admin/user.py
@@ -1,5 +1,5 @@
 # core/admin/user.py
-import logging
+from utils.log import get_global_logger
 
 from adjango.decorators import admin_description, admin_order_field
 from django.contrib import admin, messages
@@ -18,7 +18,7 @@ admin.site.site_header = 'xlartas'
 admin.site.site_title = 'xlartas'
 admin.site.index_title = ''
 
-log = logging.getLogger('global')
+log = get_global_logger()
 
 
 @admin.register(Role)

--- a/backend/apps/core/controllers/auth/common.py
+++ b/backend/apps/core/controllers/auth/common.py
@@ -1,5 +1,5 @@
 # core/controllers/auth/common.py
-import logging
+from utils.log import get_global_logger
 from random import randint
 
 from adjango.adecorators import acontroller
@@ -21,7 +21,7 @@ from apps.core.exceptions.user import UserException
 from apps.core.models.user import User
 from apps.core.serializers.user.base import SignUpSerializer
 
-log = logging.getLogger('global')
+log = get_global_logger()
 
 
 @acontroller('Logout')

--- a/backend/apps/core/middleware/auth.py
+++ b/backend/apps/core/middleware/auth.py
@@ -1,5 +1,5 @@
 # core/middleware/auth.py
-import logging
+from utils.log import get_global_logger
 from urllib.parse import parse_qs
 
 from channels.middleware import BaseMiddleware
@@ -8,7 +8,7 @@ from django.contrib.auth.models import AnonymousUser
 from rest_framework_simplejwt.tokens import AccessToken
 
 User = get_user_model()
-log = logging.getLogger('global')
+log = get_global_logger()
 
 
 async def get_user_from_token(token):

--- a/backend/apps/core/middleware/exception.py
+++ b/backend/apps/core/middleware/exception.py
@@ -1,5 +1,5 @@
 # core/middleware/exception.py
-import logging
+from utils.log import get_global_logger
 import traceback
 
 from django.utils.deprecation import MiddlewareMixin
@@ -8,7 +8,7 @@ from django.utils.deprecation import MiddlewareMixin
 class ExceptionLoggingMiddleware(MiddlewareMixin):
     @staticmethod
     def process_exception(request, _exception):
-        log = logging.getLogger('global')  # Используйте ваш логгер
+        log = get_global_logger()  # Используйте ваш логгер
         # Получаем полную трассировку ошибки
         tb = traceback.format_exc()
         # Логируем информацию об ошибке

--- a/backend/apps/core/services/phone/base.py
+++ b/backend/apps/core/services/phone/base.py
@@ -1,5 +1,5 @@
 # core/services/phone/base.py
-import logging
+from utils.log import get_global_logger
 
 import aiohttp
 import requests
@@ -17,7 +17,7 @@ class SMSServiceUnavailableException(SMSSendException):
     pass
 
 
-log = logging.getLogger('global')
+log = get_global_logger()
 
 
 async def asend_sms(phone: str, message: str):

--- a/backend/apps/core/templatetags/core_tags.py
+++ b/backend/apps/core/templatetags/core_tags.py
@@ -1,12 +1,12 @@
 # core/templatetags/core_tags.py
-import logging
+from utils.log import get_global_logger
 
 from django import template
 
 from utils.timezone import parse_and_convert, get_timezone_abbreviation
 
 register = template.Library()
-logger = logging.getLogger('global')
+logger = get_global_logger()
 
 
 @register.filter

--- a/backend/apps/filehost/controllers/file/download.py
+++ b/backend/apps/filehost/controllers/file/download.py
@@ -1,5 +1,5 @@
 # filehost/controllers/file/download.py
-import logging
+from utils.log import get_global_logger
 import os
 import shutil
 
@@ -14,7 +14,7 @@ from rest_framework.response import Response
 from apps.filehost.models import Folder, File
 from apps.filehost.services.archive import create_archive
 
-log = logging.getLogger('global')
+log = get_global_logger()
 
 
 @acontroller('Download File')

--- a/backend/apps/social_oauth/providers/google/provider.py
+++ b/backend/apps/social_oauth/providers/google/provider.py
@@ -1,6 +1,6 @@
 # social_oauth/providers/google/provider.py
 
-import logging
+from utils.log import get_global_logger
 from typing import Any
 
 import aiohttp
@@ -12,7 +12,7 @@ from apps.social_oauth.exceptions.base import SocialOAuthException
 from apps.social_oauth.models import GoogleUser
 from apps.social_oauth.oauth_provider import OAuthProvider, OAuthProviderMixin
 
-log = logging.getLogger('global')
+log = get_global_logger()
 
 
 class GoogleOAuthProvider(OAuthProviderMixin, OAuthProvider):

--- a/backend/apps/software/controllers/software.py
+++ b/backend/apps/software/controllers/software.py
@@ -1,5 +1,5 @@
 # software/controllers/software.py
-import logging
+from utils.log import get_global_logger
 from datetime import timedelta
 
 from adjango.adecorators import acontroller
@@ -14,7 +14,7 @@ from rest_framework.status import HTTP_200_OK
 from apps.software.models import Software, SoftwareLicense
 from apps.software.serializers.software import SoftwareSerializer
 
-log = logging.getLogger('global')
+log = get_global_logger()
 
 
 @acontroller('List Softwares')

--- a/backend/apps/software/legacy/desktop_software_api.py
+++ b/backend/apps/software/legacy/desktop_software_api.py
@@ -1,7 +1,7 @@
 # software/legacy/desktop_software_api.py
 
 import json
-import logging
+from utils.log import get_global_logger
 
 from adrf.decorators import api_view
 from django.utils import timezone
@@ -15,7 +15,7 @@ from apps.core.models import User
 from apps.software.models import Software, SoftwareLicense
 from .utils import get_user_by_credentials, json_response
 
-log = logging.getLogger('global')
+log = get_global_logger()
 
 # Эти константы замените своими сообщениями
 SOMETHING_WRONG = 'Something went wrong.'

--- a/backend/apps/software/models/software.py
+++ b/backend/apps/software/models/software.py
@@ -1,5 +1,5 @@
 # software/models/software.py
-import logging
+from utils.log import get_global_logger
 from typing import TYPE_CHECKING
 
 from adjango.models.mixins import ACreatedUpdatedAtIndexedMixin, ACreatedAtIndexedMixin
@@ -22,7 +22,7 @@ from apps.software.services.software import SoftwareService
 if TYPE_CHECKING:
     from apps.commerce.models.product import ProductPrice
 
-log = logging.getLogger('global')
+log = get_global_logger()
 
 
 class SoftwareFile(ACreatedAtIndexedMixin):

--- a/backend/apps/tbank/decorators/base.py
+++ b/backend/apps/tbank/decorators/base.py
@@ -1,6 +1,6 @@
 # tbank/decorators/base.py
 
-import logging
+from utils.log import get_global_logger
 from functools import wraps
 
 from adjango.utils.common import traceback_str
@@ -15,7 +15,7 @@ from apps.tbank.exceptions.base import TBankException
 from apps.tbank.models import TBankPayment
 from apps.tbank.services.payment import TBankPaymentService
 
-log = logging.getLogger('global')
+log = get_global_logger()
 
 
 def async_tbank_payment_notification(view_func):

--- a/backend/apps/tbank/decorators/installment.py
+++ b/backend/apps/tbank/decorators/installment.py
@@ -1,5 +1,5 @@
 # tbank/decorators/installment.py
-import logging
+from utils.log import get_global_logger
 from functools import wraps
 
 import dateutil.parser
@@ -12,7 +12,7 @@ from apps.commerce.models import Order
 from apps.tbank.exceptions.base import TBankException
 from apps.tbank.models import TBankInstallment
 
-log = logging.getLogger('global')
+log = get_global_logger()
 
 
 def async_tbank_installment_notification(view_func):

--- a/backend/apps/tbank/services/installment.py
+++ b/backend/apps/tbank/services/installment.py
@@ -1,6 +1,6 @@
 # tbank/services/installment.py
 import base64
-import logging
+from utils.log import get_global_logger
 from collections import namedtuple
 from typing import TYPE_CHECKING
 
@@ -9,7 +9,7 @@ from django.conf import settings
 
 if TYPE_CHECKING:
     from apps.tbank.models import TBankInstallment
-log = logging.getLogger('global')
+log = get_global_logger()
 
 InstallmentResponse = namedtuple(
     'InstallmentResponse',

--- a/backend/apps/xlmine/controllers/base.py
+++ b/backend/apps/xlmine/controllers/base.py
@@ -1,6 +1,6 @@
 # xlmine/controllers/base.py
 import json
-import logging
+from utils.log import get_global_logger
 import os
 
 from adjango.adecorators import acontroller
@@ -23,7 +23,7 @@ from apps.xlmine.serializers.base import LauncherSerializer, ReleaseSerializer, 
 from apps.xlmine.serializers.donate import DonateSerializer
 from apps.xlmine.services.base import calculate_sha256
 
-log = logging.getLogger('global')
+log = get_global_logger()
 
 
 class LauncherViewSet(ModelViewSet):

--- a/backend/apps/xlmine/services/server/console.py
+++ b/backend/apps/xlmine/services/server/console.py
@@ -1,12 +1,12 @@
 # xlmine/services/server/console.py
 
-import logging
+from utils.log import get_global_logger
 
 from adjango.utils.common import traceback_str
 from django.conf import settings
 from mcrcon import MCRcon
 
-log = logging.getLogger('global')
+log = get_global_logger()
 
 
 class RconServerConsole:

--- a/backend/apps/xlmine/utils/map_render.py
+++ b/backend/apps/xlmine/utils/map_render.py
@@ -1,10 +1,10 @@
 # xlmine/utils/map_render.py
-import logging
+from utils.log import get_global_logger
 import time
 
 from apps.xlmine.services.server.console import RconServerConsole
 
-log = logging.getLogger('global')
+log = get_global_logger()
 
 
 def teleport_player_grid(

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -1,4 +1,4 @@
-import logging
+from utils.log import get_global_logger
 
 from adjango.utils.common import is_celery
 from django.utils.translation import gettext_lazy as _
@@ -24,7 +24,7 @@ from config.modules.third_party_services import *
 from config.modules.ws import *
 from config.modules.xl_dashboard import *
 
-log = logging.getLogger('global')
+log = get_global_logger()
 log.info('#####################################')
 log.info('########## Server Settings ##########')
 log.info('#####################################')

--- a/backend/utils/handle_exceptions.py
+++ b/backend/utils/handle_exceptions.py
@@ -23,8 +23,8 @@ def handling_function(fn_name: str, request: WSGIRequest | ASGIRequest, e: Excep
     @usage:
         _handling_function(fn_name, request, e)
     """
-    import logging
-    log = logging.getLogger('global')
+    from utils.log import get_global_logger
+    log = get_global_logger()
     error_text = (f'ERROR in {fn_name}:\n'
                   f'{traceback_str(e)}\n'
                   f'{request.POST=}\n'

--- a/backend/utils/log.py
+++ b/backend/utils/log.py
@@ -1,0 +1,5 @@
+import logging
+
+def get_global_logger() -> logging.Logger:
+    """Return a logger configured with the global name."""
+    return logging.getLogger('global')

--- a/backend/utils/timezone.py
+++ b/backend/utils/timezone.py
@@ -1,11 +1,11 @@
-import logging
+from utils.log import get_global_logger
 from datetime import datetime
 
 import pytz
 from dateutil import parser
 from django.conf import settings
 
-logger = logging.getLogger('global')
+logger = get_global_logger()
 
 TIMEZONES_ABBREVIATIONS = {
     'Europe/London': 'GMT',  # GMT или BST в зависимости от времени года


### PR DESCRIPTION
## Summary
- provide `utils.log.get_global_logger` for accessing the project logger
- use the helper across the codebase

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for Django and other packages)*

------
https://chatgpt.com/codex/tasks/task_e_6874c7737c008330bf83126fe97e1db2