### PR TITLE
Ensure client-side context for auth-based components

### DIFF
--- a/frontend/src/Modules/Auth/forms/AuthForm.tsx
+++ b/frontend/src/Modules/Auth/forms/AuthForm.tsx
@@ -1,4 +1,5 @@
 // Modules/Auth/forms/AuthForm.tsx
+"use client";
 
 import React, {ChangeEvent, useEffect, useState} from 'react';
 import {useAuth} from 'Auth/AuthContext';

--- a/frontend/src/Modules/Auth/forms/NewEmailForm.tsx
+++ b/frontend/src/Modules/Auth/forms/NewEmailForm.tsx
@@ -1,4 +1,5 @@
 // Modules/Auth/forms/NewEmailForm.tsx
+"use client";
 import React, {ChangeEvent, useState} from 'react';
 import {useTranslation} from 'react-i18next';
 import TextField from '@mui/material/TextField';

--- a/frontend/src/Modules/Auth/forms/NewPhoneForm.tsx
+++ b/frontend/src/Modules/Auth/forms/NewPhoneForm.tsx
@@ -1,4 +1,5 @@
 // Modules/Auth/forms/NewPhoneForm.tsx
+"use client";
 import React, {useState} from 'react';
 import {useTranslation} from 'react-i18next';
 import PhoneField from "Core/components/elements/PhoneField/PhoneField";

--- a/frontend/src/Modules/Auth/forms/SignUpForm.tsx
+++ b/frontend/src/Modules/Auth/forms/SignUpForm.tsx
@@ -1,4 +1,5 @@
 // Modules/Auth/forms/SignUpForm.tsx
+"use client";
 import React, {useEffect, useRef, useState} from 'react';
 import {useTranslation} from 'react-i18next';
 import ConfirmationCode, {ConfirmationMethod} from 'Confirmation/ConfirmationCode';

--- a/frontend/src/Modules/Chat/Chat.tsx
+++ b/frontend/src/Modules/Chat/Chat.tsx
@@ -1,4 +1,5 @@
 // Modules/Chat/Chat.tsx
+"use client";
 import React, {useEffect, useMemo, useState} from 'react';
 import {useTranslation} from 'react-i18next';
 import {Outlet, useLocation, useNavigate} from 'Utils/nextRouter';

--- a/frontend/src/Modules/Chat/MessagesList.tsx
+++ b/frontend/src/Modules/Chat/MessagesList.tsx
@@ -1,4 +1,5 @@
 // Modules/Chat/MessagesList.tsx
+"use client";
 
 import React from 'react';
 import CircularProgressZoomify from 'Core/components/elements/CircularProgressZoomify';

--- a/frontend/src/Modules/Chat/Room.tsx
+++ b/frontend/src/Modules/Chat/Room.tsx
@@ -1,4 +1,5 @@
 // Modules/Chat/Room.tsx
+"use client";
 import React, {RefObject, useCallback, useEffect, useState} from 'react';
 import {useTranslation} from 'react-i18next';
 import {useParams} from 'Utils/nextRouter';

--- a/frontend/src/Modules/Chat/RoomHeader.tsx
+++ b/frontend/src/Modules/Chat/RoomHeader.tsx
@@ -1,4 +1,5 @@
 // Modules/Chat/RoomHeader.tsx
+"use client";
 
 import React, {useMemo} from 'react';
 import {IconButton, useMediaQuery} from '@mui/material';

--- a/frontend/src/Modules/Chat/RoomItem.tsx
+++ b/frontend/src/Modules/Chat/RoomItem.tsx
@@ -1,4 +1,5 @@
 // Modules/Chat/RoomItem.tsx
+"use client";
 
 import React, {useMemo} from 'react';
 import {useTranslation} from 'react-i18next';

--- a/frontend/src/Modules/Chat/RoomMessage.tsx
+++ b/frontend/src/Modules/Chat/RoomMessage.tsx
@@ -1,4 +1,5 @@
 // Modules/Chat/RoomMessage.tsx
