### PR TITLE
Refactor xlmine landing

### DIFF
--- a/frontend/src/Modules/xLMine/XLMineFeaturesDialog.tsx
+++ b/frontend/src/Modules/xLMine/XLMineFeaturesDialog.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import {Dialog, DialogContent, DialogTitle} from '@mui/material';
+import {FCCC} from 'wide-containers';
+import {useTheme} from 'Theme/ThemeContext';
+import {useTranslation} from 'react-i18next';
+
+interface FeatureItem {
+    name: string;
+    description: string;
+}
+
+interface Props {
+    open: boolean;
+    onClose: () => void;
+}
+
+const plugins: FeatureItem[] = [
+    {name: 'xlmine-server-core', description: 'внутренняя «сердцевина» сервера, все уникальные фичи'},
+    {name: 'AuctionGUIPlus', description: 'внутриигровой аукцион с GUI'},
+    {name: 'AxTrade', description: 'безопасный обмен предметами между игроками'},
+    {name: 'AxRewards', description: 'ежедневные/ивентовые награды, поощрения за он-лайн'},
+    {name: 'И другие...', description: ''},
+];
+
+const mods: FeatureItem[] = [
+    {name: 'Античит', description: 'Не покажу какой'},
+    {name: 'xl PvP', description: 'кастомный мод: «обратный» PvP-баланс 1.8 (кд ударов, крит-страфы)'},
+    {name: 'c2me', description: 'многопоточная генерация чанков, разгрузка мира во время TPS-пиков'},
+    {name: 'Applied Energistics 2', description: 'сетевые МЭ-хранилища, автокрафт'},
+    {name: 'Industrial Foregoing', description: 'продвинутые фермы, механизмы, авто-ресурсы'},
+    {name: 'Biomes O’ Plenty', description: 'десятки новых биомов'},
+    {name: 'Regions Unexplored', description: 'расширенная генерация ландшафтов и структур'},
+    {name: 'AdditionalStructures / Structory', description: 'заброшенные руины, лагеря, деревни'},
+    {name: 'Mutant Monsters, Creeper Overhaul, Enderman Overhaul', description: 'новые/улучшенные мобы'},
+    {name: 'Automobility & Immersive Aircraft', description: 'наземный и воздушный транспорт'},
+    {name: 'Open Parties & Claims', description: 'приваты, кланы, совместное строительство'},
+    {name: 'Xaero’s Minimap + World Map', description: 'мини-карта и полноэкранная карта'},
+    {name: 'Sodium + Lithium + FerriteCore + ModernFix', description: 'пакет оптимизаций FPS и памяти'},
+    {name: 'Useful Backpacks', description: 'вместительные рюкзаки с автосортировкой'},
+    {name: 'ItemPhysic', description: 'реалистичное поведение и физика предметов'},
+    {name: 'Automated Ruins: Philips Ruins', description: 'ещё больше тематических строений'},
+    {name: 'Ambient Sounds', description: 'объёмный саунд-дизайн биомов и пещер'},
+];
+
+const XLMineFeaturesDialog: React.FC<Props> = ({open, onClose}) => {
+    const {theme, plt} = useTheme();
+    const {t} = useTranslation();
+
+    const renderItem = (item: FeatureItem, idx: number) => (
+        <li key={idx}>
+            <span style={{color: theme.colors.primary.main}}>{item.name}</span>
+            {item.description && (
+                <> — <span style={{color: plt.text.secondary}}>{item.description}</span></>
+            )}
+        </li>
+    );
+
+    return (
+        <Dialog open={open} onClose={onClose}>
+            <DialogTitle sx={{textAlign: 'center', fontSize: '2rem'}}>
+                xlmine
+            </DialogTitle>
+            <DialogContent>
+                <FCCC g={2}>
+                    <p>{t('xlmine_description')}</p>
+                    <h3>{t('xlmine_plugins')}</h3>
+                    <ul>{plugins.map(renderItem)}</ul>
+                    <h3>{t('xlmine_mods')}</h3>
+                    <ul>{mods.map(renderItem)}</ul>
+                    <p>Всего установлено 205 модов.</p>
+                </FCCC>
+            </DialogContent>
+        </Dialog>
+    );
+};
+
+export default XLMineFeaturesDialog;

--- a/frontend/src/Modules/xLMine/XLMineLanding.tsx
+++ b/frontend/src/Modules/xLMine/XLMineLanding.tsx
@@ -5,10 +5,11 @@ import {FC, FCA, FCC, FCCC, FCSC, FR, FRCC, FRSC} from 'wide-containers';
 import {useTheme} from 'Theme/ThemeContext';
 import minecraftHero from 'Static/img/xlmine/hero-bg.webp';
 import {useNavigation} from "Core/components/Header/HeaderProvider";
