### PR TITLE
Fix meta tags not updating on SPA navigation

### DIFF
--- a/frontend_next/src/Modules/Company/CompanyDocumentDetail.tsx
+++ b/frontend_next/src/Modules/Company/CompanyDocumentDetail.tsx
@@ -9,6 +9,7 @@ import {Link, Typography} from '@mui/material';
 import {FC} from "wide-containers";
 import {CompanyDocument} from "Company/Types";
 import {useApi} from "Api/useApi";
+import Head from "Core/components/Head";
 
 
 const CompanyDocumentDetail: React.FC = () => {
@@ -36,6 +37,7 @@ const CompanyDocumentDetail: React.FC = () => {
 
     return (
         <FC maxW={700} pb={2} px={2} mx={'auto'}>
+            <Head title={`${document ? document.title + ' - ' : ''}XLARTAS`} description={'Company document details'}/>
             {document.file_url &&
                 <Link href={document.file_url} target="_blank" rel="noopener noreferrer">
                     Скачать документ

--- a/frontend_next/src/Modules/Company/CompanyPage.tsx
+++ b/frontend_next/src/Modules/Company/CompanyPage.tsx
@@ -10,6 +10,7 @@ import {useTheme} from "Theme/ThemeContext";
 import {useApi} from "Api/useApi";
 import copyToClipboard from "Utils/clipboard";
 import './CompanyPage.sass'
+import Head from "Core/components/Head";
 
 
 const CompanyPage: React.FC = () => {
@@ -44,6 +45,7 @@ const CompanyPage: React.FC = () => {
 
     return (
         <FCSS lh={'1.3rem'} px={2} g={1} maxW={500} mx={'auto'}>
+            <Head title={`${company ? company.name + ' - ' : ''}XLARTAS`} description={company?.description || 'Company details on XLARTAS'}/>
             <h1 style={{lineHeight: '1.6rem'}} className={'fs-4'}>{company.name}</h1>
             <h2 style={{lineHeight: '1.4rem'}} className={'fs-5'}>Общее</h2>
             <FC pl={2}>

--- a/frontend_next/src/Modules/Converter/Converter.tsx
+++ b/frontend_next/src/Modules/Converter/Converter.tsx
@@ -26,6 +26,7 @@ import ArrowDropDownRoundedIcon from '@mui/icons-material/ArrowDropDownRounded';
 import {buildWSUrl} from 'Utils/ws';
 import {useTranslation} from 'react-i18next';
 import ConversationResultCard from "Converter/ConversationResultCard";
+import Head from "Core/components/Head";
 
 const wsFmt = (x: unknown) => {
     if (typeof x === 'string') {
@@ -159,6 +160,7 @@ const Converter: React.FC = () => {
 
     return (
         <FC w={'100%'} px={2} maxW={600} mx={'auto'}>
+            <Head title={'Converter - XLARTAS'} description={'Convert your files on the XLARTAS platform'}/>
             <ConverterGuide/>
             {remaining !== null && (
                 <Typography align="center" fontWeight={600} mt={1}>

--- a/frontend_next/src/Modules/Landing/Landing.tsx
+++ b/frontend_next/src/Modules/Landing/Landing.tsx
@@ -1,6 +1,7 @@
 // Modules/Landing/Landing.tsx
 import React, {useEffect, useState} from 'react';
 import {useNavigation} from "Core/components/Header/HeaderProvider";
+import Head from "Core/components/Head";
 import {FCCC} from 'wide-containers';
 import ParallaxLogo from 'Core/ParallaxLogo';
 import Footer from "Landing/Footer";
@@ -42,6 +43,7 @@ const Landing: React.FC = () => {
 
     return (
         <>
+            <Head title={'XLARTAS'} description={'Landing page of XLARTAS platform'}/>
             <Zoom in={animate} appear timeout={2000}>
                 <FCCC pos="relative" w="100%" h="100%" grow>
                     <ParallaxLogo/>

--- a/frontend_next/src/Modules/Software/SoftwareDetail.tsx
+++ b/frontend_next/src/Modules/Software/SoftwareDetail.tsx
@@ -21,6 +21,7 @@ import DialogContent from '@mui/material/DialogContent';
 import DialogTitle from '@mui/material/DialogTitle';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import Collapse from '@mui/material/Collapse'; // ← NEW
+import Head from "Core/components/Head";
 
 const SoftwareDetailComponent: React.FC = () => {
     const {id} = useParams();
@@ -97,6 +98,7 @@ const SoftwareDetailComponent: React.FC = () => {
     /* ---------- рендер ---------- */
     return (
         <FC pos="relative" cls={'software-detail'} h={'100%'}>
+            <Head title={`${software ? software.name + ' - ' : ''}XLARTAS`} description={software?.description || ''}/>
             {/* ----------- Спиннер (с анимацией Zoom) ----------- */}
             <FRCC pos="relative">
                 <CircularProgressZoomify in={loading} mt={'10%'} size="80px"/>

--- a/frontend_next/src/Modules/Software/Softwares.tsx
+++ b/frontend_next/src/Modules/Software/Softwares.tsx
@@ -9,6 +9,7 @@ import {useApi} from 'Api/useApi';
 import SoftwareCard from './SoftwareCard';
 import {useTranslation} from 'react-i18next';
 import Collapse from '@mui/material/Collapse';
+import Head from "Core/components/Head";
 
 const Softwares: React.FC = () => {
     const [softwares, setSoftwares] = useState<ISoftware[]>([]);
@@ -35,6 +36,7 @@ const Softwares: React.FC = () => {
 
     return (
         <FRCC g={2} wrap position="relative" w="100%">
+            <Head title={'Softwares - XLARTAS'} description={'Explore available software on XLARTAS platform'}/>
             <CircularProgressZoomify in={loading} mt={'10%'} size="90px"/>
             {softwares.length > 0 &&
                 softwares.map((software, index) => (

--- a/frontend_next/src/Modules/xLMine/XLMineLanding.tsx
+++ b/frontend_next/src/Modules/xLMine/XLMineLanding.tsx
@@ -13,6 +13,7 @@ import XLMineFeaturesDialog from './XLMineFeaturesDialog';
 import {useDispatch} from 'react-redux';
 import {hideBackgroundFlicker, showBackgroundFlicker} from 'Redux/visibilitySlice';
 import {useTranslation} from 'react-i18next';
+import Head from "Core/components/Head";
 
 // Пример: можно использовать кастомные пути к картинкам
 // Замените на свои реальные изображения
@@ -90,6 +91,7 @@ const XLMineLanding: React.FC = () => {
              h={`calc(100vh - ${headerNavHeight}px)`}
              maxH={`calc(100vh - ${headerNavHeight}px)`}
              color={plt.text.primary + '88'}>
+            <Head title={'XLMine - XLARTAS'} description={'XLMine launcher and features'}/>
             <FRSC cls={'gradient'} w={'100%'} h={'100%'}
                   pos={'fixed'} pEvents={false} zIndex={22}
                   top={`${headerNavHeight}px`} left={0} sx={{


### PR DESCRIPTION
## Summary
- add Head component for Landing page
- update Softwares and Software detail pages to set meta
- ensure xLMine, Converter, and Company pages use Head

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: next not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68872d9845a48330b69e923f8a477f09