### PR TITLE
fix: avoid auth context access during provider init

### DIFF
--- a/frontend/src/Modules/Api/useApi.ts
+++ b/frontend/src/Modules/Api/useApi.ts
@@ -1,9 +1,9 @@
 // Modules/Api/useApi.ts
 "use client";
 import axios, {AxiosInstance, AxiosRequestConfig, AxiosResponse, InternalAxiosRequestConfig,} from 'axios';
-import {useEffect, useRef} from 'react';
+import {useEffect, useRef, useContext} from 'react';
 import {ErrorContextType, useErrorProcessing} from 'Core/components/ErrorProvider';
-import {useAuth} from 'Auth/AuthContext';
+import {AuthContext} from 'Auth/AuthContext';
 import {API_BASE_URL} from './axiosConfig';
 
 type AxiosConfig = AxiosRequestConfig | undefined;
@@ -52,7 +52,7 @@ export const useApi = () => {
         byRespRef.current = byResponse;
     }, [byResponse]);
 
-    const authCtx = useAuth();
+    const authCtx = useContext(AuthContext);
     const frontendLogoutRef = useRef<() => void>(() => {
     });
     useEffect(() => {

--- a/frontend/src/Modules/Auth/useAuthApi.ts
+++ b/frontend/src/Modules/Auth/useAuthApi.ts
@@ -1,3 +1,4 @@
+"use client";
 import {useApi} from 'Api/useApi';
 import {JWTPair} from 'types/core/auth';
 import {IUser} from 'types/core/user';

--- a/frontend/src/Modules/Chat/useRoomSocket.ts
+++ b/frontend/src/Modules/Chat/useRoomSocket.ts
@@ -1,4 +1,5 @@
 // Modules/Chat/useRoomSocket.ts
+"use client";
 
 import {useCallback} from 'react';
 import {IMessage} from 'types/chat/models';

--- a/frontend/src/Modules/Chat/useWebSocket.ts
+++ b/frontend/src/Modules/Chat/useWebSocket.ts
@@ -1,4 +1,5 @@
 // Modules/Chat/useWebSocket.ts
+"use client";
 
 import {useCallback, useEffect, useRef} from 'react';
 import {useAuthApi} from 'Auth/useAuthApi';


### PR DESCRIPTION
## Summary
- prevent `useApi` from crashing during AuthProvider init by safely reading auth context
- mark several hooks as client components

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/eslint)*
- `npm run build` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895f8005fd08330b3e035eee346f941