### PR TITLE
Fix PaymentSystemIcons path

### DIFF
--- a/frontend_next/src/Modules/Order/PaymentSystemInfo.tsx
+++ b/frontend_next/src/Modules/Order/PaymentSystemInfo.tsx
@@ -20,27 +20,27 @@ import iconUnionPay from '../../Static/img/icon/payments/unionpay.svg';
 import iconSberPay from '../../Static/img/icon/payments/sberpay.svg';
 
 export const freekassaIcons = [
-    iconSBP,
-    iconVisa,
-    iconMastercard,
-    iconMir,
-    iconSteam,
-    iconBitcoin,
-    iconLitecoin,
-    iconEthereum,
-    iconTron,
-    iconTon,
-    iconBnb,
-    iconTron,
+    iconSBP.src,
+    iconVisa.src,
+    iconMastercard.src,
+    iconMir.src,
+    iconSteam.src,
+    iconBitcoin.src,
+    iconLitecoin.src,
+    iconEthereum.src,
+    iconTron.src,
+    iconTon.src,
+    iconBnb.src,
+    iconTron.src,
 ];
 
 export const ckassaIcons = [
-    iconSBP,
-    iconSberPay,
-    iconVisa,
-    iconMastercard,
-    iconMir,
-    iconUnionPay,
+    iconSBP.src,
+    iconSberPay.src,
+    iconVisa.src,
+    iconMastercard.src,
+    iconMir.src,
+    iconUnionPay.src,
 ];
 
 interface Props {


### PR DESCRIPTION
## Summary
- fix missing icons in payment system info by using `.src` paths

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for django)*

------
https://chatgpt.com/codex/tasks/task_e_6887243c6860833083e5440942d36c33