### PR TITLE
fix: mark cabinet component as client

### DIFF
--- a/frontend/src/Modules/Cabinet/Cabinet.tsx
+++ b/frontend/src/Modules/Cabinet/Cabinet.tsx
@@ -1,3 +1,4 @@
+"use client";
 // Modules/Cabinet/Cabinet.tsx
 import React, {useEffect, useRef, useState} from 'react';
 import {useTranslation} from 'react-i18next';


### PR DESCRIPTION
## Summary
- ensure `Cabinet` is treated as a client component for hooks

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: sh: 1: next: not found)*


------
https://chatgpt.com/codex/tasks/task_e_688d6678f14c8330902fcef188f57cbc