### PR TITLE
fix: wrap layout with suspense for search params

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -10,6 +10,7 @@ import "bootstrap/dist/css/bootstrap.min.css";
 import "react-toastify/dist/ReactToastify.css";
 import Providers from "../providers";
 import LayoutClient from "./LayoutClient";
+import {Suspense} from "react";
 
 const geistSans = Geist({
     variable: "--font-geist-sans",
@@ -47,9 +48,11 @@ export default function RootLayout({
             className={`${geistSans.variable} ${geistMono.variable} ${nunito.variable} ${robotoMono.variable}`}
         >
         <body style={{fontFamily: 'var(--font-nunito)'}}>
-        <Providers>
-            <LayoutClient>{children}</LayoutClient>
-        </Providers>
+        <Suspense fallback={null}>
+            <Providers>
+                <LayoutClient>{children}</LayoutClient>
+            </Providers>
+        </Suspense>
         </body>
         </html>
     );


### PR DESCRIPTION
## Summary
- wrap app layout with a Suspense boundary to allow useSearchParams in header and providers

## Testing
- `npm run build` *(fails: next: not found – package not available)*

------
https://chatgpt.com/codex/tasks/task_e_6895faaf90188330912221950aabcdd6