### PR TITLE
Fix metadata hook for software route

### DIFF
--- a/frontend/src/app/softwares/[id]/page.tsx
+++ b/frontend/src/app/softwares/[id]/page.tsx
@@ -5,7 +5,7 @@ import type { Metadata } from "next";
 const RootApp = dynamic(() => import("../../../App"));
 
 export async function generateMetadata({ params }: { params: { id: string } }): Promise<Metadata> {
-  const id = params.id;
+  const { id } = await params;
   return {
     title: `Software ${id} - XLARTAS`,
     description: `Details about software ${id} on XLARTAS platform`,


### PR DESCRIPTION
## Summary
- fix use of dynamic params in software details metadata

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68874a92d68883309abd7246908d0692