### PR TITLE
Add page metadata hooks

### DIFF
--- a/frontend_next/src/app/converter/page.tsx
+++ b/frontend_next/src/app/converter/page.tsx
@@ -1,0 +1,13 @@
+import dynamic from "next/dynamic";
+import type { Metadata } from "next";
+
+const RootApp = dynamic(() => import("../../App"));
+
+export const metadata: Metadata = {
+  title: "Converter - XLARTAS",
+  description: "Convert your files on the XLARTAS platform",
+};
+
+export default function ConverterPage() {
+  return <RootApp />;
+}

--- a/frontend_next/src/app/page.tsx
+++ b/frontend_next/src/app/page.tsx
@@ -1,5 +1,12 @@
 import dynamic from "next/dynamic";
+import type { Metadata } from "next";
+
 const RootApp = dynamic(() => import("../App"));
+
+export const metadata: Metadata = {
+  title: "XLARTAS",
+  description: "Landing page of XLARTAS platform",
+};
 
 export default function Home() {
   return <RootApp />;

--- a/frontend_next/src/app/softwares/[id]/page.tsx
+++ b/frontend_next/src/app/softwares/[id]/page.tsx
@@ -1,0 +1,16 @@
+import dynamic from "next/dynamic";
+import type { Metadata } from "next";
+
+const RootApp = dynamic(() => import("../../../App"));
+
+export async function generateMetadata({ params }: { params: { id: string } }): Promise<Metadata> {
+  const id = params.id;
+  return {
+    title: `Software ${id} - XLARTAS`,
+    description: `Details about software ${id} on XLARTAS platform`,
+  };
+}
+
+export default function SoftwareDetailPage() {
+  return <RootApp />;
+}

--- a/frontend_next/src/app/softwares/page.tsx
+++ b/frontend_next/src/app/softwares/page.tsx
@@ -1,0 +1,13 @@
+import dynamic from "next/dynamic";
+import type { Metadata } from "next";
+
+const RootApp = dynamic(() => import("../../App"));
+
+export const metadata: Metadata = {
+  title: "Softwares - XLARTAS",
+  description: "Explore available software on XLARTAS platform",
+};
+
+export default function SoftwaresPage() {
+  return <RootApp />;
+}

--- a/frontend_next/src/app/xlmine/page.tsx
+++ b/frontend_next/src/app/xlmine/page.tsx
@@ -1,0 +1,13 @@
+import dynamic from "next/dynamic";
+import type { Metadata } from "next";
+
+const RootApp = dynamic(() => import("../../App"));
+
+export const metadata: Metadata = {
+  title: "XLMine - XLARTAS",
+  description: "XLMine launcher and features",
+};
+
+export default function XLMinePage() {
+  return <RootApp />;
+}


### PR DESCRIPTION
## Summary
- expose landing metadata
- add dedicated metadata for Softwares pages
- add per-page metadata for XLMine and Converter

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887289fda908330bd4dfd5ba93a73d5