### PR TITLE
chore: mark client components

### DIFF
--- a/frontend/src/Modules/Auth/Social/OAuthCallback.tsx
+++ b/frontend/src/Modules/Auth/Social/OAuthCallback.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 // Modules/Auth/Social/OAuthCallback.tsx
 import {OAUTH_PROVIDERS} from 'Auth/Social/constants';
 import {useParams} from 'Utils/nextRouter';

--- a/frontend/src/Modules/Auth/forms/NewPasswordForm.tsx
+++ b/frontend/src/Modules/Auth/forms/NewPasswordForm.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 // Modules/Auth/forms/NewPasswordForm.tsx
 import React, {useEffect, useRef, useState} from 'react';
 import TextField from '@mui/material/TextField';

--- a/frontend/src/Modules/Company/CompanyDocumentDetail.tsx
+++ b/frontend/src/Modules/Company/CompanyDocumentDetail.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 // Modules/Company/CompanyDocumentDetail.tsx
 import React, {useEffect, useState} from 'react';
 import {useTranslation} from 'react-i18next';

--- a/frontend/src/Modules/Company/CompanyPage.tsx
+++ b/frontend/src/Modules/Company/CompanyPage.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 // Modules/Company/CompanyPage.tsx
 import React, {useEffect, useState} from 'react';
 import {useTranslation} from 'react-i18next';

--- a/frontend/src/Modules/Company/useCompanyApi.ts
+++ b/frontend/src/Modules/Company/useCompanyApi.ts
@@ -1,3 +1,4 @@
+"use client";
 import {useApi} from 'Api/useApi';
 
 export const useCompanyApi = () => {

--- a/frontend/src/Modules/Confirmation/ConfirmationCode.tsx
+++ b/frontend/src/Modules/Confirmation/ConfirmationCode.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 // Modules/Confirmation/ConfirmationCode.tsx
 
 import React, {useEffect, useState} from 'react';

--- a/frontend/src/Modules/Confirmation/useConfirmationApi.ts
+++ b/frontend/src/Modules/Confirmation/useConfirmationApi.ts
@@ -1,3 +1,4 @@
+"use client";
 import {useApi} from 'Api/useApi';
 
 export const useConfirmationApi = () => {

--- a/frontend/src/Modules/Converter/ConversationResultCard.tsx
+++ b/frontend/src/Modules/Converter/ConversationResultCard.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 // Modules/Converter/ConversationResultCard.tsx
 import React from 'react';
 import {IconButton, Typography} from '@mui/material';

--- a/frontend/src/Modules/Converter/Converter.tsx
+++ b/frontend/src/Modules/Converter/Converter.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 // Modules/Converter/Converter.tsx
 import React, {useEffect, useRef, useState} from 'react';
 import {useConverterApi} from 'Converter/useConverterApi';

--- a/frontend/src/Modules/Converter/ConverterGuide.tsx
+++ b/frontend/src/Modules/Converter/ConverterGuide.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 // Modules/Converter/ConverterGuide.tsx
 import React, {useEffect, useState} from 'react';
 import {Box, Button, Collapse, Paper, Typography} from '@mui/material';

--- a/frontend/src/Modules/Converter/FormatParametersSettings.tsx
+++ b/frontend/src/Modules/Converter/FormatParametersSettings.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 // Modules/Converter/FormatParametersSettings.tsx
 import React from 'react';
 import {InputAdornment, MenuItem, TextField} from '@mui/material';

--- a/frontend/src/Modules/Converter/FormatPicker.tsx
+++ b/frontend/src/Modules/Converter/FormatPicker.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 // Modules/Converter/FormatPicker.tsx
 import React from 'react';
 import {Typography} from '@mui/material';

--- a/frontend/src/Modules/Converter/useConverterApi.ts
+++ b/frontend/src/Modules/Converter/useConverterApi.ts
@@ -1,3 +1,4 @@
+"use client";
 import {useApi} from 'Api/useApi';
 import {IConvertResult, IFormat, IParameter} from 'types/converter';
 

--- a/frontend/src/Modules/Core/pages/NewPassword.tsx
+++ b/frontend/src/Modules/Core/pages/NewPassword.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 // Modules/Core/pages/NewPassword.tsx
 import React from 'react';
 import {useNavigate} from "Utils/nextRouter";

--- a/frontend/src/Modules/Order/OrderTemplate.tsx
+++ b/frontend/src/Modules/Order/OrderTemplate.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 // Modules/Order/OrderTemplate.tsx
 
 import React, {useEffect, useState} from 'react';

--- a/frontend/src/UI/FileDropZone.tsx
+++ b/frontend/src/UI/FileDropZone.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 // UI/FileDropZone.tsx
 import React, {useState} from 'react';
 import {Box, Typography} from '@mui/material';


### PR DESCRIPTION
## Summary
- mark hook-based modules with `"use client"` to satisfy Next.js 15

## Testing
- `npm ci --ignore-scripts --loglevel error` *(fails: 403 Forbidden - GET https://registry.npmjs.org/eslint)*
- `npm run lint` *(fails: sh: 1: next: not found)*
- `npm run build` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68957776d0348330a67686883e7a809d