+"use client";
 
 import React, {useCallback, useState} from 'react';
 import UserAvatar from "User/UserAvatar";

--- a/frontend/src/Modules/Chat/RoomWith.tsx
+++ b/frontend/src/Modules/Chat/RoomWith.tsx
@@ -1,4 +1,5 @@
 // Modules/Chat/RoomWith.tsx
+"use client";
 
 import React, {useEffect, useState} from 'react';
 import {useAuth} from 'Auth/AuthContext';

--- a/frontend/src/Modules/Client/ClientPersonalInfoForm.tsx
+++ b/frontend/src/Modules/Client/ClientPersonalInfoForm.tsx
@@ -1,4 +1,5 @@
 // Modules/Client/ClientPersonalInfoForm.tsx
+"use client";
 import React, {ChangeEvent, FormEvent, useState} from 'react';
 import {useTranslation} from 'react-i18next';
 import {useAuth} from "Auth/AuthContext";

--- a/frontend/src/Modules/Core/ParallaxLogo.tsx
+++ b/frontend/src/Modules/Core/ParallaxLogo.tsx
@@ -1,4 +1,5 @@
 // Modules/Core/ParallaxLogo.tsx
+"use client";
 import React, {RefObject, useCallback} from 'react';
 import {useTranslation} from 'react-i18next';
 import {useNavigate} from 'Utils/nextRouter';

--- a/frontend/src/Modules/Core/SettingsTool.tsx
+++ b/frontend/src/Modules/Core/SettingsTool.tsx
@@ -1,4 +1,5 @@
 // Modules/Core/SettingsTool.tsx
+"use client";
 import React, {useCallback, useEffect, useState} from 'react';
 import Dialog from '@mui/material/Dialog';
 import DialogContent from '@mui/material/DialogContent';

--- a/frontend/src/Modules/Core/components/Header/Header.tsx
+++ b/frontend/src/Modules/Core/components/Header/Header.tsx
@@ -1,4 +1,5 @@
 // Modules/Core/components/Header/Header.tsx
+"use client";
 import React, {useRef} from 'react';
 import './Header.sass';
 import {useAuth} from "Auth/AuthContext";

--- a/frontend/src/Modules/Order/BalanceTopUpDialog.tsx
+++ b/frontend/src/Modules/Order/BalanceTopUpDialog.tsx
@@ -1,4 +1,5 @@
 // Modules/Order/BalanceTopUpDialog.tsx
+"use client";
 import React, {useEffect, useState} from 'react';
 import {useTranslation} from 'react-i18next';
 import {Button, Dialog, DialogContent, DialogTitle, TextField} from '@mui/material';

--- a/frontend/src/Modules/Order/OrderActions.tsx
+++ b/frontend/src/Modules/Order/OrderActions.tsx
@@ -1,4 +1,5 @@
 // Modules/Order/OrderActions.tsx
+"use client";
 import React, {useState} from 'react';
 import {useTranslation} from 'react-i18next';
 import {useNavigate, useSearchParams} from 'Utils/nextRouter';

--- a/frontend/src/Modules/Order/OrderDetail.tsx
+++ b/frontend/src/Modules/Order/OrderDetail.tsx
@@ -1,4 +1,5 @@
 // Modules/Order/OrderDetail.tsx
+"use client";
 import React, {useEffect, useState} from 'react';
 import {useNavigate, useParams} from 'Utils/nextRouter';
 import CircularProgressZoomify from "Core/components/elements/CircularProgressZoomify";

--- a/frontend/src/Modules/Order/UserOrders.tsx
+++ b/frontend/src/Modules/Order/UserOrders.tsx
@@ -1,4 +1,5 @@
 // Modules/Order/UserOrders.tsx
+"use client";
 import React, {useEffect, useState} from 'react';
 import {useNavigate} from 'Utils/nextRouter';
 import {useErrorProcessing} from 'Core/components/ErrorProvider';

--- a/frontend/src/Modules/Software/Macros/MacrosExecutorForm.tsx
+++ b/frontend/src/Modules/Software/Macros/MacrosExecutorForm.tsx
@@ -1,4 +1,5 @@
 // Modules/Software/Macros/MacrosExecutorForm.tsx
