### PR TITLE
refactor: centralize API calls via hooks

### DIFF
--- a/frontend/src/Modules/Chat/RoomWith.tsx
+++ b/frontend/src/Modules/Chat/RoomWith.tsx
@@ -4,7 +4,7 @@ import React, {useEffect, useState} from 'react';
 import {useAuth} from 'Auth/AuthContext';
 import Room from './Room';
 import {IRoom} from 'types/chat/models';
-import {useApi} from "Api/useApi";
+import {useChatApi} from './useChatApi';
 
 interface RoomWithProps {
     userId?: number;
@@ -19,15 +19,15 @@ const RoomWith: React.FC<RoomWithProps> = (
 
     const {isAuthenticated} = useAuth();
     const [room, setRoom] = useState<IRoom | null>(null);
-    const {api} = useApi();
+    const {getPersonalRoomWith} = useChatApi();
 
     useEffect(() => {
         if (!userId) {
             setRoom(null);
             return;
         }
-        api.get(`api/v1/rooms/personal/with/${userId}/`).then(data => setRoom(data));
-    }, [userId, api]);
+        getPersonalRoomWith(userId).then(data => setRoom(data));
+    }, [userId, getPersonalRoomWith]);
 
     if (!room || !isAuthenticated) return null;
     return <Room key={room.id} showHeader={!!showHeader} roomId={String(room.id)} room={room}/>;

--- a/frontend/src/Modules/Chat/useChatApi.ts
+++ b/frontend/src/Modules/Chat/useChatApi.ts
@@ -7,6 +7,7 @@ export const useChatApi = () => {
         listRooms: () => api.get<{results: IRoom[]; next: string | null}>("/api/v1/rooms/"),
         listRoomsByUrl: (url: string) => api.get<{results: IRoom[]; next: string | null}>(url),
         getRoom: (roomId: number | string) => api.get(`/api/v1/rooms/${roomId}/`),
+        getPersonalRoomWith: (userId: number | string) => api.get<IRoom>(`/api/v1/rooms/personal/with/${userId}/`),
         listMessages: (roomId: number | string, url?: string) =>
             api.get(url || `/api/v1/rooms/${roomId}/messages/`),
     };

--- a/frontend/src/Modules/FileHost/useFileHost.ts
+++ b/frontend/src/Modules/FileHost/useFileHost.ts
@@ -1,5 +1,4 @@
 // Modules/FileHost/useFileHost.ts
-import {useApi} from 'Api/useApi';
 import {useEffect, useState} from 'react';
 import {IFile, IFolder} from './types';
 import {
@@ -9,9 +8,10 @@ import {
     setFavoriteFilesCached,
     setFolderCached
 } from './storageCache';
+import {useFileHostApi} from './useFileHostApi';
 
 const useFileHost = (folderId: number | null) => {
-    const {api} = useApi();
+    const {getFolderContent} = useFileHostApi();
     const [folders, setFolders] = useState<IFolder[]>([]);
     const [folder, setFolder] = useState<IFolder | null>(null);
     const [files, setFiles] = useState<IFile[]>([]);
@@ -30,7 +30,7 @@ const useFileHost = (folderId: number | null) => {
             setFolder(cached.folder);
             return;
         }
-        api.post('/api/v1/filehost/folder/content/', {id: folderId}).then((data: FolderContent) => {
+        getFolderContent(folderId).then((data: FolderContent) => {
             setFolders(data.folders);
             setFiles(data.files);
             setFolder(data.folder);
@@ -40,7 +40,7 @@ const useFileHost = (folderId: number | null) => {
 
     useEffect(() => {
         load();
-    }, [api, folderId]);
+    }, [getFolderContent, folderId]);
 
     return {folders, folder, files, load, refreshCaches};
 };

--- a/frontend/src/Modules/FileHost/useFileHostApi.ts
+++ b/frontend/src/Modules/FileHost/useFileHostApi.ts
@@ -1,4 +1,6 @@
 import {useApi} from 'Api/useApi';
+import type {AxiosRequestConfig} from 'axios';
+import type {FolderContent} from './storageCache';
 
 export const useFileHostApi = () => {
     const {api} = useApi();
@@ -15,6 +17,9 @@ export const useFileHostApi = () => {
         deleteItem: (payload: any) => api.delete('/api/v1/filehost/item/delete/', {data: payload}),
         getFile: (id: number) => api.post('/api/v1/filehost/file/', {id}),
         getFolders: () => api.get('/api/v1/filehost/folders/'),
+        getFolderContent: (id: number | null) => api.post<FolderContent>('/api/v1/filehost/folder/content/', {id}),
+        uploadFiles: (formData: FormData, config?: AxiosRequestConfig) =>
+            api.post('/api/v1/filehost/files/upload/', formData, config),
         moveItem: (item_id: number, new_folder_id: number | null) => api.post('/api/v1/filehost/item/move/', {item_id, new_folder_id}),
         renameItem: (item_id: number, new_name: string) => api.post('/api/v1/filehost/item/rename/', {item_id, new_name}),
         getFolder: (id: number) => api.post('/api/v1/filehost/folder/', {id}),

--- a/frontend/src/Modules/FileHost/useFileUpload.ts
+++ b/frontend/src/Modules/FileHost/useFileUpload.ts
@@ -1,10 +1,10 @@
 // Modules/FileHost/useFileUpload.ts
-import {useApi} from 'Api/useApi';
 import {useState} from 'react';
 import {UploadItem} from './UploadProgressWindow';
+import {useFileHostApi} from './useFileHostApi';
 
 const useFileUpload = (parentId: number | null, onUploaded?: () => void) => {
-    const {api} = useApi();
+    const {uploadFiles} = useFileHostApi();
     const [uploads, setUploads] = useState<UploadItem[]>([]);
 
     const handleUpload = async (file: File | null) => {
@@ -14,7 +14,7 @@ const useFileUpload = (parentId: number | null, onUploaded?: () => void) => {
         const formData = new FormData();
         formData.append('files', file);
         if (parentId) formData.append('parent_id', String(parentId));
-        const resp = await api.post('/api/v1/filehost/files/upload/', formData, {
+        const resp = await uploadFiles(formData, {
             headers: {'Content-Type': 'multipart/form-data'},
             onUploadProgress: e => {
                 if (e.total !== undefined) {


### PR DESCRIPTION
## Summary
- add `getPersonalRoomWith` to chat API and use it in `RoomWith`
- extend FileHost API with folder content and upload helpers
- refactor FileHost hooks to rely on API helpers

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next not found)*
- `npm install` *(fails: dependency conflict ERESOLVE)*

------
https://chatgpt.com/codex/tasks/task_e_689561aa0478833081d8bd1618ff5cf3