### PR TITLE
Fix browser API access in Next.js components

### DIFF
--- a/frontend_next/src/Modules/Core/hooks/useViewportHeight.ts
+++ b/frontend_next/src/Modules/Core/hooks/useViewportHeight.ts
@@ -2,9 +2,13 @@
 import {useEffect, useState} from 'react';
 
 const useViewportHeight = () => {
-    const [viewportHeight, setViewportHeight] = useState(window.innerHeight);
+    const [viewportHeight, setViewportHeight] = useState(
+        typeof window !== 'undefined' ? window.innerHeight : 0,
+    );
 
     useEffect(() => {
+        if (typeof window === 'undefined') return;
+
         const handleResize = () => {
             setViewportHeight(window.innerHeight);
         };
@@ -22,3 +26,4 @@ const useViewportHeight = () => {
 };
 
 export default useViewportHeight;
+

--- a/frontend_next/src/Utils/ws.ts
+++ b/frontend_next/src/Utils/ws.ts
@@ -21,6 +21,8 @@ export const buildWSUrl = (path: string): string => {
         ? window.location.host
         : 'localhost:3000';
     const proto = getWsProtocol();
-    const token = localStorage.getItem('access');
+    const token = typeof window !== 'undefined'
+        ? window.localStorage.getItem('access')
+        : null;
     return `${proto}://${host}${path}${token ? `?token=${token}` : ''}`.replace(':3000', ':8000');
 };


### PR DESCRIPTION
## Summary
- avoid accessing `localStorage` on the server in WebSocket URL helper
- guard `window` usage in `useViewportHeight`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887174686848330a55071b8bfff5f1e