### PR TITLE
refactor: centralize xLMine API calls with hook

### DIFF
--- a/frontend/src/Modules/xLMine/Donate/DonateModal.tsx
+++ b/frontend/src/Modules/xLMine/Donate/DonateModal.tsx
@@ -9,13 +9,13 @@ import CloseIcon from "@mui/icons-material/Close";
 import Tooltip from "@mui/material/Tooltip";
 import {Button, Slider} from "@mui/material";
 import {useAuth} from "Auth/AuthContext";
-import {useApi} from "Modules/Api/useApi";
 import {Message} from "Core/components/Message";
 import CircularProgressZoomify from "Core/components/elements/CircularProgressZoomify";
 import {FC, FCSC, FR, FRBC, FRSC} from "wide-containers";
 import {useErrorProcessing} from "Core/components/ErrorProvider";
 import {IDonate} from "./types";
 import PrivilegesView from "../Privilege/PrivilegesView";
+import {useXLMineApi} from 'xLMine/useXLMineApi';
 
 const MIN_COINS = 10;
 const MAX_COINS = 10000;
@@ -44,7 +44,7 @@ const DonateModal: React.FC<IDonateModalProps> = ({isOpen, onClose}) => {
     const [loading, setLoading] = useState<boolean>(false);
 
     const {isAuthenticated} = useAuth();
-    const {api} = useApi();
+    const {getLatestDonateProduct, createOrder} = useXLMineApi();
     const {notAuthentication} = useErrorProcessing();
     const {t} = useTranslation();
 
@@ -54,8 +54,7 @@ const DonateModal: React.FC<IDonateModalProps> = ({isOpen, onClose}) => {
         setCoins(MIN_COINS);
         setDonate(null);
         setPrice(1);
-        api
-            .get("/api/v1/xlmine/donate/product/latest/")
+        getLatestDonateProduct()
             .then((data) => {
                 setDonate(data);
                 // Берём price из product.prices[0].amount
@@ -65,7 +64,7 @@ const DonateModal: React.FC<IDonateModalProps> = ({isOpen, onClose}) => {
                 }
             })
             .catch((_error) => null);
-    }, [isOpen, api]);
+    }, [isOpen, getLatestDonateProduct]);
 
     const handleClose = () => {
         if (!loading) onClose();
@@ -91,8 +90,7 @@ const DonateModal: React.FC<IDonateModalProps> = ({isOpen, onClose}) => {
             coins_amount: coins,
             amount: finalCost,
         };
-        api
-            .post("/api/v1/orders/create/", payload)
+        createOrder(payload)
             .then((_data) => {
                 Message.success(t('donate_coins_created_success'), 2, 5000);
                 onClose();

--- a/frontend/src/Modules/xLMine/LauncherManager.tsx
+++ b/frontend/src/Modules/xLMine/LauncherManager.tsx
@@ -19,15 +19,15 @@ import {
 import CircularProgressZoomify from 'Core/components/elements/CircularProgressZoomify';
 import {Message} from 'Core/components/Message';
 import DeleteIcon from '@mui/icons-material/Delete';
-import {useApi} from "Api/useApi";
 import {FC, FCCC, FRSC} from "wide-containers";
 import FileUpload from "../../UI/FileUpload";
 import {ILauncher} from "./types/base";
 import TextField from "@mui/material/TextField";
 import Collapse from '@mui/material/Collapse';
+import {useXLMineApi} from 'xLMine/useXLMineApi';
 
 const LauncherManager: React.FC = () => {
-    const {api} = useApi();
+    const {getLaunchers, createLauncher, deleteLauncher} = useXLMineApi();
     const {t} = useTranslation();
 
     // ==== Состояния ====
@@ -48,7 +48,7 @@ const LauncherManager: React.FC = () => {
     const fetchVersions = async () => {
         setLoading(true);
         try {
-            const {results} = await api.get('/api/v1/xlmine/launcher/');
+            const {results} = await getLaunchers();
             setLaunchers(results);
         } catch (error) {
             Message.error(t('launcher_versions_load_error'));
@@ -83,9 +83,7 @@ const LauncherManager: React.FC = () => {
             formData.append('file', file);
             formData.append('version', version);
 
-            const newVersion = await api.post('/api/v1/xlmine/launcher/', formData, {
-                headers: {'Content-Type': 'multipart/form-data'}
-            });
+            const newVersion = await createLauncher(formData);
 
             setLaunchers(prev => [...prev, newVersion]);
 
@@ -114,7 +112,7 @@ const LauncherManager: React.FC = () => {
         if (!confirmDeleteId) return;
         setDeletingId(confirmDeleteId);
         try {
-            await api.delete(`/api/v1/xlmine/launcher/${confirmDeleteId}/`);
+            await deleteLauncher(confirmDeleteId);
             Message.success(t('version_deleted'));
             setLaunchers(prev => prev.filter(item => item.id !== confirmDeleteId));
         } catch (error) {

--- a/frontend/src/Modules/xLMine/Privilege/PrivilegesView.tsx
+++ b/frontend/src/Modules/xLMine/Privilege/PrivilegesView.tsx
@@ -1,6 +1,5 @@
 // Modules/xLMine/Privilege/PrivilegesView.tsx
 import React, {useEffect, useState} from 'react';
-import {useApi} from "Modules/Api/useApi";
 import {Message} from "Core/components/Message";
 import CircularProgressZoomify from "Core/components/elements/CircularProgressZoomify";
 import {useTheme} from "Theme/ThemeContext";
@@ -8,6 +7,7 @@ import {IPrivilege} from "../types/base";
 import {FC, FCCC, FRSC} from "wide-containers";
 import PrivilegeItem from "./PrivilegeItem";
 import {useTranslation} from 'react-i18next';
+import {useXLMineApi} from 'xLMine/useXLMineApi';
 
 interface ICurrentPrivilegeResponse {
     privilege: IPrivilege | null;
@@ -16,7 +16,7 @@ interface ICurrentPrivilegeResponse {
 
 
 const PrivilegesView: React.FC = () => {
-    const {api} = useApi();
+    const {getPrivileges, getCurrentPrivilege} = useXLMineApi();
     const {plt} = useTheme();
     const {t} = useTranslation();
 
@@ -30,8 +30,8 @@ const PrivilegesView: React.FC = () => {
     useEffect(() => {
         setLoading(true);
         Promise.all([
-            api.get<IPrivilege[]>('/api/v1/xlmine/privilege/'),
-            api.get<ICurrentPrivilegeResponse>('/api/v1/xlmine/privilege/current/')
+            getPrivileges(),
+            getCurrentPrivilege()
         ])
             .then(([privData, currentData]) => {
                 setPrivileges(privData);
@@ -43,7 +43,7 @@ const PrivilegesView: React.FC = () => {
                 setTotalDonate(0);
             })
             .finally(() => setLoading(false));
-    }, [api]);
+    }, [getPrivileges, getCurrentPrivilege]);
 
     if (loading) return <FCCC><CircularProgressZoomify in size="60px"/></FCCC>;
     if (!privileges || privileges.length === 0) return null; // Привилегий нет у юзера

--- a/frontend/src/Modules/xLMine/Privilege/UserPrivilege.tsx
+++ b/frontend/src/Modules/xLMine/Privilege/UserPrivilege.tsx
@@ -1,6 +1,5 @@
 // Modules/xLMine/Privilege/UserPrivilege.tsx
 import React, {useEffect, useState} from 'react';
-import {useApi} from 'Api/useApi';
 import {FC, FR, FRCC} from 'wide-containers';
 import CircularProgressZoomify from 'Core/components/elements/CircularProgressZoomify';
 import {Message} from 'Core/components/Message';
@@ -8,9 +7,10 @@ import Tooltip from '@mui/material/Tooltip';
 import Zoom from '@mui/material/Zoom';
 import {IPrivilege} from '../types/base';
 import {useTranslation} from 'react-i18next';
+import {useXLMineApi} from 'xLMine/useXLMineApi';
 
 const UserPrivilege: React.FC = () => {
-    const {api} = useApi();
+    const {getCurrentPrivilege} = useXLMineApi();
     const [privilege, setPrivilege] = useState<IPrivilege | null | undefined>(undefined);
     const {t} = useTranslation();
 
@@ -38,13 +38,13 @@ const UserPrivilege: React.FC = () => {
     };
 
     useEffect(() => {
-        api.get('/api/v1/xlmine/privilege/current/')
+        getCurrentPrivilege()
             .then(data => setPrivilege(data.privilege))
             .catch(() => {
                 Message.error(t('privilege_load_error'));
                 setPrivilege(null);
             });
-    }, [api]);
+    }, [getCurrentPrivilege]);
 
     // Показываем индикатор загрузки, пока привилегия не получена
     if (privilege === undefined) {

--- a/frontend/src/Modules/xLMine/SkinCape/SkinCapeSetter.tsx
+++ b/frontend/src/Modules/xLMine/SkinCape/SkinCapeSetter.tsx
@@ -1,13 +1,13 @@
 // Modules/xLMine/SkinCape/SkinCapeSetter.tsx
 import React, {useCallback, useEffect, useState} from 'react';
 import {useTranslation} from 'react-i18next';
-import {useApi} from 'Modules/Api/useApi';
 import {Button} from "@mui/material";
 import {FCC, FRCC} from "wide-containers";
 import {Message} from 'Core/components/Message';
+import {useXLMineApi} from 'xLMine/useXLMineApi';
 
 const SkinCapeSetter: React.FC = () => {
-    const {api} = useApi();
+    const {getCurrentSkinCape, uploadSkin, uploadCape} = useXLMineApi();
     const {t} = useTranslation();
     const [skinUrl, setSkinUrl] = useState<string | null>(null);
     const [capeUrl, setCapeUrl] = useState<string | null>(null);
@@ -15,12 +15,12 @@ const SkinCapeSetter: React.FC = () => {
     const [validCape, setValidCape] = useState<boolean>(false);
 
     const fetchCurrent = useCallback(async () => {
-        const data = await api.get('/api/v1/xlmine/current/skin-cape/');
+        const data = await getCurrentSkinCape();
         if (data?.skin) setSkinUrl(data.skin);
         else setSkinUrl(null);
         if (data?.cape) setCapeUrl(data.cape);
         else setCapeUrl(null);
-    }, [api]);
+    }, [getCurrentSkinCape]);
 
     useEffect(() => {
         fetchCurrent().then();
@@ -64,11 +64,9 @@ const SkinCapeSetter: React.FC = () => {
         const fd = new FormData();
         fd.append(type, file);
         try {
-            const data = await api.post(
-                `/api/v1/xlmine/${type === 'skin' ? 'skin' : 'cape'}/`,
-                fd,
-                {headers: {'Content-Type': 'multipart/form-data'}}
-            );
+            const data = type === 'skin'
+                ? await uploadSkin(fd)
+                : await uploadCape(fd);
             if (type === 'skin') setSkinUrl(data.skin);
             else setCapeUrl(data.cape);
             Message.success(t('update_success'));

--- a/frontend/src/Modules/xLMine/XLMineLanding.tsx
+++ b/frontend/src/Modules/xLMine/XLMineLanding.tsx
@@ -16,6 +16,7 @@ import {useDispatch} from 'react-redux';
 import {hideBackgroundFlicker, showBackgroundFlicker} from 'Redux/visibilitySlice';
 import {useTranslation} from 'react-i18next';
 import Head from "Core/components/Head";
+import {useXLMineApi} from 'xLMine/useXLMineApi';
 
 // Пример: можно использовать кастомные пути к картинкам
 // Замените на свои реальные изображения
@@ -41,10 +42,11 @@ const XLMineLanding: React.FC = () => {
     const MOVE_PERCENT = 25;   // усиление движения мышью
     const AUTO_PERCENT = 5;    // автоматическое движение
 
+    const {getLatestLauncher} = useXLMineApi();
+
     const handleDownload = async () => {
         setLoading(true);
-        const response = await fetch('/api/v1/xlmine/launcher/latest/');
-        const data = await response.json();
+        const data = await getLatestLauncher();
         window.location.href = data.file;
         setTimeout(() => {
             setLoading(false);

--- a/frontend/src/Modules/xLMine/useXLMineApi.ts
+++ b/frontend/src/Modules/xLMine/useXLMineApi.ts
@@ -1,0 +1,45 @@
+import {useApi} from 'Api/useApi';
+
+export const useXLMineApi = () => {
+    const {api} = useApi();
+
+    return {
+        // Launcher endpoints
+        getLaunchers: () => api.get('/api/v1/xlmine/launcher/'),
+        createLauncher: (formData: FormData) =>
+            api.post('/api/v1/xlmine/launcher/', formData, {
+                headers: {'Content-Type': 'multipart/form-data'},
+            }),
+        deleteLauncher: (id: number) => api.delete(`/api/v1/xlmine/launcher/${id}/`),
+        getLatestLauncher: () => api.get('/api/v1/xlmine/launcher/latest/'),
+
+        // Release endpoints
+        getReleases: () => api.get('/api/v1/xlmine/release/'),
+        uploadReleaseChunk: (formData: FormData) =>
+            api.post('/api/v1/xlmine/chunked-release/', formData, {
+                headers: {'Content-Type': 'multipart/form-data'},
+            }),
+        deleteRelease: (id: number) => api.delete(`/api/v1/xlmine/release/${id}/`),
+
+        // Skin & Cape
+        getCurrentSkinCape: () => api.get('/api/v1/xlmine/current/skin-cape/'),
+        uploadSkin: (formData: FormData) =>
+            api.post('/api/v1/xlmine/skin/', formData, {
+                headers: {'Content-Type': 'multipart/form-data'},
+            }),
+        uploadCape: (formData: FormData) =>
+            api.post('/api/v1/xlmine/cape/', formData, {
+                headers: {'Content-Type': 'multipart/form-data'},
+            }),
+
+        // Privileges
+        getPrivileges: () => api.get('/api/v1/xlmine/privilege/'),
+        getCurrentPrivilege: () => api.get('/api/v1/xlmine/privilege/current/'),
+
+        // Donate
+        getLatestDonateProduct: () => api.get('/api/v1/xlmine/donate/product/latest/'),
+        createOrder: (payload: unknown) => api.post('/api/v1/orders/create/', payload),
+    };
+};
+
+export type UseXLMineApi = ReturnType<typeof useXLMineApi>;


### PR DESCRIPTION
## Summary
- add `useXLMineApi` hook wrapping all xLMine endpoints
- refactor xLMine components to use the new hook instead of hardcoded URLs

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: next: not found; dependencies could not be installed due to conflicts)*

------
https://chatgpt.com/codex/tasks/task_e_689558c1afd48330a6e19cc159bae776