### PR TITLE
Fix BrowserRouter SSR

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,7 +17,9 @@ import {ErrorProvider} from "Core/components/ErrorProvider";
 import {Provider, useSelector} from "react-redux";
 import {HeaderProvider, useNavigation} from "Core/components/Header/HeaderProvider";
 import {AuthProvider, useAuth} from 'Auth/AuthContext';
-import {BrowserRouter as Router, Navigate, Route, Routes} from 'react-router-dom';
+import {BrowserRouter, Navigate, Route, Routes} from 'react-router-dom';
+import {StaticRouter} from 'react-router-dom/server';
+import {usePathname} from 'next/navigation';
 import Landing from "Landing/Landing";
 import Header from "Core/components/Header/Header";
 import GlobalAuthModal from "Auth/GlobalAuthModal";
@@ -140,9 +142,17 @@ const App: React.FC = () => {
     );
 };
 
+const RouterWrapper: React.FC<{children: React.ReactNode}> = ({children}) => {
+    const pathname = usePathname();
+    if (typeof window === 'undefined') {
+        return <StaticRouter location={pathname}>{children}</StaticRouter>;
+    }
+    return <BrowserRouter>{children}</BrowserRouter>;
+};
+
 const RootApp: React.FC = () => (
     <Provider store={store}>
-        <Router>
+        <RouterWrapper>
             <HeaderProvider>
                 <AuthProvider>
                     <LangProvider>
@@ -156,7 +166,7 @@ const RootApp: React.FC = () => (
                     </LangProvider>
                 </AuthProvider>
             </HeaderProvider>
-        </Router>
+        </RouterWrapper>
     </Provider>
 );
 

--- a/frontend/src/app/converter/page.tsx
+++ b/frontend/src/app/converter/page.tsx
@@ -1,6 +1,7 @@
 import dynamic from "next/dynamic";
 import type { Metadata } from "next";
 
+// Allow RootApp to render on the server as well as the client.
 const RootApp = dynamic(() => import("../../App"));
 
 export const metadata: Metadata = {

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,6 +1,8 @@
 import dynamic from "next/dynamic";
 import type { Metadata } from "next";
 
+// Enable server-side rendering for the RootApp component by using the default
+// dynamic import behavior (SSR enabled).
 const RootApp = dynamic(() => import("../App"));
 
 export const metadata: Metadata = {

--- a/frontend/src/app/softwares/[id]/page.tsx
+++ b/frontend/src/app/softwares/[id]/page.tsx
@@ -1,6 +1,7 @@
 import dynamic from "next/dynamic";
 import type { Metadata } from "next";
 
+// Server-side rendering is enabled by default for dynamic imports.
 const RootApp = dynamic(() => import("../../../App"));
 
 export async function generateMetadata({ params }: { params: { id: string } }): Promise<Metadata> {

--- a/frontend/src/app/softwares/page.tsx
+++ b/frontend/src/app/softwares/page.tsx
@@ -1,6 +1,7 @@
 import dynamic from "next/dynamic";
 import type { Metadata } from "next";
 
+// SSR support for RootApp
 const RootApp = dynamic(() => import("../../App"));
 
 export const metadata: Metadata = {


### PR DESCRIPTION
## Summary
- handle `BrowserRouter` during SSR by falling back to `StaticRouter`
- allow `RootApp` to server-side render across pages

## Testing
- `npm --prefix frontend run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68873e2b7cec8330b65a930d7af8e0c4