### PR TITLE
Enable SSR for Next.js frontend

### DIFF
--- a/frontend_next/src/App.tsx
+++ b/frontend_next/src/App.tsx
@@ -40,7 +40,9 @@ const App: React.FC = () => {
     const {isAuthenticated} = useAuth();
     const {t} = useTranslation();
     const {headerNavHeight, mainRef} = useNavigation();
-    const isGt1000 = window.innerWidth > 1000;
+    // `window` is undefined during server-side rendering. Guard against it to
+    // ensure the component can render on the server without errors.
+    const isGt1000 = typeof window !== 'undefined' && window.innerWidth > 1000;
     const isBackgroundFlickerEnabled = useSelector((state: RootState) => state.visibility.isBackgroundFlickerEnabled);
 
     useEffect(() => {

--- a/frontend_next/src/app/page.tsx
+++ b/frontend_next/src/app/page.tsx
@@ -2,7 +2,9 @@
 
 import dynamic from "next/dynamic";
 
-const RootApp = dynamic(() => import("../App"), { ssr: false });
+// Enable server-side rendering for the RootApp component by removing
+// the `ssr: false` option. Dynamic imports default to SSR enabled.
+const RootApp = dynamic(() => import("../App"));
 
 export default function Home() {
   return <RootApp />;


### PR DESCRIPTION
## Summary
- enable SSR for main Next.js app
- guard `window` access during server-side rendering

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm install` *(fails: 403 Forbidden when downloading packages)*


------
https://chatgpt.com/codex/tasks/task_e_6887245edfec8330a980b4c1edd33a94