### PR TITLE
feat: mark xlmine landing as client component

### DIFF
--- a/frontend/src/Modules/xLMine/XLMineLanding.tsx
+++ b/frontend/src/Modules/xLMine/XLMineLanding.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 // Modules/xLMine/XLMineLanding.tsx
 
 import React, {useEffect, useRef, useState} from 'react';


### PR DESCRIPTION
## Summary
- mark XLMine landing component as a client component so hooks run correctly

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next: not found)*
- `npm install` *(fails: ERESOLVE could not resolve)*

------
https://chatgpt.com/codex/tasks/task_e_688e8e89c8b48330a8f62199336ce167