### PR TITLE
fix: correct search params usage

### DIFF
--- a/frontend/src/Modules/Order/OrderActions.tsx
+++ b/frontend/src/Modules/Order/OrderActions.tsx
@@ -35,7 +35,7 @@ const OrderActions: React.FC<OrderActionsProps> = (
     const {api} = useApi()
     const {t} = useTranslation();
     const [payModal, setPayModal] = useState(false);
-    const [searchParams] = useSearchParams();
+    const searchParams = useSearchParams();
 
     // если в URL есть `?pay=1`, открываем modal сразу
     React.useEffect(() => {


### PR DESCRIPTION
## Summary
- fix SearchParams hook usage by avoiding array destructuring

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e8d9df5608330a7c3b131e39eaf02