### PR TITLE
Fix client component wiring on Softwares page

### DIFF
--- a/frontend/src/app/softwares/SoftwaresPageClient.tsx
+++ b/frontend/src/app/softwares/SoftwaresPageClient.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import Softwares from "../../Modules/Software/Softwares";
+import {FC} from "wide-containers";
+
+export default function SoftwaresPageClient() {
+    return (
+        <FC g={2} p={2} mx={"auto"} maxW={800}>
+            <Softwares />
+        </FC>
+    );
+}

--- a/frontend/src/app/softwares/page.tsx
+++ b/frontend/src/app/softwares/page.tsx
@@ -1,6 +1,5 @@
 import type {Metadata} from "next";
-import Softwares from "../../Modules/Software/Softwares";
-import {FC} from "wide-containers";
+import SoftwaresPageClient from "./SoftwaresPageClient";
 
 export const metadata: Metadata = {
     title: "Softwares - XLARTAS",
@@ -8,9 +7,5 @@ export const metadata: Metadata = {
 };
 
 export default function SoftwaresPage() {
-    return (
-        <FC g={2} p={2} mx={"auto"} maxW={800}>
-            <Softwares/>
-        </FC>
-    );
+    return <SoftwaresPageClient />;
 }


### PR DESCRIPTION
## Summary
- Split Softwares page into server page and client wrapper to avoid passing function props across server/client boundary

## Testing
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e83973b18833097fd06c55a0dac00