+"use client";
 import React, {useState} from 'react';
 import {useAuth} from 'Auth/AuthContext';
 import {Message} from 'Core/components/Message';

--- a/frontend/src/Modules/Software/SoftwareOrder.tsx
+++ b/frontend/src/Modules/Software/SoftwareOrder.tsx
@@ -1,4 +1,5 @@
 // Modules/Software/SoftwareOrder.tsx
+"use client";
 import React, {useEffect, useState} from 'react';
 import {useTranslation} from 'react-i18next';
 import {Button, Collapse, Dialog, DialogContent, DialogTitle, IconButton, Slider, useMediaQuery} from '@mui/material';

--- a/frontend/src/Modules/Software/SoftwareTestPeriodButton.tsx
+++ b/frontend/src/Modules/Software/SoftwareTestPeriodButton.tsx
@@ -1,4 +1,5 @@
 // Modules/Software/SoftwareTestPeriodButton.tsx
+"use client";
 import React, {useState} from 'react';
 import {useTranslation} from 'react-i18next';
 import {Button} from "@mui/material";

--- a/frontend/src/Modules/User/Profile.tsx
+++ b/frontend/src/Modules/User/Profile.tsx
@@ -1,4 +1,5 @@
 // Modules/User/Profile.tsx
+"use client";
 import React, {useEffect} from 'react';
 import {Route, Routes, useLocation, useNavigate} from 'Utils/nextRouter';
 import {FC, FRS} from 'wide-containers';

--- a/frontend/src/Modules/User/ProfileContext.tsx
+++ b/frontend/src/Modules/User/ProfileContext.tsx
@@ -1,4 +1,5 @@
 // Modules/User/ProfileContext.tsx
+"use client";
 import React, {createContext, ReactNode, useContext, useEffect, useState} from 'react';
 import {useNavigate} from 'Utils/nextRouter';
 import {useAuth} from "Auth/AuthContext";

--- a/frontend/src/Modules/User/UserAvatarEditable.tsx
+++ b/frontend/src/Modules/User/UserAvatarEditable.tsx
@@ -1,4 +1,5 @@
 // Modules/User/UserAvatarEditable.tsx
+"use client";
 import React, {ChangeEvent, useRef, useState} from 'react';
 import {useTranslation} from 'react-i18next';
 import UserAvatar from 'User/UserAvatar';

--- a/frontend/src/Modules/User/UserPersonalInfoForm.tsx
+++ b/frontend/src/Modules/User/UserPersonalInfoForm.tsx
@@ -1,4 +1,5 @@
 // Modules/User/UserPersonalInfoForm.tsx
+"use client";
 import React, {FormEvent, useEffect, useState} from 'react';
 import {useTranslation} from 'react-i18next';
 import {format} from 'date-fns';

--- a/frontend/src/Modules/xLMine/Donate/DonateModal.tsx
+++ b/frontend/src/Modules/xLMine/Donate/DonateModal.tsx
@@ -1,4 +1,5 @@
 // Modules/xLMine/Donate/DonateModal.tsx
+"use client";
 import React, {useEffect, useState} from "react";
 import {useTranslation} from 'react-i18next';
 import Modal from "@mui/material/Modal";

--- a/frontend/src/Modules/xLMine/xLMineProfileInfoForm.tsx
+++ b/frontend/src/Modules/xLMine/xLMineProfileInfoForm.tsx
@@ -1,4 +1,5 @@
 // Modules/xLMine/xLMineProfileInfoForm.tsx
+"use client";
 import React, {useEffect, useState} from 'react';
 import {FC, FR, FRSC} from 'wide-containers';
 import SkinCapeSetter from './SkinCape/SkinCapeSetter';


### PR DESCRIPTION
## Summary
- add explicit `"use client"` directive to components that rely on `useAuth`
- avoid `useAuth must be used within an AuthProvider` build errors

## Testing
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895f49fc16c8330a57813366044cb5f