### PR TITLE
Fix SSR document error and sass warning

### DIFF
--- a/frontend_next/src/Modules/Api/axiosConfig.tsx
+++ b/frontend_next/src/Modules/Api/axiosConfig.tsx
@@ -19,7 +19,7 @@ export const DOMAIN_URL_ENCODED = encodeURIComponent(DOMAIN_URL);
 const axiosInstance = axios.create({baseURL: `${DOMAIN_URL}/`});
 
 function getCookie(name: string): string | null {
-    if (!document.cookie) return null;
+    if (typeof document === 'undefined' || !document.cookie) return null;
     const xsrfCookies = document.cookie.split(';')
         .map(c => c.trim())
         .filter(c => c.startsWith(`${name}=`));
@@ -28,15 +28,17 @@ function getCookie(name: string): string | null {
 }
 
 axiosInstance.interceptors.request.use(config => {
-    const token = localStorage.getItem('access');
-    if (token) config.headers.Authorization = `Bearer ${token}`;
+    if (typeof localStorage !== 'undefined') {
+        const token = localStorage.getItem('access');
+        if (token) config.headers.Authorization = `Bearer ${token}`;
+    }
     const csrfToken = getCookie('csrftoken');
     if (csrfToken) config.headers['X-CSRFToken'] = csrfToken;
     return config;
 }, error => Promise.reject(error));
 
 axiosInstance.interceptors.response.use(response => response, error => {
-    if (error.response && error.response.status === 401) {
+    if (error.response && error.response.status === 401 && typeof localStorage !== 'undefined') {
         localStorage.removeItem('access');
         localStorage.removeItem('refresh');
     }

--- a/frontend_next/src/Modules/Api/useApi.ts
+++ b/frontend_next/src/Modules/Api/useApi.ts
@@ -12,17 +12,23 @@ const LS_ACCESS = 'access';
 const LS_REFRESH = 'refresh';
 
 const saveTokens = (a: string, r: string) => {
-    localStorage.setItem(LS_ACCESS, a);
-    localStorage.setItem(LS_REFRESH, r);
+    if (typeof localStorage !== 'undefined') {
+        localStorage.setItem(LS_ACCESS, a);
+        localStorage.setItem(LS_REFRESH, r);
+    }
 };
 
 const clearTokens = () => {
-    localStorage.removeItem(LS_ACCESS);
-    localStorage.removeItem(LS_REFRESH);
+    if (typeof localStorage !== 'undefined') {
+        localStorage.removeItem(LS_ACCESS);
+        localStorage.removeItem(LS_REFRESH);
+    }
 };
 
-const getAccess = () => localStorage.getItem(LS_ACCESS);
-const getRefresh = () => localStorage.getItem(LS_REFRESH);
+const getAccess = () =>
+    typeof localStorage !== 'undefined' ? localStorage.getItem(LS_ACCESS) : null;
+const getRefresh = () =>
+    typeof localStorage !== 'undefined' ? localStorage.getItem(LS_REFRESH) : null;
 
 /* -------- stringify / preview helper (для логов) -------- */
 const fmt = (x: unknown) => {
@@ -52,10 +58,13 @@ export const useApi = () => {
 
     if (!axiosRef.current) {
         const inst = axios.create({baseURL: `${DOMAIN_URL}/`});
-        inst.defaults.headers.common['Accept-Language'] = localStorage.getItem('lang') || 'ru';
+        if (typeof localStorage !== 'undefined') {
+            inst.defaults.headers.common['Accept-Language'] =
+                localStorage.getItem('lang') || 'ru';
+        }
 
         const getCookie = (name: string): string | null => {
-            if (!document.cookie) return null;
+            if (typeof document === 'undefined' || !document.cookie) return null;
             const xsrfCookies = document.cookie
                 .split(';')
                 .map(c => c.trim())

--- a/frontend_next/src/Modules/Core/LanguageContext.tsx
+++ b/frontend_next/src/Modules/Core/LanguageContext.tsx
@@ -17,13 +17,17 @@ export const LangCtx = createContext<{
 
 export const LangProvider: React.FC<PropsWithChildren> = ({children}) => {
     const [lang, setLangState] = useState<Lang>(() =>
-        (localStorage.getItem('lang') as Lang) || 'ru',
+        typeof window !== 'undefined'
+            ? ((localStorage.getItem('lang') as Lang) || 'ru')
+            : 'ru',
     );
 
     const setLang = (l: Lang) => {
         i18n.changeLanguage(l).then();
         moment.locale(l);
-        localStorage.setItem('lang', l);
+        if (typeof window !== 'undefined') {
+            localStorage.setItem('lang', l);
+        }
         setLangState(l);
         axios.defaults.headers.common['Accept-Language'] = l;
         axios.post('/api/v1/user/set-lang/', {lang: l}).catch(() => null);

--- a/frontend_next/src/Static/css/base.sass
+++ b/frontend_next/src/Static/css/base.sass
@@ -1,6 +1,6 @@
 @import url('https://fonts.googleapis.com/css2?family=Nunito:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;0,1000;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900;1,1000&display=swap')
 @import url('https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,100..700;1,100..700&display=swap')
-@import "vars"
+@use "vars" as *
 
 body
   font-size: 16px


### PR DESCRIPTION
## Summary
- fix SSR crash by checking for browser globals before using `document` or `localStorage`
- update Sass usage to remove deprecated `@import`

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: next not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_688719f414688330acd4dd2cdf3eaef4