### PR TITLE
Fix auth context on software detail page

### DIFF
--- a/frontend/src/app/softwares/[id]/SoftwareDetailPageClient.tsx
+++ b/frontend/src/app/softwares/[id]/SoftwareDetailPageClient.tsx
@@ -4,6 +4,7 @@
 import {FC} from "wide-containers";
 import {useParams} from "next/navigation";
 import SoftwareDetail from "../../../Modules/Software/SoftwareDetail";
+import Providers from "../../../providers";
 
 export default function SoftwareDetailPageClient() {
     const params = useParams();
@@ -16,8 +17,10 @@ export default function SoftwareDetailPageClient() {
     }
 
     return (
-        <FC g={2} p={2} mx={"auto"} maxW={700}>
-            <SoftwareDetail id={id}/>
-        </FC>
+        <Providers>
+            <FC g={2} p={2} mx={"auto"} maxW={700}>
+                <SoftwareDetail/>
+            </FC>
+        </Providers>
     );
 }


### PR DESCRIPTION
## Summary
- wrap software detail page in application providers to ensure AuthContext is available

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: sh: 1: next: not found)


------
https://chatgpt.com/codex/tasks/task_e_688e8ad632dc8330a5a3ea21928e0b4f