### PR TITLE
Fix client hook errors

### DIFF
--- a/frontend/src/Modules/Api/useApi.ts
+++ b/frontend/src/Modules/Api/useApi.ts
@@ -1,3 +1,4 @@
+"use client";
 // Modules/Api/useApi.ts
 import axios, {AxiosInstance, AxiosRequestConfig, AxiosResponse, InternalAxiosRequestConfig,} from 'axios';
 import {useEffect, useRef} from 'react';

--- a/frontend/src/Modules/Auth/AuthContext.tsx
+++ b/frontend/src/Modules/Auth/AuthContext.tsx
@@ -1,3 +1,4 @@
+"use client";
 // Modules/Auth/AuthContext.tsx
 import React, {createContext, ReactNode, useEffect, useState} from 'react';
 import {useTranslation} from 'react-i18next';

--- a/frontend/src/Modules/Auth/Social/components/SocialOAuth.tsx
+++ b/frontend/src/Modules/Auth/Social/components/SocialOAuth.tsx
@@ -1,3 +1,4 @@
+"use client";
 // Modules/Auth/Social/components/SocialOAuth.tsx
 import React, {useEffect, useRef, useState} from 'react';
 import {Button as MuiButton, Button, Dialog, DialogActions, DialogContent, DialogTitle, Snackbar} from '@mui/material';

--- a/frontend/src/Modules/Auth/Social/elements/OAuthButton.tsx
+++ b/frontend/src/Modules/Auth/Social/elements/OAuthButton.tsx
@@ -1,3 +1,4 @@
+"use client";
 // Modules/Auth/Social/elements/OAuthButton.tsx
 import React, {useEffect} from "react";
 import {IconButton} from "@mui/material";

--- a/frontend/src/Modules/Core/ParallaxContainer.tsx
+++ b/frontend/src/Modules/Core/ParallaxContainer.tsx
@@ -1,3 +1,4 @@
+"use client";
 // Modules/Core/ParallaxContainer.tsx
 import React, {useEffect, useRef} from 'react';
 import {FC as FCLayout, FCCC} from 'wide-containers';

--- a/frontend/src/Modules/Core/components/ErrorProvider.tsx
+++ b/frontend/src/Modules/Core/components/ErrorProvider.tsx
@@ -1,3 +1,4 @@
+"use client";
 // Modules/Core/components/ErrorProvider.tsx
 import React, {createContext, ReactNode, useContext, useEffect, useRef} from 'react';
 import {useLocation, useNavigate} from 'Utils/nextRouter';

--- a/frontend/src/Modules/Core/components/Header/HeaderProvider.tsx
+++ b/frontend/src/Modules/Core/components/Header/HeaderProvider.tsx
@@ -1,3 +1,4 @@
+"use client";
 // Modules/Core/components/Header/HeaderProvider.tsx
 import React, {createContext, ReactNode, RefObject, useContext, useRef, useState,} from 'react';
 import Logo from 'Core/Logo';

--- a/frontend/src/Modules/Landing/Footer.tsx
+++ b/frontend/src/Modules/Landing/Footer.tsx
@@ -1,3 +1,4 @@
+"use client";
 // Modules/Landing/Footer.tsx
 import React, {useEffect, useState} from 'react';
 import {FC} from 'wide-containers';

--- a/frontend/src/Modules/Landing/Landing.tsx
+++ b/frontend/src/Modules/Landing/Landing.tsx
@@ -1,3 +1,4 @@
+"use client";
 // Modules/Landing/Landing.tsx
 import React, {useEffect, useState} from 'react';
 import {useNavigation} from "Core/components/Header/HeaderProvider";

--- a/frontend/src/Modules/Theme/ThemeContext.tsx
+++ b/frontend/src/Modules/Theme/ThemeContext.tsx
@@ -1,3 +1,4 @@
+"use client";
 // Modules/Theme/ThemeContext.tsx
 import React, {createContext, ReactNode, useContext, useEffect, useState} from 'react';
 import {Palette, ThemeProvider as MuiThemeProvider} from '@mui/material/styles';


### PR DESCRIPTION
## Summary
- mark React hook files with `"use client"` directive

## Testing
- `npm install` *(fails: network disabled)*
- `npm run lint` *(fails: `next` not found)*
- `pytest -q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688798279eb8833081822307abfa8aa1