### PR TITLE
Fix SoftwareDetail route to await params and use client wrapper

### DIFF
--- a/frontend/src/app/softwares/[id]/SoftwareDetailPageClient.tsx
+++ b/frontend/src/app/softwares/[id]/SoftwareDetailPageClient.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import SoftwareDetail from "../../../Modules/Software/SoftwareDetail";
+import { FC } from "wide-containers";
+
+export default function SoftwareDetailPageClient() {
+  return (
+    <FC g={2} p={2} mx={"auto"} maxW={700}>
+      <SoftwareDetail />
+    </FC>
+  );
+}

--- a/frontend/src/app/softwares/[id]/page.tsx
+++ b/frontend/src/app/softwares/[id]/page.tsx
@@ -1,9 +1,8 @@
 import type { Metadata } from "next";
-import SoftwareDetail from "../../../Modules/Software/SoftwareDetail";
-import { FC } from "wide-containers";
+import SoftwareDetailPageClient from "./SoftwareDetailPageClient";
 
-export async function generateMetadata({ params }: { params: { id: string } }): Promise<Metadata> {
-  const { id } = params;
+export async function generateMetadata({ params }: { params: Promise<{ id: string }> }): Promise<Metadata> {
+  const { id } = await params;
   return {
     title: `Software ${id} - XLARTAS`,
     description: `Details about software ${id} on XLARTAS platform`,
@@ -11,9 +10,5 @@ export async function generateMetadata({ params }: { params: { id: string } }): 
 }
 
 export default function SoftwareDetailPage() {
-  return (
-    <FC g={2} p={2} mx={"auto"} maxW={700}>
-      <SoftwareDetail />
-    </FC>
-  );
+  return <SoftwareDetailPageClient />;
 }


### PR DESCRIPTION
## Summary
- Split SoftwareDetail page into server and client components to prevent passing functions from server to client
- Await dynamic route params in generateMetadata to satisfy Next.js requirements

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next: not found)*
- `npm ci` *(fails: dependency resolution ERESOLVE)*

------
https://chatgpt.com/codex/tasks/task_e_688e865b63ac8330aeeb413d3515c98f