### PR TITLE
refactor(frontend): centralize api calls via hooks

### DIFF
--- a/frontend/src/Modules/Auth/forms/AuthForm.tsx
+++ b/frontend/src/Modules/Auth/forms/AuthForm.tsx
@@ -16,7 +16,7 @@ import {Message} from "Core/components/Message";
 import {isEmail, isPhone} from "Utils/validator/base";
 import SignUpForm from "Auth/forms/SignUpForm";
 import BackButton from "Core/components/BackButton";
-import {useApi} from "Api/useApi";
+import {useAuthApi} from 'Auth/useAuthApi';
 import {useTranslation} from "react-i18next";
 
 type AuthFormProps = {
@@ -45,7 +45,7 @@ const AuthForm: React.FC<AuthFormProps> = ({ways = ['phone']}) => {
     const [useConfirmation, setUseConfirmation] = useState<boolean>(false);
     const [confirmationAction, setConfirmationAction] = useState<string>('auth'); // 'auth' or 'signup'
     const [initialCodeSent, setInitialCodeSent] = useState<boolean>(false);
-    const {api} = useApi();
+    const {getAuthMethods} = useAuthApi();
 
     useEffect(() => {
         if (!hasPhone && hasEmail) setSelectedTab(1);
@@ -106,7 +106,7 @@ const AuthForm: React.FC<AuthFormProps> = ({ways = ['phone']}) => {
     const handleNextStep = async (e: React.FormEvent) => {
         e.preventDefault();
         setLoading(true);
-        api.post('/api/v1/user/auth_methods/', {credential}).then(data => {
+        getAuthMethods(credential).then(data => {
             if (data.user_not_exists) {
                 setStep(3);
             } else {

--- a/frontend/src/Modules/Auth/forms/SignUpForm.tsx
+++ b/frontend/src/Modules/Auth/forms/SignUpForm.tsx
@@ -16,7 +16,7 @@ import {debounce} from 'lodash';
 import 'Core/components/elements/PhoneField/PhoneField.sass';
 import {YANDEX_RECAPTCHA_SITE_KEY} from "Api/axiosConfig";
 import pprint from "Utils/pprint";
-import {useApi} from "Api/useApi";
+import {useAuthApi} from 'Auth/useAuthApi';
 
 interface SignUpFormProps {
     credential: string;
@@ -59,7 +59,7 @@ const SignUpForm: React.FC<SignUpFormProps> = (
 
     const [initialCodeSent, setInitialCodeSent] = useState<boolean>(false);
 
-    const {api} = useApi();
+    const {checkPhoneExists, checkEmailExists, signup} = useAuthApi();
 
     useEffect(() => {
         pprint('credential');
@@ -83,7 +83,7 @@ const SignUpForm: React.FC<SignUpFormProps> = (
             if (phoneCheckRef.current) phoneCheckRef.current.cancel();
             if (valid) {
                 phoneCheckRef.current = debounce(async () => {
-                    api.post('/api/v1/check-phone-exists/', {phone}).then(
+                    checkPhoneExists(phone).then(
                         data => setIsPhoneAvailable(!data.exists)
                     );
                 }, 500);
@@ -103,7 +103,7 @@ const SignUpForm: React.FC<SignUpFormProps> = (
             if (emailCheckRef.current) emailCheckRef.current.cancel();
             if (valid) {
                 emailCheckRef.current = debounce(async () => {
-                    api.post('/api/v1/check-email-exists/', {email}).then(
+                    checkEmailExists(email).then(
                         data => setIsEmailAvailable(!data.exists)
                     );
                 }, 500);
@@ -135,7 +135,7 @@ const SignUpForm: React.FC<SignUpFormProps> = (
         if (mode === 'phone') data.phone = phone || null;
         else data.email = email || null;
 
-        api.post('/api/v1/signup/', data).then(data => {
+        signup(data).then(data => {
             Message.success(data.message);
             if (data.confirmation_sent) {
                 setConfirmationSent(true);

--- a/frontend/src/Modules/Auth/useAuthApi.ts
+++ b/frontend/src/Modules/Auth/useAuthApi.ts
@@ -15,6 +15,10 @@ export const useAuthApi = () => {
         refreshToken: (refresh: string) =>
             api.post<{access: string; refresh?: string}>('/api/v1/token/refresh/', {refresh}),
         getSocialAccounts: () => api.get<Record<string, boolean>>('/api/v1/oauth/user/social-accounts/'),
+        checkPhoneExists: (phone: string) => api.post('/api/v1/check-phone-exists/', {phone}),
+        checkEmailExists: (email: string) => api.post('/api/v1/check-email-exists/', {email}),
+        signup: (payload: unknown) => api.post('/api/v1/signup/', payload),
+        getAuthMethods: (credential: string) => api.post('/api/v1/user/auth_methods/', {credential}),
     };
 };
 

--- a/frontend/src/Modules/Chat/Room.tsx
+++ b/frontend/src/Modules/Chat/Room.tsx
@@ -15,7 +15,7 @@ import MessagesList from './MessagesList';
 import useRoomMessages from './useRoomMessages';
 import useRoomSocket from './useRoomSocket';
 import {useNavigation} from 'Core/components/Header/HeaderProvider';
-import {useApi} from 'Api/useApi';
+import {useChatApi} from 'Chat/useChatApi';
 
 interface RoomProps {
     room?: IRoom | null;
@@ -31,7 +31,7 @@ const Room: React.FC<RoomProps> = ({room: roomProp, roomId: propRoomId, showHead
     const {isAuthenticated: authStatus, user} = useAuth();
     const isAuthenticated = authStatus ?? false;
     const {notAuthentication} = useErrorProcessing();
-    const {api} = useApi();
+    const {getRoom} = useChatApi();
     const {t} = useTranslation();
 
     const {
@@ -44,7 +44,7 @@ const Room: React.FC<RoomProps> = ({room: roomProp, roomId: propRoomId, showHead
         fetchMessages,
         reset,
         messagesRef,
-    } = useRoomMessages({roomId, api});
+    } = useRoomMessages({roomId});
 
     const sendMessage = useRoomSocket({
         roomId: roomId || '',
@@ -55,8 +55,8 @@ const Room: React.FC<RoomProps> = ({room: roomProp, roomId: propRoomId, showHead
 
     const fetchRoom = useCallback(async () => {
         if (roomProp || !roomId) return;
-        api.get(`/api/v1/rooms/${roomId}/`).then(data => setRoom(data));
-    }, [roomId, api, roomProp]);
+        getRoom(roomId).then(data => setRoom(data));
+    }, [roomId, getRoom, roomProp]);
 
     useEffect(() => {
         if (!isAuthenticated) {

--- a/frontend/src/Modules/Chat/useChatApi.ts
+++ b/frontend/src/Modules/Chat/useChatApi.ts
@@ -6,6 +6,9 @@ export const useChatApi = () => {
     return {
         listRooms: () => api.get<{results: IRoom[]; next: string | null}>("/api/v1/rooms/"),
         listRoomsByUrl: (url: string) => api.get<{results: IRoom[]; next: string | null}>(url),
+        getRoom: (roomId: number | string) => api.get(`/api/v1/rooms/${roomId}/`),
+        listMessages: (roomId: number | string, url?: string) =>
+            api.get(url || `/api/v1/rooms/${roomId}/messages/`),
     };
 };
 

--- a/frontend/src/Modules/Chat/useRoomMessages.tsx
+++ b/frontend/src/Modules/Chat/useRoomMessages.tsx
@@ -4,13 +4,14 @@ import {useCallback, useEffect, useLayoutEffect, useRef, useState} from 'react';
 import {parseISO} from 'date-fns';
 import DateLabel from './DateLabel';
 import {IMessage} from 'types/chat/models';
+import {useChatApi} from 'Chat/useChatApi';
 
 interface UseRoomMessagesParams {
     roomId?: string;
-    api: any;
 }
 
-const useRoomMessages = ({roomId, api}: UseRoomMessagesParams) => {
+const useRoomMessages = ({roomId}: UseRoomMessagesParams) => {
+    const {listMessages} = useChatApi();
     const [messages, setMessages] = useState<IMessage[]>([]);
     const messagesRef = useRef<IMessage[]>(messages);
     const [nextPageUrl, setNextPageUrl] = useState<string | null>(null);
@@ -35,7 +36,7 @@ const useRoomMessages = ({roomId, api}: UseRoomMessagesParams) => {
         if (url && messagesContainerRef.current) {
             prevScrollHeightRef.current = messagesContainerRef.current.scrollHeight;
         }
-        api.get(url || `/api/v1/rooms/${roomId}/messages/`).then((data: any) => {
+        listMessages(roomId, url || undefined).then((data: any) => {
             setMessages(prev => {
                 const newMessages = data.results.filter((msg: IMessage) => !prev.some(e => e.id === msg.id));
                 return [...newMessages, ...prev];
@@ -62,7 +63,7 @@ const useRoomMessages = ({roomId, api}: UseRoomMessagesParams) => {
             setIsLoadingMore(false);
             isFetchingRef.current = false;
         });
-    }, [roomId, api, isLoadingMore]);
+    }, [roomId, isLoadingMore, listMessages]);
 
     const handleScroll = useCallback(() => {
         if (

--- a/frontend/src/Modules/Client/ClientPersonalInfoForm.tsx
+++ b/frontend/src/Modules/Client/ClientPersonalInfoForm.tsx
@@ -6,7 +6,7 @@ import {FC} from "wide-containers";
 import {Message} from "Core/components/Message";
 import TextField from "@mui/material/TextField";
 import {Button} from "@mui/material";
-import {useApi} from "Api/useApi";
+import {useClientApi} from 'Client/useClientApi';
 
 interface FormData {
     about_me: string;
@@ -19,7 +19,7 @@ const ClientPersonalInfoForm: React.FC = () => {
         about_me: user?.client?.about_me || '',
     });
 
-    const {api} = useApi();
+    const {updateClient} = useClientApi();
     const {t} = useTranslation();
     const [showSaveButton, setShowSaveButton] = useState(false);
     const [isSubmitting, setIsSubmitting] = useState(false);
@@ -36,7 +36,7 @@ const ClientPersonalInfoForm: React.FC = () => {
     const handleSubmit = async (e: FormEvent) => {
         e.preventDefault();
         setIsSubmitting(true);
-        api.patch('/api/v1/client/update/', formData).then(() => {
+        updateClient(formData as any).then(() => {
             Message.success(t('client_update_success'));
             setShowSaveButton(false);
         }).finally(() => setIsSubmitting(false));

--- a/frontend/src/Modules/Client/useClientApi.ts
+++ b/frontend/src/Modules/Client/useClientApi.ts
@@ -1,0 +1,13 @@
+import {useApi} from 'Api/useApi';
+
+export const useClientApi = () => {
+    const {api} = useApi();
+    return {
+        updateClient: (formData: FormData) =>
+            api.patch('/api/v1/client/update/', formData, {
+                headers: {'Content-Type': 'multipart/form-data'},
+            }),
+    };
+};
+
+export type UseClientApi = ReturnType<typeof useClientApi>;

--- a/frontend/src/Modules/Company/CompanyDocumentDetail.tsx
+++ b/frontend/src/Modules/Company/CompanyDocumentDetail.tsx
@@ -8,7 +8,7 @@ import ReactMarkdown from 'react-markdown';
 import {Link, Typography} from '@mui/material';
 import {FC} from "wide-containers";
 import {CompanyDocument} from "Company/Types";
-import {useApi} from "Api/useApi";
+import {useCompanyApi} from 'Company/useCompanyApi';
 import Head from "Core/components/Head";
 
 
@@ -17,11 +17,11 @@ const CompanyDocumentDetail: React.FC = () => {
     const [document, setDocument] = useState<CompanyDocument | null>(null);
     const [loading, setLoading] = useState<boolean>(true);
 
-    const {api} = useApi();
+    const {getDocument} = useCompanyApi();
     const {t} = useTranslation();
     useEffect(() => {
         const fetchDocument = async () => {
-            api.get(`/api/v1/docs/${id}/`).then(data => setDocument(data)).finally(() => setLoading(false));
+            getDocument(id!).then(data => setDocument(data)).finally(() => setLoading(false));
         };
         if (id) {
             fetchDocument().then();
@@ -29,7 +29,7 @@ const CompanyDocumentDetail: React.FC = () => {
             setLoading(false);
             Message.error(t('document_id_not_specified'));
         }
-    }, [id]);
+    }, [id, getDocument, t]);
 
     if (loading) return <CircularProgressZoomify in size="60px"/>;
 

--- a/frontend/src/Modules/Company/CompanyPage.tsx
+++ b/frontend/src/Modules/Company/CompanyPage.tsx
@@ -7,7 +7,7 @@ import CircularProgressZoomify from 'Core/components/elements/CircularProgressZo
 import {FC, FCSS, FR} from "wide-containers";
 import {Company} from "Company/Types";
 import {useTheme} from "Theme/ThemeContext";
-import {useApi} from "Api/useApi";
+import {useCompanyApi} from 'Company/useCompanyApi';
 import copyToClipboard from "Utils/clipboard";
 import './CompanyPage.sass'
 import Head from "Core/components/Head";
@@ -19,13 +19,13 @@ const CompanyPage: React.FC = () => {
     const [loading, setLoading] = useState<boolean>(true);
     const navigate = useNavigate();
     const {theme} = useTheme();
-    const {api} = useApi();
+    const {getCompany} = useCompanyApi();
     const {t} = useTranslation();
 
     useEffect(() => {
         if (!name) return
         const fetchCompany = async () => {
-            api.get(`/api/v1/companies/${encodeURIComponent(name)}/`).then(data => setCompany(data)).finally(() => setLoading(false));
+            getCompany(name).then(data => setCompany(data)).finally(() => setLoading(false));
         };
         if (name) {
             fetchCompany().then();
@@ -33,7 +33,7 @@ const CompanyPage: React.FC = () => {
             setLoading(false);
             Message.error(t('company_name_not_specified'));
         }
-    }, [name, api]);
+    }, [name, getCompany]);
 
     if (loading) {
         return <CircularProgressZoomify in size="60px"/>;

--- a/frontend/src/Modules/Company/useCompanyApi.ts
+++ b/frontend/src/Modules/Company/useCompanyApi.ts
@@ -1,0 +1,11 @@
+import {useApi} from 'Api/useApi';
+
+export const useCompanyApi = () => {
+    const {api} = useApi();
+    return {
+        getCompany: (name: string) => api.get(`/api/v1/companies/${encodeURIComponent(name)}/`),
+        getDocument: (id: number | string) => api.get(`/api/v1/docs/${id}/`),
+    };
+};
+
+export type UseCompanyApi = ReturnType<typeof useCompanyApi>;

--- a/frontend/src/Modules/Confirmation/ConfirmationCode.tsx
+++ b/frontend/src/Modules/Confirmation/ConfirmationCode.tsx
@@ -12,7 +12,7 @@ import {FC, FCCC} from 'wide-containers';
 import CircularProgressZoomify from 'Core/components/elements/CircularProgressZoomify';
 import {isEmail, isPhone} from 'Utils/validator/base';
 import pprint from 'Utils/pprint';
-import {useApi} from "Api/useApi";
+import {useConfirmationApi} from 'Confirmation/useConfirmationApi';
 
 export type ConfirmationMethod = 'email' | 'phone';
 
@@ -61,7 +61,7 @@ const ConfirmationCode: React.FC<ConfirmationCodeProps> = (
     const [resetCaptcha, setResetCaptcha] = useState<number>(0);
     const [isSending, setIsSending] = useState<boolean>(false);
     const {plt} = useTheme();
-    const {api} = useApi();
+    const {confirmCode: confirmCodeApi, sendCode} = useConfirmationApi();
     const {t} = useTranslation();
 
     useEffect(() => {
@@ -96,7 +96,7 @@ const ConfirmationCode: React.FC<ConfirmationCodeProps> = (
 
     const confirmCode = async () => {
         try {
-            const data = await api.post('/api/v1/confirmation-code/confirm/', {
+            const data = await confirmCodeApi({
                 code,
                 credential,
                 action,
@@ -134,10 +134,7 @@ const ConfirmationCode: React.FC<ConfirmationCodeProps> = (
                     captchaToken,
                     ...additional_params,
                 };
-            const endpoint = initialCodeSent
-                ? '/api/v1/confirmation-code/resend/'
-                : '/api/v1/confirmation-code/new/';
-            const data = await api.post(endpoint, payload);
+            const data = await sendCode(payload, initialCodeSent);
             if (onGeneratedCode) onGeneratedCode();
             setResendTimeout(60);
             setCodeSent(true);

--- a/frontend/src/Modules/Confirmation/useConfirmationApi.ts
+++ b/frontend/src/Modules/Confirmation/useConfirmationApi.ts
@@ -1,0 +1,12 @@
+import {useApi} from 'Api/useApi';
+
+export const useConfirmationApi = () => {
+    const {api} = useApi();
+    return {
+        confirmCode: (payload: unknown) => api.post('/api/v1/confirmation-code/confirm/', payload),
+        sendCode: (payload: unknown, isResend: boolean) =>
+            api.post(isResend ? '/api/v1/confirmation-code/resend/' : '/api/v1/confirmation-code/new/', payload),
+    };
+};
+
+export type UseConfirmationApi = ReturnType<typeof useConfirmationApi>;

--- a/frontend/src/Modules/Converter/ConversationResultCard.tsx
+++ b/frontend/src/Modules/Converter/ConversationResultCard.tsx
@@ -6,6 +6,7 @@ import {IConversion} from 'types/converter';
 import formatFileSize from 'Utils/formatFileSize';
 import {useTheme} from 'Modules/Theme/ThemeContext';
 import {FRBC} from "wide-containers";
+import {useConverterApi} from 'Converter/useConverterApi';
 
 interface ConversationResultCardProps {
     conversion: IConversion | null;
@@ -13,6 +14,7 @@ interface ConversationResultCardProps {
 
 const ConversationResultCard: React.FC<ConversationResultCardProps> = ({conversion}) => {
     const {plt} = useTheme();
+    const {getDownloadLink} = useConverterApi();
     if (!conversion?.is_done || !conversion.output_file) return null;
 
     return (
@@ -27,7 +29,7 @@ const ConversationResultCard: React.FC<ConversationResultCardProps> = ({conversi
             )}
             <IconButton
                 color="primary"
-                href={`/api/v1/converter/download/${conversion.id}/`}
+                href={getDownloadLink(conversion.id)}
                 download
             >
                 <DownloadRoundedIcon/>

--- a/frontend/src/Modules/Converter/useConverterApi.ts
+++ b/frontend/src/Modules/Converter/useConverterApi.ts
@@ -1,0 +1,16 @@
+import {useApi} from 'Api/useApi';
+import {IFormat, IParameter, IConvertResult} from 'types/converter';
+
+export const useConverterApi = () => {
+    const {api} = useApi();
+    return {
+        listFormats: () => api.get<IFormat[]>('/api/v1/converter/formats/'),
+        getRemaining: () => api.get<{ remaining: number }>('/api/v1/converter/remaining/'),
+        listFormatVariants: (id: number) => api.get<IFormat[]>(`/api/v1/converter/formats/${id}/variants/`),
+        listFormatParameters: (id: number) => api.get<IParameter[]>(`/api/v1/converter/formats/${id}/parameters/`),
+        convert: (formData: FormData) => api.post<IConvertResult>('/api/v1/converter/convert/', formData),
+        getDownloadLink: (id: number | string) => `/api/v1/converter/download/${id}/`,
+    };
+};
+
+export type UseConverterApi = ReturnType<typeof useConverterApi>;

--- a/frontend/src/Modules/Core/SettingsTool.tsx
+++ b/frontend/src/Modules/Core/SettingsTool.tsx
@@ -10,7 +10,7 @@ import {useAuth} from 'Auth/AuthContext';
 import {FC, FCCC, FCSC} from "wide-containers";
 import {useTheme} from "Theme/ThemeContext";
 import CircularProgressZoomify from "Core/components/elements/CircularProgressZoomify";
-import {useApi} from "Api/useApi";
+import {useCoreApi} from 'Core/useCoreApi';
 
 interface BackendConfigResponse {
     config: {
@@ -26,7 +26,7 @@ const SettingsTool: React.FC = () => {
     const [data, setData] = useState<BackendConfigResponse | null>(null);
     const {isAuthenticated, user} = useAuth();
     const {theme} = useTheme();
-    const {api} = useApi();
+    const {getBackendConfig} = useCoreApi();
     const openModal = useCallback(() => {
         setIsOpen(true);
     }, []);
@@ -41,8 +41,8 @@ const SettingsTool: React.FC = () => {
             return;
         }
         pprint("Fetching backend config...");
-        api.get('/api/v1/backend/config/').then(data => setData(data));
-    }, [api, isAuthenticated, user]);
+        getBackendConfig().then(data => setData(data));
+    }, [getBackendConfig, isAuthenticated, user]);
 
     useEffect(() => {
         if (isOpen) {

--- a/frontend/src/Modules/Core/useCoreApi.ts
+++ b/frontend/src/Modules/Core/useCoreApi.ts
@@ -4,6 +4,7 @@ export const useCoreApi = () => {
     const {api} = useApi();
     return {
         setLang: (lang: string) => api.post('/api/v1/user/set-lang/', {lang}, undefined, true),
+        getBackendConfig: () => api.get('/api/v1/backend/config/'),
     };
 };
 

--- a/frontend/src/Modules/FileHost/AllFiles.tsx
+++ b/frontend/src/Modules/FileHost/AllFiles.tsx
@@ -1,7 +1,7 @@
 // Modules/FileHost/AllFiles.tsx
 import React, {useEffect, useState} from 'react';
 import PaginatedList from 'Core/components/elements/PaginatedList';
-import {useApi} from 'Api/useApi';
+import {useFileHostApi} from 'FileHost/useFileHostApi';
 import FileTableRow from './FileTableRow';
 import {IFile} from './types';
 import useFileUpload from './useFileUpload';
@@ -26,7 +26,7 @@ import {useTranslation} from 'react-i18next';
 import {getAllFilesCached, setAllFilesCached} from './storageCache';
 
 const AllFiles: React.FC = () => {
-    const {api} = useApi();
+    const {getFiles, bulkDelete} = useFileHostApi();
     const {handleUpload, uploads, clearUploads} = useFileUpload(null, () => setAllFilesCached(undefined as any));
     const {t} = useTranslation();
 
@@ -43,7 +43,7 @@ const AllFiles: React.FC = () => {
             const cached = getAllFilesCached();
             if (cached) return cached;
         }
-        const data = await api.get(`/api/v1/filehost/files/?page=${page}&page_size=20`);
+        const data = await getFiles(page, 20);
         if (page === 1) setAllFilesCached(data);
         return data;
     };
@@ -57,7 +57,7 @@ const AllFiles: React.FC = () => {
     }, [selected]);
 
     const deleteSelected = async () => {
-        await api.post('/api/v1/filehost/items/bulk_delete/', {file_ids: selected.map(s => s.id)});
+        await bulkDelete(selected.map(s => s.id));
         setSelected([]);
         setAllFilesCached(undefined as any);
         setTrigger(t => t + 1);

--- a/frontend/src/Modules/FileHost/FavoriteFiles.tsx
+++ b/frontend/src/Modules/FileHost/FavoriteFiles.tsx
@@ -1,7 +1,7 @@
 // Modules/FileHost/FavoriteFiles.tsx
 import React, {useEffect, useState} from 'react';
 import PaginatedList from 'Core/components/elements/PaginatedList';
-import {useApi} from 'Api/useApi';
+import {useFileHostApi} from 'FileHost/useFileHostApi';
 import FileTableRow from './FileTableRow';
 import {IFile} from './types';
 import useFileUpload from './useFileUpload';
@@ -26,7 +26,7 @@ import {useTranslation} from 'react-i18next';
 import {getFavoriteFilesCached, setFavoriteFilesCached} from './storageCache';
 
 const FavoriteFiles: React.FC = () => {
-    const {api} = useApi();
+    const {getFavoriteFiles, bulkDelete} = useFileHostApi();
     const {handleUpload, uploads, clearUploads} = useFileUpload(null, () => setFavoriteFilesCached(undefined as any));
     const {t} = useTranslation();
     const isGtSm = useMediaQuery('(min-width: 576px)');
@@ -43,7 +43,7 @@ const FavoriteFiles: React.FC = () => {
             const cached = getFavoriteFilesCached();
             if (cached) return cached;
         }
-        const data = await api.get(`/api/v1/filehost/files/favorite/?page=${page}&page_size=20`);
+        const data = await getFavoriteFiles(page, 20);
         if (page === 1) setFavoriteFilesCached(data);
         return data;
     };
@@ -57,7 +57,7 @@ const FavoriteFiles: React.FC = () => {
     }, [selected]);
 
     const deleteSelected = async () => {
-        await api.post('/api/v1/filehost/items/bulk_delete/', {file_ids: selected.map(s => s.id)});
+        await bulkDelete(selected.map(s => s.id));
         setSelected([]);
         setFavoriteFilesCached(undefined as any);
         setTrigger(t => t + 1);

--- a/frontend/src/Modules/FileHost/FileCard.tsx
+++ b/frontend/src/Modules/FileHost/FileCard.tsx
@@ -3,7 +3,7 @@ import React, {useEffect, useState} from 'react';
 import {IconButton, Paper} from '@mui/material';
 import StarIcon from '@mui/icons-material/Star';
 import {useNavigate} from 'Utils/nextRouter';
-import {useApi} from 'Api/useApi';
+import {useFileHostApi} from 'FileHost/useFileHostApi';
 import {IFile} from './types';
 import formatFileSize from 'Utils/formatFileSize';
 import {useTranslation} from 'react-i18next';
@@ -38,7 +38,7 @@ const FileCard: React.FC<Props> = (
         onShare,
         onSelectMode
     }) => {
-    const {api} = useApi();
+    const {toggleFavorite} = useFileHostApi();
     const navigate = useNavigate();
     const {t} = useTranslation();
     const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
@@ -50,7 +50,7 @@ const FileCard: React.FC<Props> = (
     const longPress = useLongPress(e => setAnchorEl(e.currentTarget as HTMLElement));
 
     const toggleFav = () => {
-        api.post('/api/v1/filehost/files/toggle_favorite/', {file_id: file.id}).then(d => {
+        toggleFavorite(file.id).then(d => {
             setFavorite(d.is_favorite);
             onFavorite && onFavorite({...file, is_favorite: d.is_favorite});
             setFavoriteFilesCached(undefined as any);

--- a/frontend/src/Modules/FileHost/FileDetail.tsx
+++ b/frontend/src/Modules/FileHost/FileDetail.tsx
@@ -1,7 +1,7 @@
 // Modules/FileHost/FileDetail.tsx
 import React, {useEffect, useState} from 'react';
 import {useNavigate, useParams} from 'Utils/nextRouter';
-import {useApi} from 'Api/useApi';
+import {useFileHostApi} from 'FileHost/useFileHostApi';
 import {IFile} from './types';
 import {Container, FC, FR, FRBC} from 'wide-containers';
 
@@ -16,7 +16,7 @@ import ImagePreview from "UI/ImagePreview";
 
 const FileDetail: React.FC = () => {
     const {id} = useParams();
-    const {api} = useApi();
+    const {getFile, deleteItem} = useFileHostApi();
     const navigate = useNavigate();
     const {t} = useTranslation();
     const [file, setFile] = useState<IFile | null>(null);
@@ -25,8 +25,8 @@ const FileDetail: React.FC = () => {
     const {plt} = useTheme();
 
     useEffect(() => {
-        if (id) api.post('/api/v1/filehost/file/', {id: Number(id)}).then(setFile);
-    }, [id]);
+        if (id) getFile(Number(id)).then(setFile);
+    }, [id, getFile]);
     if (!file) return null;
 
     return (
@@ -41,7 +41,7 @@ const FileDetail: React.FC = () => {
                     onDownload={() => window.open(file.file)}
                     onShare={() => setShowShare(true)}
                     onDelete={async (f) => {
-                        await api.delete('/api/v1/filehost/item/delete/', {data: {file_id: f.id}});
+                        await deleteItem({file_id: f.id});
                         navigate(-1);
                     }}
                 />

--- a/frontend/src/Modules/FileHost/FileItem.tsx
+++ b/frontend/src/Modules/FileHost/FileItem.tsx
@@ -3,7 +3,7 @@ import React, {useEffect, useState} from 'react';
 import {IconButton, Menu, MenuItem} from '@mui/material';
 import StarIcon from '@mui/icons-material/Star';
 import {IFile} from './types';
-import {useApi} from 'Api/useApi';
+import {useFileHostApi} from 'FileHost/useFileHostApi';
 import {FRSE} from 'wide-containers';
 import {useNavigate} from 'Utils/nextRouter';
 import {useTranslation} from 'react-i18next';
@@ -32,7 +32,7 @@ const FileItem: React.FC<Props> = ({
                                        onShare,
                                        onSelectMode
                                    }) => {
-    const {api} = useApi();
+    const {toggleFavorite} = useFileHostApi();
     const {t} = useTranslation();
     const navigate = useNavigate();
     const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
@@ -41,7 +41,7 @@ const FileItem: React.FC<Props> = ({
     useEffect(() => setFavorite(file.is_favorite), [file.is_favorite]);
 
     const toggleFav = () => {
-        api.post('/api/v1/filehost/files/toggle_favorite/', {file_id: file.id}).then((d) => {
+        toggleFavorite(file.id).then((d) => {
             setFavorite(d.is_favorite);
             onFavorite && onFavorite({...file, is_favorite: d.is_favorite});
             setFavoriteFilesCached(undefined as any);

--- a/frontend/src/Modules/FileHost/FileTableRow.tsx
+++ b/frontend/src/Modules/FileHost/FileTableRow.tsx
@@ -4,7 +4,7 @@ import {IconButton, TableCell, TableRow, useMediaQuery} from '@mui/material';
 import StarIcon from '@mui/icons-material/Star';
 import {IFile} from './types';
 import formatFileSize from 'Utils/formatFileSize';
-import {useApi} from 'Api/useApi';
+import {useFileHostApi} from 'FileHost/useFileHostApi';
 import {FRSE} from 'wide-containers';
 import {useNavigate} from 'Utils/nextRouter';
 import {useTranslation} from 'react-i18next';
@@ -36,7 +36,7 @@ const FileTableRow: React.FC<Props> = ({
                                            onShare,
                                            onSelectMode
                                        }) => {
-    const {api} = useApi();
+    const {toggleFavorite} = useFileHostApi();
     const {t} = useTranslation();
     const navigate = useNavigate();
     const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
@@ -47,7 +47,7 @@ const FileTableRow: React.FC<Props> = ({
     const longPress = useLongPress(e => setAnchorEl(e.currentTarget as HTMLElement));
 
     const toggleFav = () => {
-        api.post('/api/v1/filehost/files/toggle_favorite/', {file_id: file.id}).then(d => {
+        toggleFavorite(file.id).then(d => {
             setFavorite(d.is_favorite);
             onFavorite && onFavorite({...file, is_favorite: d.is_favorite});
             setFavoriteFilesCached(undefined as any);

--- a/frontend/src/Modules/FileHost/Master.tsx
+++ b/frontend/src/Modules/FileHost/Master.tsx
@@ -1,6 +1,6 @@
 // Modules/FileHost/Master.tsx
 import React, {useEffect, useRef, useState} from 'react';
-import {useApi} from 'Api/useApi';
+import {useFileHostApi} from 'FileHost/useFileHostApi';
 import {IFile} from './types';
 import FileGrid from './FileGrid';
 import FileTable from './FileTable';
@@ -27,7 +27,7 @@ import CreateNewFolderRoundedIcon from '@mui/icons-material/CreateNewFolderRound
 import {useTheme} from "Theme/ThemeContext";
 
 const Master: React.FC = () => {
-    const {api} = useApi();
+    const {bulkDelete, addFolder, deleteItem} = useFileHostApi();
     const {plt} = useTheme();
     const {id} = useParams();
     const folderId = id ? Number(id) : null;
@@ -58,7 +58,7 @@ const Master: React.FC = () => {
     }, [selected]);
 
     const deleteSelected = async () => {
-        await api.post('/api/v1/filehost/items/bulk_delete/', {file_ids: selected.map(s => s.id)});
+        await bulkDelete(selected.map(s => s.id));
         setSelected([]);
         refreshCaches();
         load();
@@ -76,7 +76,7 @@ const Master: React.FC = () => {
     };
 
     const handleCreateFolder = async () => {
-        await api.post('/api/v1/filehost/folder/add/', {name: newFolderName, parent_id: folderId});
+        await addFolder(newFolderName, folderId);
         setShowCreate(false);
         setNewFolderName('');
         refreshCaches();
@@ -84,7 +84,7 @@ const Master: React.FC = () => {
     };
 
     const handleDeleteFolder = async (id: number) => {
-        await api.delete('/api/v1/filehost/item/delete/', {data: {folder_id: id}});
+        await deleteItem({folder_id: id});
         refreshCaches();
         load();
     };

--- a/frontend/src/Modules/FileHost/MoveDialog.tsx
+++ b/frontend/src/Modules/FileHost/MoveDialog.tsx
@@ -1,7 +1,7 @@
 // Modules/FileHost/MoveDialog.tsx
 import React, {useEffect, useState} from 'react';
 import {Button, Dialog, DialogActions, DialogContent, DialogTitle, MenuItem, Select} from '@mui/material';
-import {useApi} from 'Api/useApi';
+import {useFileHostApi} from 'FileHost/useFileHostApi';
 import {useTranslation} from 'react-i18next';
 import {IFile, IFolder} from './types';
 
@@ -13,21 +13,21 @@ interface Props {
 }
 
 const MoveDialog: React.FC<Props> = ({files, open, onClose, onMoved}) => {
-    const {api} = useApi();
+    const {getFolders, moveItem} = useFileHostApi();
     const {t} = useTranslation();
     const [folders, setFolders] = useState<IFolder[]>([]);
     const [target, setTarget] = useState<number | ''>('');
 
     useEffect(() => {
         if (open) {
-            api.get('/api/v1/filehost/folders/').then(setFolders);
+            getFolders().then(setFolders);
         }
-    }, [open]);
+    }, [open, getFolders]);
 
     const handleMove = async () => {
         if (!target) return;
         for (const f of files) {
-            await api.post('/api/v1/filehost/item/move/', {item_id: f.id, new_folder_id: target});
+            await moveItem(f.id, target as number);
         }
         onMoved && onMoved(target as number);
         onClose();

--- a/frontend/src/Modules/FileHost/RenameDialog.tsx
+++ b/frontend/src/Modules/FileHost/RenameDialog.tsx
@@ -1,7 +1,7 @@
 // Modules/FileHost/RenameDialog.tsx
 import React, {useEffect, useState} from 'react';
 import {Button, Dialog, DialogActions, DialogContent, DialogTitle, TextField} from '@mui/material';
-import {useApi} from 'Api/useApi';
+import {useFileHostApi} from 'FileHost/useFileHostApi';
 import {useTranslation} from 'react-i18next';
 
 interface Props {
@@ -13,7 +13,7 @@ interface Props {
 }
 
 const RenameDialog: React.FC<Props> = ({id, name, open, onClose, onRenamed}) => {
-    const {api} = useApi();
+    const {renameItem} = useFileHostApi();
     const {t} = useTranslation();
     const [value, setValue] = useState(name);
 
@@ -23,7 +23,7 @@ const RenameDialog: React.FC<Props> = ({id, name, open, onClose, onRenamed}) => 
 
     const handleRename = async () => {
         if (!id) return;
-        await api.post('/api/v1/filehost/item/rename/', {item_id: id, new_name: value});
+        await renameItem(id, value);
         onClose();
         onRenamed && onRenamed();
     };

--- a/frontend/src/Modules/FileHost/StorageUsageBar.tsx
+++ b/frontend/src/Modules/FileHost/StorageUsageBar.tsx
@@ -1,24 +1,24 @@
 // Modules/FileHost/StorageUsageBar.tsx
 import React, {useEffect, useState} from 'react';
 import LinearProgress from '@mui/material/LinearProgress';
-import {useApi} from 'Api/useApi';
+import {useFileHostApi} from 'FileHost/useFileHostApi';
 import {useTranslation} from 'react-i18next';
 import {FRCC} from 'wide-containers';
 import {useTheme} from "Theme/ThemeContext";
 
 const StorageUsageBar: React.FC = () => {
-    const {api} = useApi();
+    const {getStorageUsage} = useFileHostApi();
     const {t} = useTranslation();
     const [used, setUsed] = useState(0);
     const [limit, setLimit] = useState(1);
     const {plt} = useTheme();
 
     useEffect(() => {
-        api.get('/api/v1/filehost/storage/usage/').then(data => {
+        getStorageUsage().then(data => {
             setUsed(data.used);
             setLimit(data.limit);
         }).catch(() => null);
-    }, [api]);
+    }, [getStorageUsage]);
 
     const percent = Math.min(100, (used / limit) * 100);
 

--- a/frontend/src/Modules/FileHost/useFileHostApi.ts
+++ b/frontend/src/Modules/FileHost/useFileHostApi.ts
@@ -1,0 +1,24 @@
+import {useApi} from 'Api/useApi';
+
+export const useFileHostApi = () => {
+    const {api} = useApi();
+    return {
+        toggleFavorite: (file_id: number) => api.post('/api/v1/filehost/files/toggle_favorite/', {file_id}),
+        listAccess: (file_id: number) => api.get(`/api/v1/filehost/access/list/?file_id=${file_id}`),
+        grantAccess: (payload: any) => api.post('/api/v1/filehost/access/grant/', payload),
+        revokeAccess: (access_id: number) => api.delete('/api/v1/filehost/access/revoke/', {data: {access_id}}),
+        getFiles: (page: number, page_size = 20) => api.get(`/api/v1/filehost/files/?page=${page}&page_size=${page_size}`),
+        getFavoriteFiles: (page: number, page_size = 20) => api.get(`/api/v1/filehost/files/favorite/?page=${page}&page_size=${page_size}`),
+        bulkDelete: (file_ids: number[]) => api.post('/api/v1/filehost/items/bulk_delete/', {file_ids}),
+        getStorageUsage: () => api.get('/api/v1/filehost/storage/usage/'),
+        addFolder: (name: string, parent_id: number | null) => api.post('/api/v1/filehost/folder/add/', {name, parent_id}),
+        deleteItem: (payload: any) => api.delete('/api/v1/filehost/item/delete/', {data: payload}),
+        getFile: (id: number) => api.post('/api/v1/filehost/file/', {id}),
+        getFolders: () => api.get('/api/v1/filehost/folders/'),
+        moveItem: (item_id: number, new_folder_id: number | null) => api.post('/api/v1/filehost/item/move/', {item_id, new_folder_id}),
+        renameItem: (item_id: number, new_name: string) => api.post('/api/v1/filehost/item/rename/', {item_id, new_name}),
+        getFolder: (id: number) => api.post('/api/v1/filehost/folder/', {id}),
+    };
+};
+
+export type UseFileHostApi = ReturnType<typeof useFileHostApi>;

--- a/frontend/src/Modules/FileHost/useFolderPath.ts
+++ b/frontend/src/Modules/FileHost/useFolderPath.ts
@@ -1,10 +1,10 @@
 // Modules/FileHost/useFolderPath.ts
 import {useEffect, useState} from 'react';
-import {useApi} from 'Api/useApi';
+import {useFileHostApi} from 'FileHost/useFileHostApi';
 import {IFolder} from './types';
 
 const useFolderPath = (folder: IFolder | null) => {
-    const {api} = useApi();
+    const {getFolder} = useFileHostApi();
     const [path, setPath] = useState<IFolder[]>([]);
 
     useEffect(() => {
@@ -18,12 +18,12 @@ const useFolderPath = (folder: IFolder | null) => {
             while (cur) {
                 p.unshift(cur);
                 if (cur.parent === null) break;
-                cur = await api.post('/api/v1/filehost/folder/', {id: cur.parent});
+                cur = await getFolder(cur.parent);
             }
             setPath(p);
         };
         build().then();
-    }, [folder, api]);
+    }, [folder, getFolder]);
 
     return path;
 };

--- a/frontend/src/Modules/Landing/Footer.tsx
+++ b/frontend/src/Modules/Landing/Footer.tsx
@@ -4,21 +4,21 @@
 import React, {useEffect, useState} from 'react';
 import {FC} from 'wide-containers';
 import {useTheme} from 'Theme/ThemeContext';
-import {useApi} from 'Api/useApi';
+import {useCompanyApi} from 'Company/useCompanyApi';
 import {Company} from 'Company/Types';
 import {useNavigate} from "Utils/nextRouter";
 
 const Footer: React.FC = () => {
     const {plt} = useTheme();
-    const {api} = useApi();
+    const {getCompany} = useCompanyApi();
     const [company, setCompany] = useState<Company | null>(null);
     const navigate = useNavigate();
 
     useEffect(() => {
-        api.get<Company>('/api/v1/companies/XLARTAS/').then(setCompany).catch(() => {
+        getCompany('XLARTAS').then(setCompany).catch(() => {
             setCompany(null);
         });
-    }, [api]);
+    }, [getCompany]);
 
     return (
         <FC component={'footer'}

--- a/frontend/src/Modules/Order/BalanceTopUpDialog.tsx
+++ b/frontend/src/Modules/Order/BalanceTopUpDialog.tsx
@@ -6,7 +6,7 @@ import CircularProgressZoomify from 'Core/components/elements/CircularProgressZo
 import {FC, FR} from 'wide-containers';
 import PaymentSystemInfo from './PaymentSystemInfo';
 
-import {useApi} from 'Api/useApi';
+import {useOrderApi} from 'Order/useOrderApi';
 import PaymentTypePicker from 'Order/PaymentTypePicker';
 import {ICurrencyWithPrice, IPaymentSystem, IProduct} from 'types/commerce/shop';
 import {Message} from 'Core/components/Message';
@@ -19,7 +19,7 @@ interface BalanceTopUpDialogProps {
 }
 
 const BalanceTopUpDialog: React.FC<BalanceTopUpDialogProps> = ({open, onClose}) => {
-    const {api} = useApi();
+    const {getLatestBalanceProduct, createOrder} = useOrderApi();
     const {notAuthentication} = useErrorProcessing();
     const {isAuthenticated} = useAuth();
     const {t} = useTranslation();
@@ -33,7 +33,7 @@ const BalanceTopUpDialog: React.FC<BalanceTopUpDialogProps> = ({open, onClose}) 
 
     useEffect(() => {
         if (open) {
-            api.get('/api/v1/balance/product/latest/').then(p => setProduct(p)).catch(() => null);
+            getLatestBalanceProduct().then(p => setProduct(p)).catch(() => null);
         }
     }, [open, api]);
 
@@ -59,7 +59,7 @@ const BalanceTopUpDialog: React.FC<BalanceTopUpDialogProps> = ({open, onClose}) 
                 payment_system: system,
                 requested_amount: amount,
             };
-            const data = await api.post('/api/v1/orders/create/', payload);
+            const data = await createOrder(payload);
             if (data?.payment_url) window.open(data.payment_url, '_blank');
             Message.success(t('balance_topup_created'));
             onClose();

--- a/frontend/src/Modules/Order/OrderActions.tsx
+++ b/frontend/src/Modules/Order/OrderActions.tsx
@@ -9,7 +9,7 @@ import {useTheme} from "Theme/ThemeContext";
 import {Message} from "Core/components/Message";
 import pprint from 'Utils/pprint';
 import {IOrder} from "types/commerce/shop";
-import {useApi} from "Api/useApi";
+import {useOrderApi} from 'Order/useOrderApi';
 import PaymentTypePickerModal from "Order/PaymentTypePickerModal";
 import {FRSC} from "wide-containers";
 
@@ -32,7 +32,7 @@ const OrderActions: React.FC<OrderActionsProps> = (
     const navigate = useNavigate();
     const {user} = useAuth();
     const {theme, plt} = useTheme();
-    const {api} = useApi()
+    const {cancelOrder, executeOrder, deleteOrder, resendPaymentNotification} = useOrderApi();
     const {t} = useTranslation();
     const [payModal, setPayModal] = useState(false);
     const searchParams = useSearchParams();
@@ -48,7 +48,7 @@ const OrderActions: React.FC<OrderActionsProps> = (
     // Action Handlers
     const handleCancelOrder = () => {
         setLoading(true);
-        api.post(`/api/v1/orders/${order.id}/cancel/`).then(data => {
+        cancelOrder(order.id).then(data => {
             onSomeUpdatingOrderAction(data);
             navigate(`?success_message=${encodeURIComponent(t('order_canceled_success'))}`);
         }).catch(_ => null).finally(() => setLoading(false));
@@ -56,14 +56,14 @@ const OrderActions: React.FC<OrderActionsProps> = (
 
     const handleExecuteOrder = () => {
         setLoading(true);
-        api.post(`/api/v1/orders/${order.id}/execute/`).then(data => {
+        executeOrder(order.id).then(data => {
             onSomeUpdatingOrderAction(data);
             navigate(`?success_message=${encodeURIComponent(t('order_completed_success'))}`);
         }).catch(_ => null).finally(() => setLoading(false));
     };
     const handleDeleteOrder = () => {
         setLoading(true);
-        api.post(`/api/v1/orders/${order.id}/delete/`).then(data => {
+        deleteOrder(order.id).then(() => {
             Message.success(t('order_deleted_success'))
             if (onOrderDeleted) onOrderDeleted();
         }).catch(_ => null).finally(() => setLoading(false));
@@ -71,7 +71,7 @@ const OrderActions: React.FC<OrderActionsProps> = (
 
     const handleResendNotificationOrder = () => {
         setLoading(true);
-        api.post(`/api/v1/orders/${order.id}/resend_payment_notification/`).then(data => {
+        resendPaymentNotification(order.id).then(data => {
             pprint(`Order ID: ${order.id} notification resent`, data);
             onSomeUpdatingOrderAction(data);
             navigate(`?success_message=${encodeURIComponent(t('order_notification_resent_success'))}`);

--- a/frontend/src/Modules/Order/OrderDetail.tsx
+++ b/frontend/src/Modules/Order/OrderDetail.tsx
@@ -12,7 +12,7 @@ import OrderActions from "Order/OrderActions";
 import {useAuth} from "Auth/AuthContext";
 import {useTheme} from "Theme/ThemeContext";
 import {FC, FCCC, FR, FRBC, FRSC} from "wide-containers";
-import {useApi} from "Api/useApi";
+import {useOrderApi} from 'Order/useOrderApi';
 import {useTranslation} from 'react-i18next';
 import Collapse from '@mui/material/Collapse';
 
@@ -31,7 +31,7 @@ const OrderDetail: React.FC<OrderDetailProps> = ({className}) => {
     const [isActionLoading, setIsActionLoading] = useState<boolean>(false);
     const navigate = useNavigate();
     const {plt} = useTheme();
-    const {api} = useApi();
+    const {getOrder} = useOrderApi();
     const {t} = useTranslation();
 
     useEffect(() => {
@@ -40,11 +40,11 @@ const OrderDetail: React.FC<OrderDetailProps> = ({className}) => {
             return;
         }
         setLoading(true);
-        api.get(`/api/v1/orders/${id}/`).then(data => {
+        getOrder(id).then(data => {
             setOrder(data);
             if (!data) setOrderNotFound(true);
         }).catch(_ => null).finally(() => setLoading(false));
-    }, [id, isAuthenticated]);
+    }, [id, isAuthenticated, getOrder]);
 
     useEffect(() => {
         if (!loading) setAnimate(true);

--- a/frontend/src/Modules/Order/PaymentTypePicker.tsx
+++ b/frontend/src/Modules/Order/PaymentTypePicker.tsx
@@ -12,7 +12,7 @@ import logoFreeKassa from '../../Static/img/icon/freekassa/logo.png';
 import RadioCustomLine from 'Core/components/elements/RadioCustomLine';
 import {FC, FR, FRCC} from 'wide-containers';
 import {useTheme} from 'Theme/ThemeContext';
-import {useApi} from 'Api/useApi';
+import {useOrderApi} from 'Order/useOrderApi';
 import CircularProgressZoomify from 'Core/components/elements/CircularProgressZoomify';
 import pprint from 'Utils/pprint';
 import {useTranslation} from 'react-i18next';
@@ -39,18 +39,17 @@ const PaymentTypePicker: React.FC<PaymentTypePickerProps> = (
     const [paymentTypes, setPaymentTypes] = useState<{ [key: string]: IPaymentSystem[] }>({});
     const [selectedPaymentType, setSelectedPaymentType] = useState<IPaymentSystem | null>(null);
     const {plt, theme} = useTheme();
-    const {api} = useApi();
+    const {getPaymentTypes} = useOrderApi();
     const {t} = useTranslation();
 
     /* -------------------- Загрузка типов оплаты -------------------- */
     useEffect(() => {
         setLoading(true);
-        api
-            .get('/api/v1/payment/types/')
+        getPaymentTypes()
             .then((data) => setPaymentTypes(data))
             .catch(() => null)
             .finally(() => setLoading(false));
-    }, [api]);
+    }, [getPaymentTypes]);
 
     /* -------------------- Инициализация валюты/системы -------------------- */
     useEffect(() => {

--- a/frontend/src/Modules/Order/PaymentTypePickerModal.tsx
+++ b/frontend/src/Modules/Order/PaymentTypePickerModal.tsx
@@ -10,7 +10,7 @@ import {ICurrencyWithPrice, IOrder, IPaymentSystem} from 'types/commerce/shop';
 import {Button} from '@mui/material';
 import {Message} from 'Core/components/Message';
 import CircularProgressZoomify from 'Core/components/elements/CircularProgressZoomify';
-import {useApi} from 'Api/useApi';
+import {useOrderApi} from 'Order/useOrderApi';
 import {FC, FRE} from "wide-containers";
 
 interface Props {
@@ -21,7 +21,7 @@ interface Props {
 }
 
 const PaymentTypePickerModal: React.FC<Props> = ({open, onClose, order, onPaymentInited}) => {
-    const {api} = useApi();
+    const {initPayment} = useOrderApi();
     const [currency, setCurrency] = useState<ICurrencyWithPrice | null>(null);
     const [system, setSystem] = useState<IPaymentSystem | null>(null);
     const [loading, setLoading] = useState(false);
@@ -35,7 +35,7 @@ const PaymentTypePickerModal: React.FC<Props> = ({open, onClose, order, onPaymen
         }
         setLoading(true);
         try {
-            const resp = await api.post(`/api/v1/orders/${order.id}/init-payment/`, {
+            const resp = await initPayment(order.id, {
                 payment_system: system,
                 currency: currency.currency,
                 amount: currency.priceObject?.amount,

--- a/frontend/src/Modules/Order/PromoCodeField.tsx
+++ b/frontend/src/Modules/Order/PromoCodeField.tsx
@@ -12,7 +12,7 @@ import {useErrorProcessing} from "Core/components/ErrorProvider";
 import {IPromocode} from "types/commerce/promocode";
 import {ICurrency} from "types/commerce/shop";
 import {Message} from "Core/components/Message";
-import {useApi} from "Api/useApi";
+import {useOrderApi} from 'Order/useOrderApi';
 
 interface PromoCodeFieldProps {
     cls?: string;
@@ -30,7 +30,7 @@ const PromoCodeField: React.FC<PromoCodeFieldProps> = (
     const [promoCode, setPromoCode] = useState<string>('');
     const [status, setStatus] = useState<'idle' | 'checking' | 'valid' | 'invalid'>('idle');
     const promoCodeRef = useRef<HTMLInputElement>(null);
-    const {api} = useApi();
+    const {applyPromocode} = useOrderApi();
     const {plt, theme} = useTheme();
     const {byResponse} = useErrorProcessing();
     const {t} = useTranslation();
@@ -43,7 +43,7 @@ const PromoCodeField: React.FC<PromoCodeFieldProps> = (
         }
         setStatus('checking');
         try {
-            const response = await api.post('api/v1/promocode/applicable/', {
+            const response = await applyPromocode({
                 promocode: code,
                 employee: employeeId,
                 product: productId,

--- a/frontend/src/Modules/Order/UserBalance.tsx
+++ b/frontend/src/Modules/Order/UserBalance.tsx
@@ -1,7 +1,7 @@
 // Modules/Order/UserBalance.tsx
 import React, {useEffect, useState} from 'react';
 import BalanceTopUpDialog from './BalanceTopUpDialog';
-import {useApi} from 'Api/useApi';
+import {useOrderApi} from 'Order/useOrderApi';
 import {FR, FRSC} from 'wide-containers';
 import {Button} from '@mui/material';
 import Zoom from '@mui/material/Zoom';
@@ -9,7 +9,7 @@ import {useTranslation} from 'react-i18next';
 import CircularProgressZoomify from "Core/components/elements/CircularProgressZoomify";
 
 const UserBalance: React.FC = () => {
-    const {api} = useApi();
+    const {getUserBalance} = useOrderApi();
     const {t} = useTranslation();
     const [balance, setBalance] = useState<number>(0);
     const [loading, setLoading] = useState<boolean>(true);
@@ -17,7 +17,7 @@ const UserBalance: React.FC = () => {
 
     const fetchBalance = () => {
         setLoading(true);
-        api.get('/api/v1/user/balance/')
+        getUserBalance()
             .then((d: any) => setBalance(parseFloat(d.balance)))
             .catch(() => null)
             .finally(() => setLoading(false));

--- a/frontend/src/Modules/Order/UserOrders.tsx
+++ b/frontend/src/Modules/Order/UserOrders.tsx
@@ -7,14 +7,14 @@ import {IOrder} from 'types/commerce/shop';
 import OrderItem from 'Order/OrderItem';
 import {FC, FR} from 'wide-containers';
 import CircularProgressZoomify from 'Core/components/elements/CircularProgressZoomify';
-import {useApi} from 'Api/useApi';
+import {useOrderApi} from 'Order/useOrderApi';
 import Collapse from '@mui/material/Collapse';
 
 const UserOrders: React.FC = () => {
     const {user, isAuthenticated} = useAuth();
     const {notAuthentication} = useErrorProcessing();
     const [orders, setOrders] = useState<IOrder[]>([]);
-    const {api} = useApi();
+    const {getUserOrders} = useOrderApi();
     const navigate = useNavigate();
 
     const [loading, setLoading] = useState(true);
@@ -29,10 +29,10 @@ const UserOrders: React.FC = () => {
 
         setAnimate(false);
 
-        api.get('/api/v1/user/orders/')
+        getUserOrders()
             .then(data => setOrders(data))
             .finally(() => setLoading(false));
-    }, [user, isAuthenticated, api, notAuthentication]);
+    }, [user, isAuthenticated, getUserOrders, notAuthentication]);
 
     /* ---------- старт анимации после загрузки ---------- */
     useEffect(() => {

--- a/frontend/src/Modules/Order/useOrderApi.ts
+++ b/frontend/src/Modules/Order/useOrderApi.ts
@@ -1,0 +1,23 @@
+import {useApi} from 'Api/useApi';
+
+export const useOrderApi = () => {
+    const {api} = useApi();
+    return {
+        getUserBalance: () => api.get('/api/v1/user/balance/'),
+        getLatestBalanceProduct: () => api.get('/api/v1/balance/product/latest/'),
+        createOrder: (payload: unknown) => api.post('/api/v1/orders/create/', payload),
+        applyPromocode: (payload: unknown) => api.post('/api/v1/promocode/applicable/', payload),
+        getPaymentTypes: () => api.get('/api/v1/payment/types/'),
+        getUserOrders: () => api.get('/api/v1/user/orders/'),
+        initPayment: (orderId: number, payload: unknown) =>
+            api.post(`/api/v1/orders/${orderId}/init-payment/`, payload),
+        getOrder: (id: number | string) => api.get(`/api/v1/orders/${id}/`),
+        cancelOrder: (id: number | string) => api.post(`/api/v1/orders/${id}/cancel/`),
+        executeOrder: (id: number | string) => api.post(`/api/v1/orders/${id}/execute/`),
+        deleteOrder: (id: number | string) => api.post(`/api/v1/orders/${id}/delete/`),
+        resendPaymentNotification: (id: number | string) =>
+            api.post(`/api/v1/orders/${id}/resend_payment_notification/`),
+    };
+};
+
+export type UseOrderApi = ReturnType<typeof useOrderApi>;

--- a/frontend/src/Modules/Software/Licenses.tsx
+++ b/frontend/src/Modules/Software/Licenses.tsx
@@ -1,7 +1,7 @@
 // Modules/Software/Licenses.tsx
 import React, {useEffect, useState} from 'react';
 import {useTranslation} from 'react-i18next';
-import {useApi} from 'Api/useApi';
+import {useSoftwareApi} from 'Software/useSoftwareApi';
 import CircularProgressZoomify from 'Core/components/elements/CircularProgressZoomify';
 import {FCC, FR} from 'wide-containers';
 import LicenseCard from './LicenseCard';
@@ -9,7 +9,7 @@ import {Message} from 'Core/components/Message';
 import Collapse from '@mui/material/Collapse';
 
 const Licenses: React.FC = () => {
-    const {api} = useApi();
+    const {listLicenses} = useSoftwareApi();
     const {t} = useTranslation();
     const [licenses, setLicenses] = useState<any[]>([]);
     const [loading, setLoading] = useState(true);
@@ -18,11 +18,11 @@ const Licenses: React.FC = () => {
     useEffect(() => {
         setLoading(true);
         setAnimate(false);
-        api.get('/api/v1/software/licenses/')
+        listLicenses()
             .then(data => setLicenses(data))
             .catch(() => Message.error(t('licenses_load_error')))
             .finally(() => setLoading(false));
-    }, [api, t]);
+    }, [listLicenses, t]);
 
     useEffect(() => {
         if (!loading) setAnimate(true);

--- a/frontend/src/Modules/Software/Macros/MacroFormDialog.tsx
+++ b/frontend/src/Modules/Software/Macros/MacroFormDialog.tsx
@@ -3,7 +3,7 @@ import React, {useEffect, useState} from 'react';
 import {Button, Dialog, DialogActions, DialogContent, DialogTitle, TextField} from '@mui/material';
 import CircularProgressZoomify from 'Core/components/elements/CircularProgressZoomify';
 import {Message} from 'Core/components/Message';
-import {useApi} from "Api/useApi";
+import {useSoftwareApi} from 'Software/useSoftwareApi';
 import {WirelessMacro} from "../Types/Software";
 import {useTranslation} from "react-i18next";
 
@@ -23,7 +23,7 @@ const MacroFormDialog: React.FC<Props> = ({open, onClose, onSaved, macro}) => {
     const [name, setName] = useState(macro?.name ?? '');
     const [priority, setPriority] = useState(macro?.priority ?? 0);
     const [saving, setSaving] = useState(false);
-    const {api} = useApi();
+    const {updateWirelessMacro, createWirelessMacro} = useSoftwareApi();
     const {t} = useTranslation();
 
     /* Подтягиваем данные при повторных открытиях диалога */
@@ -46,15 +46,9 @@ const MacroFormDialog: React.FC<Props> = ({open, onClose, onSaved, macro}) => {
         try {
             let resp: WirelessMacro;
             if (isEdit) {
-                resp = await api.patch<WirelessMacro>(
-                    `/api/v1/wireless-macros/${macro!.id}/`,
-                    {name: name.trim(), priority}
-                );
+                resp = await updateWirelessMacro(macro!.id, {name: name.trim(), priority});
             } else {
-                resp = await api.post<WirelessMacro>(
-                    '/api/v1/wireless-macros/',
-                    {name: name.trim(), priority}
-                );
+                resp = await createWirelessMacro({name: name.trim(), priority});
             }
             onSaved(resp);
             onClose();

--- a/frontend/src/Modules/Software/Macros/MacrosWirelessDashboard.tsx
+++ b/frontend/src/Modules/Software/Macros/MacrosWirelessDashboard.tsx
@@ -9,14 +9,14 @@ import {Message} from 'Core/components/Message';
 import {FC, FRC, FREC} from 'wide-containers';
 import {useTheme} from 'Theme/ThemeContext';
 import MacroFormDialog from './MacroFormDialog';
-import {useApi} from 'Api/useApi';
+import {useSoftwareApi} from 'Software/useSoftwareApi';
 import {WirelessMacro} from '../Types/Software';
 import {useMacroControl} from './MacroControlProvider';
 import {useTranslation} from 'react-i18next';
 
 const MacrosWirelessDashboard: React.FC = () => {
     const {plt} = useTheme();
-    const {api} = useApi();
+    const {listWirelessMacros, deleteWirelessMacro} = useSoftwareApi();
     const {sendMacro} = useMacroControl();
 
     const [macros, setMacros] = useState<WirelessMacro[] | null>(null);
@@ -26,7 +26,7 @@ const MacrosWirelessDashboard: React.FC = () => {
 
     const load = async () => {
         try {
-            setMacros((await api.get('/api/v1/wireless-macros/')).results);
+            setMacros((await listWirelessMacros()).results);
         } catch {
             Message.error(t('load_macros_error'));
         }
@@ -37,7 +37,7 @@ const MacrosWirelessDashboard: React.FC = () => {
 
     const handleDelete = async (id: number) => {
         try {
-            await api.delete(`/api/v1/wireless-macros/${id}/`);
+            await deleteWirelessMacro(id);
             setMacros(prev => prev!.filter(m => m.id !== id));
         } catch {
             Message.error(t('delete_macro_error'));

--- a/frontend/src/Modules/Software/SoftwareDetail.tsx
+++ b/frontend/src/Modules/Software/SoftwareDetail.tsx
@@ -12,7 +12,7 @@ import {useTheme} from 'Theme/ThemeContext';
 import SoftwareOrder from './SoftwareOrder';
 import {ISoftware} from './Types/Software';
 import {useAuth} from 'Auth/AuthContext';
-import {useApi} from 'Api/useApi';
+import {useSoftwareApi} from 'Software/useSoftwareApi';
 import {Message} from 'Core/components/Message';
 import SoftwareTestPeriodButton from './SoftwareTestPeriodButton';
 import FeedRoundedIcon from '@mui/icons-material/FeedRounded';
@@ -28,7 +28,7 @@ const SoftwareDetail: React.FC = () => {
     const {id} = useParams();
     const {isAuthenticated} = useAuth();
     const {plt} = useTheme();
-    const {api} = useApi();
+    const {getSoftware, getLicense} = useSoftwareApi();
     const navigate = useNavigate();
     const {t} = useTranslation();
 
@@ -53,11 +53,11 @@ const SoftwareDetail: React.FC = () => {
             setLoading(false);
             return;
         }
-        api.get(`/api/v1/software/${id}/`)
+        getSoftware(id as any)
             .then(data => setSoftware(data))
             .catch(() => Message.error(t('software_load_error')))
             .finally(() => setLoading(false));
-    }, [id, api, t]);
+    }, [id, getSoftware, t]);
 
     /* ---------- старт анимации контента после загрузки ---------- */
     useEffect(() => {
@@ -68,7 +68,7 @@ const SoftwareDetail: React.FC = () => {
     useEffect(() => {
         if (isAuthenticated && software) {
             setLicenseLoading(true);
-            api.get(`/api/v1/license/${software.id}/`)
+            getLicense(software.id)
                 .then(data => {
                     if (data.no_one) {
                         setLicenseHours(0);
@@ -81,12 +81,12 @@ const SoftwareDetail: React.FC = () => {
                 .catch(() => null)
                 .finally(() => setLicenseLoading(false));
         }
-    }, [isAuthenticated, software, api]);
+    }, [isAuthenticated, software, getLicense]);
 
     const refreshLicense = () => {
         if (isAuthenticated && software) {
             setLicenseLoading(true);
-            api.get(`/api/v1/license/${software.id}/`)
+            getLicense(software.id)
                 .then(data => {
                     setLicenseHours(data.remaining_hours);
                     setIsTested(data.is_tested);

--- a/frontend/src/Modules/Software/SoftwareOrder.tsx
+++ b/frontend/src/Modules/Software/SoftwareOrder.tsx
@@ -15,8 +15,8 @@ import AddRoundedIcon from '@mui/icons-material/AddRounded';
 import RemoveRoundedIcon from '@mui/icons-material/RemoveRounded';
 import {useAuth} from 'Auth/AuthContext';
 import {useNavigate} from 'Utils/nextRouter';
-import {useApi} from 'Api/useApi';
 import {useErrorProcessing} from 'Core/components/ErrorProvider';
+import {useOrderApi} from 'Order/useOrderApi';
 import PaymentTypePicker from 'Order/PaymentTypePicker';
 
 /* ----------  utils ---------- */
@@ -61,7 +61,7 @@ const SoftwareOrder: React.FC<SoftwareOrderProps> = ({software, onSuccess}) => {
     const [system, setSystem] = useState<IPaymentSystem | null>(null);
 
     const navigate = useNavigate();
-    const {api} = useApi();
+    const {createOrder} = useOrderApi();
     const {notAuthentication} = useErrorProcessing();
     const {t} = useTranslation();
 
@@ -118,7 +118,7 @@ const SoftwareOrder: React.FC<SoftwareOrderProps> = ({software, onSuccess}) => {
                 promocode: promoCode || null,
                 email: user?.email ?? null,
             };
-            const data = await api.post('/api/v1/orders/create/', payload);
+            const data = await createOrder(payload);
 
             Message.success(t('order_created_success'), 2, 5000);
 

--- a/frontend/src/Modules/Software/SoftwareTestPeriodButton.tsx
+++ b/frontend/src/Modules/Software/SoftwareTestPeriodButton.tsx
@@ -5,7 +5,7 @@ import {Button} from "@mui/material";
 import Dialog from '@mui/material/Dialog';
 import DialogContent from '@mui/material/DialogContent';
 import {FCC, FRCC} from "wide-containers";
-import {useApi} from "Api/useApi";
+import {useSoftwareApi} from 'Software/useSoftwareApi';
 import {Message} from "Core/components/Message";
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 import {useTheme} from "Theme/ThemeContext";
@@ -31,7 +31,7 @@ const SoftwareTestPeriodButton: React.FC<SoftwareTestPeriodButtonProps> = (
     const [isModalOpen, setIsModalOpen] = useState(false);
     const [isLoading, setIsLoading] = useState(false);
     const {isAuthenticated} = useAuth();
-    const {api} = useApi();
+    const {activateTestPeriod} = useSoftwareApi();
     const {plt, theme} = useTheme();
     const {t} = useTranslation();
     const navigate = useNavigate();
@@ -45,7 +45,7 @@ const SoftwareTestPeriodButton: React.FC<SoftwareTestPeriodButtonProps> = (
         }
         setIsLoading(true);
         try {
-            const response = await api.post(`/api/v1/software/${softwareId}/activate-test-period/`);
+            const response = await activateTestPeriod(softwareId);
             Message.success(response.detail || t('test_activation_success'));
             refreshLicense();
             setIsModalOpen(false);

--- a/frontend/src/Modules/Software/Softwares.tsx
+++ b/frontend/src/Modules/Software/Softwares.tsx
@@ -6,7 +6,7 @@ import CircularProgressZoomify from 'Core/components/elements/CircularProgressZo
 import {FC, FRCC} from 'wide-containers';
 import {useTheme} from 'Theme/ThemeContext';
 import {ISoftware} from './Types/Software';
-import {useApi} from 'Api/useApi';
+import {useSoftwareApi} from 'Software/useSoftwareApi';
 import SoftwareCard from './SoftwareCard';
 import {useTranslation} from 'react-i18next';
 import Collapse from '@mui/material/Collapse';
@@ -17,16 +17,16 @@ const Softwares: React.FC = () => {
     const [animate, setAnimate] = useState(false);
     const navigate = useNavigate();
     const {plt} = useTheme();
-    const {api} = useApi();
+    const {listSoftware} = useSoftwareApi();
     const {t} = useTranslation();
 
     useEffect(() => {
         setLoading(true);
         setAnimate(false);
-        api.get('/api/v1/software/')
+        listSoftware()
             .then(data => setSoftwares(data))
             .finally(() => setLoading(false));
-    }, [api]);
+    }, [listSoftware]);
 
     useEffect(() => {
         if (!loading) {

--- a/frontend/src/Modules/Software/useSoftwareApi.ts
+++ b/frontend/src/Modules/Software/useSoftwareApi.ts
@@ -1,0 +1,18 @@
+import {useApi} from 'Api/useApi';
+
+export const useSoftwareApi = () => {
+    const {api} = useApi();
+    return {
+        listLicenses: () => api.get('/api/v1/software/licenses/'),
+        listSoftware: () => api.get('/api/v1/software/'),
+        getSoftware: (id: number | string) => api.get(`/api/v1/software/${id}/`),
+        getLicense: (softwareId: number | string) => api.get(`/api/v1/license/${softwareId}/`),
+        activateTestPeriod: (softwareId: number | string) => api.post(`/api/v1/software/${softwareId}/activate-test-period/`),
+        listWirelessMacros: () => api.get('/api/v1/wireless-macros/'),
+        deleteWirelessMacro: (id: number | string) => api.delete(`/api/v1/wireless-macros/${id}/`),
+        updateWirelessMacro: (id: number | string, payload: unknown) => api.put(`/api/v1/wireless-macros/${id}/`, payload),
+        createWirelessMacro: (payload: unknown) => api.post('/api/v1/wireless-macros/', payload),
+    };
+};
+
+export type UseSoftwareApi = ReturnType<typeof useSoftwareApi>;

--- a/frontend/src/Modules/Theme/ThemeContext.tsx
+++ b/frontend/src/Modules/Theme/ThemeContext.tsx
@@ -4,7 +4,7 @@
 import React, {createContext, ReactNode, useContext, useEffect, useState} from 'react';
 import {Palette, ThemeProvider as MuiThemeProvider} from '@mui/material/styles';
 import {darkTheme, lightTheme} from "../../theme";
-import {useApi} from "Api/useApi";
+import {useThemeApi} from 'Theme/useThemeApi';
 
 interface ThemeContextType {
     theme: any;
@@ -37,10 +37,10 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({children}) => {
     const [backgroundImages, setBackgroundImages] = useState<BackgroundImages>({dark: [], light: []});
     const [currentBackgroundIndex, setCurrentBackgroundIndex] = useState(0);
     const [themeLoading, setThemeLoading] = useState<boolean>(true);
-    const {api} = useApi();
+    const {getThemes} = useThemeApi();
     const processTheme = async () => {
         try {
-            const data = await api.get('/api/v1/themes/');
+            const data = await getThemes();
             const darkImages = data.filter((theme: any) => theme.mode === 'dark').map((theme: any) => theme.bg_image);
             const lightImages = data.filter((theme: any) => theme.mode === 'light').map((theme: any) => theme.bg_image);
             setBackgroundImages({dark: darkImages, light: lightImages});

--- a/frontend/src/Modules/Theme/useThemeApi.ts
+++ b/frontend/src/Modules/Theme/useThemeApi.ts
@@ -1,0 +1,10 @@
+import {useApi} from 'Api/useApi';
+
+export const useThemeApi = () => {
+    const {api} = useApi();
+    return {
+        getThemes: () => api.get('/api/v1/themes/'),
+    };
+};
+
+export type UseThemeApi = ReturnType<typeof useThemeApi>;

--- a/frontend/src/Modules/User/UserAvatarEditable.tsx
+++ b/frontend/src/Modules/User/UserAvatarEditable.tsx
@@ -10,7 +10,7 @@ import './UserAvatarEditable.sass';
 import {useTheme} from 'Theme/ThemeContext';
 import {FC, FCCC} from 'wide-containers';
 import CircularProgressZoomify from 'Core/components/elements/CircularProgressZoomify';
-import {useApi} from 'Api/useApi';
+import {useUserApi} from 'User/useUserApi';
 
 interface UserAvatarEditableProps {
     size: string;
@@ -24,7 +24,7 @@ const UserAvatarEditable: React.FC<UserAvatarEditableProps> = ({size, sx, classN
     const {t} = useTranslation();
     const uploadIconRef = useRef<HTMLDivElement>(null);
     const [isLoading, setIsLoading] = useState<boolean>(false);
-    const {api} = useApi();
+    const {updateAvatar} = useUserApi();
 
     const handleAvatarChange = async (event: ChangeEvent<HTMLInputElement>) => {
         const file = event.target.files?.[0];
@@ -32,9 +32,7 @@ const UserAvatarEditable: React.FC<UserAvatarEditableProps> = ({size, sx, classN
             setIsLoading(true);
             const formData = new FormData();
             formData.append('avatar', file);
-            api.patch('/api/v1/user/update/avatar/', formData, {
-                headers: {'Content-Type': 'multipart/form-data'},
-            }).then(() => {
+            updateAvatar(formData).then(() => {
                 updateCurrentUser().then(() => Message.success(t('avatar_update_success')));
             }).catch(() => Message.error(t('avatar_update_error')))
                 .finally(() => {

--- a/frontend/src/Modules/User/UserPersonalInfoForm.tsx
+++ b/frontend/src/Modules/User/UserPersonalInfoForm.tsx
@@ -19,7 +19,7 @@ import {useTheme} from "Theme/ThemeContext";
 import {FC, FR, FRC, FRSC} from "wide-containers";
 import NewPasswordForm from "Auth/forms/NewPasswordForm";
 import copyToClipboard from "Utils/clipboard";
-import {useApi} from "Api/useApi";
+import {useUserApi} from 'User/useUserApi';
 import TextField from "@mui/material/TextField";
 import UserBalance from "Order/UserBalance";
 import Collapse from '@mui/material/Collapse';
@@ -43,7 +43,7 @@ const UserPersonalInfoForm: React.FC = () => {
     const {notAuthentication} = useErrorProcessing();
     const {plt} = useTheme();
     const {t} = useTranslation();
-    const {api} = useApi();
+    const {updateInfo} = useUserApi();
 
     const [isPasswordModalOpen, setIsPasswordModalOpen] = useState<boolean>(false);
     const [isEmailModalOpen, setIsEmailModalOpen] = useState<boolean>(false);
@@ -97,7 +97,7 @@ const UserPersonalInfoForm: React.FC = () => {
             delete dataToSubmit.birth_date;
         }
 
-        api.patch('/api/v1/user/update/', dataToSubmit).then(() => {
+        updateInfo(dataToSubmit).then(() => {
             setShowSaveButton(false);
             updateCurrentUser().then(
                 () => Message.success(t('user_update_success'))

--- a/frontend/src/Modules/User/useUserApi.ts
+++ b/frontend/src/Modules/User/useUserApi.ts
@@ -1,0 +1,14 @@
+import {useApi} from 'Api/useApi';
+
+export const useUserApi = () => {
+    const {api} = useApi();
+    return {
+        updateAvatar: (formData: FormData) =>
+            api.patch('/api/v1/user/update/avatar/', formData, {
+                headers: {'Content-Type': 'multipart/form-data'},
+            }),
+        updateInfo: (payload: unknown) => api.patch('/api/v1/user/update/', payload),
+    };
+};
+
+export type UseUserApi = ReturnType<typeof useUserApi>;


### PR DESCRIPTION
## Summary
- replace direct API calls with dedicated hooks across modules
- add per-domain hooks (orders, files, company, etc.)
- streamline component logic to consume these hooks

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68955daddec8833081cdd9c5f3938cf8