### PR TITLE
refactor: centralize API calls via hooks

### DIFF
--- a/frontend/src/Modules/Auth/Social/components/SocialOAuth.tsx
+++ b/frontend/src/Modules/Auth/Social/components/SocialOAuth.tsx
@@ -5,7 +5,8 @@ import React, {useEffect, useRef, useState} from 'react';
 import {Button as MuiButton, Button, Dialog, DialogActions, DialogContent, DialogTitle, Snackbar} from '@mui/material';
 import MuiAlert, {AlertProps} from '@mui/material/Alert';
 import {faGoogle, faYandex} from '@fortawesome/free-brands-svg-icons';
-import {axios, GOOGLE_CLIENT_ID, YANDEX_CLIENT_ID} from '../../../Api/axiosConfig';
+import {GOOGLE_CLIENT_ID, YANDEX_CLIENT_ID} from '../../../Api/axiosConfig';
+import {useAuthApi} from 'Auth/useAuthApi';
 import OAuthButton from "Auth/Social/elements/OAuthButton";
 import {ProviderConfig} from "Auth/Social/types";
 import {useAuth} from "Auth/AuthContext";
@@ -24,6 +25,7 @@ interface SocialOAuthProps {
 const SocialOAuth: React.FC<SocialOAuthProps> = ({className}) => {
     const socialDiv = useRef<HTMLDivElement | null>(null);
     const {isAuthenticated} = useAuth();
+    const {getSocialAccounts} = useAuthApi();
     const [openSnackbar, setOpenSnackbar] = useState<boolean>(false);
     const [socialAccounts, setSocialAccounts] = useState<{ [key: string]: boolean }>({});
     const [pendingOAuthUrl, setPendingOAuthUrl] = useState<string | null>(null);
@@ -38,14 +40,14 @@ const SocialOAuth: React.FC<SocialOAuthProps> = ({className}) => {
 
     useEffect(() => {
         if (isAuthenticated)
-            axios.get('/api/v1/oauth/user/social-accounts/')
-                .then(response => {
-                    setSocialAccounts(response.data);
+            getSocialAccounts()
+                .then(data => {
+                    setSocialAccounts(data);
                 })
                 .catch(error => {
                     console.error(error);
                 });
-    }, [isAuthenticated]);
+    }, [isAuthenticated, getSocialAccounts]);
 
     const providers: ProviderConfig[] = [
         {

--- a/frontend/src/Modules/Auth/useAuthApi.ts
+++ b/frontend/src/Modules/Auth/useAuthApi.ts
@@ -1,0 +1,21 @@
+import {useApi} from 'Api/useApi';
+import {JWTPair} from 'types/core/auth';
+import {IUser} from 'types/core/user';
+
+export const useAuthApi = () => {
+    const {api} = useApi();
+
+    return {
+        login: (username: string, password: string) =>
+            api.post<JWTPair>('/api/v1/token/', {username, password}),
+        logout: () => api.post('/api/v1/logout/'),
+        getCurrentUser: () => api.get<IUser>('/api/v1/current_user/'),
+        oauthCallback: (provider: string, code: string) =>
+            api.get(`/api/v1/oauth/${provider}/callback/`, {params: {code}}),
+        refreshToken: (refresh: string) =>
+            api.post<{access: string; refresh?: string}>('/api/v1/token/refresh/', {refresh}),
+        getSocialAccounts: () => api.get<Record<string, boolean>>('/api/v1/oauth/user/social-accounts/'),
+    };
+};
+
+export type UseAuthApi = ReturnType<typeof useAuthApi>;

--- a/frontend/src/Modules/Chat/useChatApi.ts
+++ b/frontend/src/Modules/Chat/useChatApi.ts
@@ -1,0 +1,12 @@
+import {useApi} from 'Api/useApi';
+import {IRoom} from 'types/chat/models';
+
+export const useChatApi = () => {
+    const {api} = useApi();
+    return {
+        listRooms: () => api.get<{results: IRoom[]; next: string | null}>("/api/v1/rooms/"),
+        listRoomsByUrl: (url: string) => api.get<{results: IRoom[]; next: string | null}>(url),
+    };
+};
+
+export type UseChatApi = ReturnType<typeof useChatApi>;

--- a/frontend/src/Modules/Core/LanguageContext.tsx
+++ b/frontend/src/Modules/Core/LanguageContext.tsx
@@ -1,6 +1,7 @@
 // Modules/Core/LanguageContext.tsx
 import React, {createContext, PropsWithChildren, useEffect, useState} from 'react';
 import axios from 'axios';
+import {useCoreApi} from 'Core/useCoreApi';
 import moment from 'moment';
 import 'moment/locale/ru';
 import i18n from "../../i18n";
@@ -21,6 +22,8 @@ export const LangProvider: React.FC<PropsWithChildren> = ({children}) => {
             ? ((localStorage.getItem('lang') as Lang) || 'ru')
             : 'ru',
     );
+    const {setLang: setLangRequest} = useCoreApi();
+
 
     const setLang = (l: Lang) => {
         i18n.changeLanguage(l).then();
@@ -30,7 +33,7 @@ export const LangProvider: React.FC<PropsWithChildren> = ({children}) => {
         }
         setLangState(l);
         axios.defaults.headers.common['Accept-Language'] = l;
-        axios.post('/api/v1/user/set-lang/', {lang: l}).catch(() => null);
+        setLangRequest(l);
     };
 
     /* init once */

--- a/frontend/src/Modules/Core/useCoreApi.ts
+++ b/frontend/src/Modules/Core/useCoreApi.ts
@@ -1,0 +1,10 @@
+import {useApi} from 'Api/useApi';
+
+export const useCoreApi = () => {
+    const {api} = useApi();
+    return {
+        setLang: (lang: string) => api.post('/api/v1/user/set-lang/', {lang}, undefined, true),
+    };
+};
+
+export type UseCoreApi = ReturnType<typeof useCoreApi>;


### PR DESCRIPTION
## Summary
- add dedicated useAuthApi, useChatApi, and useCoreApi hooks
- refactor auth, chat, and language logic to consume new hooks

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: sh: next: not found)
- `npm install --no-audit --no-fund` (fails: 403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_68955af548bc83309f3284b74fd06d9e