-import {Button, Dialog, DialogContent, DialogTitle, useMediaQuery} from "@mui/material";
+import {Button, useMediaQuery} from "@mui/material";
 import DownloadRoundedIcon from "@mui/icons-material/DownloadRounded";
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import CircularProgressZoomify from "Core/components/elements/CircularProgressZoomify";
+import XLMineFeaturesDialog from './XLMineFeaturesDialog';
 import {useDispatch} from 'react-redux';
 import {hideBackgroundFlicker, showBackgroundFlicker} from 'Redux/visibilitySlice';
 import {useTranslation} from 'react-i18next';
@@ -19,33 +20,6 @@ const screenshot1 = 'https://via.placeholder.com/400x250?text=Screenshot+1';
 const screenshot2 = 'https://via.placeholder.com/400x250?text=Screenshot+2';
 const screenshot3 = 'https://via.placeholder.com/400x250?text=Screenshot+3';
 
-const plugins = [
-    'xlmine-server-core — внутренняя «сердцевина» сервера, все уникальные фичи',
-    'AuctionGUIPlus — внутриигровой аукцион с GUI',
-    'AxTrade — безопасный обмен предметами между игроками',
-    'AxRewards — ежедневные/ивентовые награды, поощрения за он-лайн',
-    'И другие...'
-];
-
-const mods = [
-    'Античит — Не покажу какой',
-    'xl PvP — кастомный мод: «обратный» PvP-баланс 1.8 (кд ударов, крит-страфы)',
-    'c2me — многопоточная генерация чанков, разгрузка мира во время TPS-пиков',
-    'Applied Energistics 2 — сетевые МЭ-хранилища, автокрафт',
-    'Industrial Foregoing — продвинутые фермы, механизмы, авто-ресурсы',
-    'Biomes O’ Plenty — десятки новых биомов',
-    'Regions Unexplored — расширенная генерация ландшафтов и структур',
-    'AdditionalStructures / Structory — заброшенные руины, лагеря, деревни',
-    'Mutant Monsters, Creeper Overhaul, Enderman Overhaul — новые/улучшенные мобы',
-    'Automobility & Immersive Aircraft — наземный и воздушный транспорт',
-    'Open Parties & Claims — приваты, кланы, совместное строительство',
-    'Xaero’s Minimap + World Map — мини-карта и полноэкранная карта',
-    'Sodium + Lithium + FerriteCore + ModernFix — пакет оптимизаций FPS и памяти',
-    'Useful Backpacks — вместительные рюкзаки с автосортировкой',
-    'ItemPhysic — реалистичное поведение и физика предметов',
-    'Automated Ruins: Philips Ruins — ещё больше тематических строений',
-    'Ambient Sounds — объёмный саунд-дизайн биомов и пещер'
-];
 
 const XLMineLanding: React.FC = () => {
     const {plt, theme} = useTheme();
@@ -226,25 +200,10 @@ const XLMineLanding: React.FC = () => {
                     </FC>
                 </FCCC>
             </FCA>
-            <Dialog open={featuresOpen} onClose={() => setFeaturesOpen(false)}>
-                <DialogTitle sx={{textAlign: 'center', fontSize: '2rem'}}>
-                    xlmine
-                </DialogTitle>
-                <DialogContent>
-                    <FCCC g={2}>
-                        <p>{t('xlmine_description')}</p>
-                        <h3>{t('xlmine_plugins')}</h3>
-                        <ul>
-                            {plugins.map((p, i) => (<li key={i}>{p}</li>))}
-                        </ul>
-                        <h3>{t('xlmine_mods')}</h3>
-                        <ul>
-                            {mods.map((m, i) => (<li key={i}>{m}</li>))}
-                        </ul>
-                        <p>Всего установлено 205 модов.</p>
-                    </FCCC>
-                </DialogContent>
-            </Dialog>
+            <XLMineFeaturesDialog
+                open={featuresOpen}
+                onClose={() => setFeaturesOpen(false)}
+            />
         </FCC>
     );
 };


### PR DESCRIPTION
## Summary
- extract features dialog into its own component
- style plugin and mod names separately from descriptions
- simplify `XLMineLanding` usage

## Testing
- `npm test --silent` *(fails: craco not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68767eaf9fc08330a18811380d4ac6cf