### PR TITLE
Refactor FileHost to use dedicated hook

### DIFF
--- a/frontend/src/Modules/FileHost/Master.tsx
+++ b/frontend/src/Modules/FileHost/Master.tsx
@@ -21,13 +21,8 @@ import {IconButton, useMediaQuery} from '@mui/material';
 import FileUpload from 'UI/FileUpload';
 import {useNavigate, useParams} from 'react-router-dom';
 import DropOverlay from './DropOverlay';
-import {
-    FolderContent,
-    getFolderCached,
-    setAllFilesCached,
-    setFavoriteFilesCached,
-    setFolderCached
-} from './storageCache';
+import {setFolderCached} from './storageCache';
+import useFileHost from './useFileHost';
 import CreateNewFolderRoundedIcon from '@mui/icons-material/CreateNewFolderRounded';
 import {useTheme} from "Theme/ThemeContext";
 
@@ -41,9 +36,7 @@ const Master: React.FC = () => {
     const isGtSm = useMediaQuery('(min-width: 576px)');
     const {handleUpload: uploadFile, uploads, clearUploads} = useFileUpload(folderId);
     const containerRef = useRef<HTMLDivElement | null>(null);
-    const [folders, setFolders] = useState<IFolder[]>([]);
-    const [folder, setFolder] = useState<IFolder | null>(null);
-    const [files, setFiles] = useState<IFile[]>([]);
+    const {folders, folder, files, load, refreshCaches} = useFileHost(folderId);
     const [selectMode, setSelectMode] = useState(false);
     const [selected, setSelected] = useState<IFile[]>([]);
     const [showMove, setShowMove] = useState(false);
@@ -53,31 +46,6 @@ const Master: React.FC = () => {
     const [context, setContext] = useState<{ x: number; y: number } | null>(null);
     const [confirmOpen, setConfirmOpen] = useState(false);
     const [view, setView] = useState<'cards' | 'table'>('cards');
-
-    const refreshCaches = () => {
-        setFolderCached(folderId, undefined as any);
-        setAllFilesCached(undefined as any);
-        setFavoriteFilesCached(undefined as any);
-    };
-
-    const load = () => {
-        const cached = getFolderCached(folderId);
-        if (cached) {
-            setFolders(cached.folders);
-            setFiles(cached.files);
-            setFolder(cached.folder);
-            return;
-        }
-        api.post('/api/v1/filehost/folder/content/', {id: folderId}).then((data: FolderContent) => {
-            setFolders(data.folders);
-            setFiles(data.files);
-            setFolder(data.folder);
-            setFolderCached(folderId, data);
-        });
-    };
-    useEffect(() => {
-        load();
-    }, [api, folderId]);
 
     const path = useFolderPath(folder);
 

--- a/frontend/src/Modules/FileHost/index.ts
+++ b/frontend/src/Modules/FileHost/index.ts
@@ -18,3 +18,4 @@ export {default as FolderTableRow} from './FolderTableRow';
 export {default as FileActions} from './FileActions';
 export {default as FolderActions} from './FolderActions';
 export {default as useLongPress} from './useLongPress';
+export {default as useFileHost} from './useFileHost';

--- a/frontend/src/Modules/FileHost/useFileHost.ts
+++ b/frontend/src/Modules/FileHost/useFileHost.ts
@@ -1,0 +1,42 @@
+// Modules/FileHost/useFileHost.ts
+import {useApi} from 'Api/useApi';
+import {useEffect, useState} from 'react';
+import {IFile, IFolder} from './types';
+import {FolderContent, getFolderCached, setAllFilesCached, setFavoriteFilesCached, setFolderCached} from './storageCache';
+
+const useFileHost = (folderId: number | null) => {
+    const {api} = useApi();
+    const [folders, setFolders] = useState<IFolder[]>([]);
+    const [folder, setFolder] = useState<IFolder | null>(null);
+    const [files, setFiles] = useState<IFile[]>([]);
+
+    const refreshCaches = () => {
+        setFolderCached(folderId, undefined as any);
+        setAllFilesCached(undefined as any);
+        setFavoriteFilesCached(undefined as any);
+    };
+
+    const load = () => {
+        const cached = getFolderCached(folderId);
+        if (cached) {
+            setFolders(cached.folders);
+            setFiles(cached.files);
+            setFolder(cached.folder);
+            return;
+        }
+        api.post('/api/v1/filehost/folder/content/', {id: folderId}).then((data: FolderContent) => {
+            setFolders(data.folders);
+            setFiles(data.files);
+            setFolder(data.folder);
+            setFolderCached(folderId, data);
+        });
+    };
+
+    useEffect(() => {
+        load();
+    }, [api, folderId]);
+
+    return {folders, folder, files, load, refreshCaches};
+};
+
+export default useFileHost;


### PR DESCRIPTION
## Summary
- create `useFileHost` hook for loading and cache management
- export the hook
- simplify `Master` component to use the new hook

## Testing
- `npm ci --silent` *(fails: internet disabled)*
- `npm test --silent` *(fails: craco not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874c78f8b708330b4cdae552fe08fe7