### PR TITLE
Fix Link wrapper prop

### DIFF
--- a/frontend/src/Utils/nextRouter.tsx
+++ b/frontend/src/Utils/nextRouter.tsx
@@ -1,9 +1,16 @@
 "use client";
-import NextLink from "next/link";
+import NextLink, {LinkProps as NextLinkProps} from "next/link";
 import {useRouter, usePathname, useSearchParams} from "next/navigation";
 import React from "react";
 
-export const Link = NextLink;
+export interface LinkProps extends Omit<NextLinkProps, 'href'> {
+    to?: NextLinkProps['href'];
+    href?: NextLinkProps['href'];
+}
+
+export const Link: React.FC<LinkProps> = ({to, href, ...props}) => (
+    <NextLink href={to ?? href ?? '#'} {...props} />
+);
 
 export function useNavigate() {
     const router = useRouter();


### PR DESCRIPTION
## Summary
- update Next.js Link wrapper to accept `to` prop

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887c52ac0e4833081c947f59fcd6dc0