### PR TITLE
Fix Yggdrasil 404 and update session endpoints

### DIFF
--- a/backend/apps/xlmine/controllers/session.py
+++ b/backend/apps/xlmine/controllers/session.py
@@ -1,5 +1,6 @@
 # xlmine/controllers/session.py
 import logging
+import uuid
 
 from adrf.decorators import api_view
 from rest_framework import status
@@ -34,29 +35,14 @@ async def join_server_view(request):
     except MinecraftSession.DoesNotExist:
         return Response({'error': 'Forbidden'}, status=status.HTTP_403_FORBIDDEN)
     user = session_obj.user
-    _xlmine_user = UserXLMine.objects.aget_or_create(
-        user=user,
-        uuid=profile_id,
-        uuid__gte=50,
-    )
+    xlmine_user, _ = await UserXLMine.objects.aget_or_create(user=user)
+    if profile_id and xlmine_user.uuid != profile_id:
+        xlmine_user.uuid = profile_id
+        await xlmine_user.asave()
     session_obj.last_server_id = server_id
     await session_obj.asave()
 
-    return Response({
-        'accessToken': access_token,
-        'clientToken': session_obj.client_token,
-        'selectedProfile': profile_id,
-        'user': {
-            'id': profile_id,
-            'username': user.username,
-            'properties': [
-                {
-                    'name': 'preferredLanguage',
-                    'value': 'ru'
-                }
-            ]
-        }
-    }, status=status.HTTP_204_NO_CONTENT)
+    return Response(status=status.HTTP_204_NO_CONTENT)
 
 
 @api_view(['GET'])
@@ -100,7 +86,14 @@ async def profile_view(request, player_uuid):
     try:
         xlmine_user = await UserXLMine.objects.select_related('user').aget(uuid=full_uuid)
     except UserXLMine.DoesNotExist:
-        return Response({'error': 'Not found'}, status=status.HTTP_404_NOT_FOUND)
+        if len(full_uuid) == 32:
+            try:
+                hyphen_uuid = str(uuid.UUID(full_uuid))
+                xlmine_user = await UserXLMine.objects.select_related('user').aget(uuid=hyphen_uuid)
+            except (ValueError, UserXLMine.DoesNotExist):
+                return Response({'error': 'Not found'}, status=status.HTTP_404_NOT_FOUND)
+        else:
+            return Response({'error': 'Not found'}, status=status.HTTP_404_NOT_FOUND)
     user = xlmine_user.user
     resp = {
         'id': full_uuid.replace('-', ''),


### PR DESCRIPTION
## Summary
- update join logic for yggdrasil session server
- allow profile lookup by hyphenless UUID
- return proper 204 response on join

## Testing
- `python -m py_compile backend/apps/xlmine/controllers/session.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6876092a31608330943f4d37a820c37e