### PR TITLE
Refactor API hooks and enable SSR for software pages

### DIFF
--- a/frontend/src/Modules/Api/axiosConfig.tsx
+++ b/frontend/src/Modules/Api/axiosConfig.tsx
@@ -1,5 +1,5 @@
 // Modules/Api/axiosConfig.tsx
-import axios from 'axios';
+// Содержит только константы конфигурации API. Сам Axios-инстанс создаётся в useApi.ts.
 
 const isClient = typeof window !== 'undefined';
 const isHttps = isClient && window.location.protocol === 'https:';
@@ -26,41 +26,3 @@ export const DOMAIN_URL = isClient
     : (process.env.NEXT_PUBLIC_APP_ORIGIN as string || 'http://localhost:3000');
 
 export const DOMAIN_URL_ENCODED = encodeURIComponent(DOMAIN_URL);
-
-const axiosInstance = axios.create({baseURL: API_BASE_URL});
-
-function getCookie(name: string): string | null {
-    if (typeof document === 'undefined' || !document.cookie) return null;
-    const xsrfCookies = document.cookie
-        .split(';')
-        .map(c => c.trim())
-        .filter(c => c.startsWith(`${name}=`));
-    if (xsrfCookies.length === 0) return null;
-    return decodeURIComponent(xsrfCookies[0].split('=')[1]);
-}
-
-axiosInstance.interceptors.request.use(
-    (config) => {
-        if (typeof localStorage !== 'undefined') {
-            const token = localStorage.getItem('access');
-            if (token) (config.headers as any).Authorization = `Bearer ${token}`;
-        }
-        const csrfToken = getCookie('csrftoken');
-        if (csrfToken) (config.headers as any)['X-CSRFToken'] = csrfToken;
-        return config;
-    },
-    (error) => Promise.reject(error),
-);
-
-axiosInstance.interceptors.response.use(
-    (response) => response,
-    (error) => {
-        if (error?.response?.status === 401 && typeof localStorage !== 'undefined') {
-            localStorage.removeItem('access');
-            localStorage.removeItem('refresh');
-        }
-        throw error;
-    },
-);
-
-export {axiosInstance as axios};

--- a/frontend/src/Modules/Auth/useAuthApi.ts
+++ b/frontend/src/Modules/Auth/useAuthApi.ts
@@ -1,12 +1,13 @@
 "use client";
 import {useApi} from 'Api/useApi';
+import {useMemo} from 'react';
 import {JWTPair} from 'types/core/auth';
 import {IUser} from 'types/core/user';
 
 export const useAuthApi = () => {
     const {api} = useApi();
 
-    return {
+    return useMemo(() => ({
         login: (username: string, password: string) =>
             api.post<JWTPair>('/api/v1/token/', {username, password}),
         logout: () => api.post('/api/v1/logout/'),
@@ -20,7 +21,7 @@ export const useAuthApi = () => {
         checkEmailExists: (email: string) => api.post('/api/v1/check-email-exists/', {email}),
         signup: (payload: unknown) => api.post('/api/v1/signup/', payload),
         getAuthMethods: (credential: string) => api.post('/api/v1/user/auth_methods/', {credential}),
-    };
+    }), [api]);
 };
 
 export type UseAuthApi = ReturnType<typeof useAuthApi>;

--- a/frontend/src/Modules/Chat/useChatApi.ts
+++ b/frontend/src/Modules/Chat/useChatApi.ts
@@ -1,16 +1,17 @@
 import {useApi} from 'Api/useApi';
+import {useMemo} from 'react';
 import {IRoom} from 'types/chat/models';
 
 export const useChatApi = () => {
     const {api} = useApi();
-    return {
+    return useMemo(() => ({
         listRooms: () => api.get<{ results: IRoom[]; next: string | null }>("/api/v1/rooms/"),
         listRoomsByUrl: (url: string) => api.get<{ results: IRoom[]; next: string | null }>(url),
         getRoom: (roomId: number | string) => api.get(`/api/v1/rooms/${roomId}/`),
         getPersonalRoomWith: (userId: number | string) => api.get<IRoom>(`/api/v1/rooms/personal/with/${userId}/`),
         listMessages: (roomId: number | string, url?: string) =>
             api.get(url || `/api/v1/rooms/${roomId}/messages/`),
-    };
+    }), [api]);
 };
 
 export type UseChatApi = ReturnType<typeof useChatApi>;

--- a/frontend/src/Modules/Client/useClientApi.ts
+++ b/frontend/src/Modules/Client/useClientApi.ts
@@ -1,13 +1,14 @@
 import {useApi} from 'Api/useApi';
+import {useMemo} from 'react';
 
 export const useClientApi = () => {
     const {api} = useApi();
-    return {
+    return useMemo(() => ({
         updateClient: (formData: FormData) =>
             api.patch('/api/v1/client/update/', formData, {
                 headers: {'Content-Type': 'multipart/form-data'},
             }),
-    };
+    }), [api]);
 };
 
 export type UseClientApi = ReturnType<typeof useClientApi>;

--- a/frontend/src/Modules/Company/useCompanyApi.ts
+++ b/frontend/src/Modules/Company/useCompanyApi.ts
@@ -1,12 +1,13 @@
 "use client";
 import {useApi} from 'Api/useApi';
+import {useMemo} from 'react';
 
 export const useCompanyApi = () => {
     const {api} = useApi();
-    return {
+    return useMemo(() => ({
         getCompany: (name: string) => api.get(`/api/v1/companies/${encodeURIComponent(name)}/`),
         getDocument: (id: number | string) => api.get(`/api/v1/docs/${id}/`),
-    };
+    }), [api]);
 };
 
 export type UseCompanyApi = ReturnType<typeof useCompanyApi>;

--- a/frontend/src/Modules/Confirmation/useConfirmationApi.ts
+++ b/frontend/src/Modules/Confirmation/useConfirmationApi.ts
@@ -1,13 +1,14 @@
 "use client";
 import {useApi} from 'Api/useApi';
+import {useMemo} from 'react';
 
 export const useConfirmationApi = () => {
     const {api} = useApi();
-    return {
+    return useMemo(() => ({
         confirmCode: (payload: unknown) => api.post('/api/v1/confirmation-code/confirm/', payload),
         sendCode: (payload: unknown, isResend: boolean) =>
             api.post(isResend ? '/api/v1/confirmation-code/resend/' : '/api/v1/confirmation-code/new/', payload),
-    };
+    }), [api]);
 };
 
 export type UseConfirmationApi = ReturnType<typeof useConfirmationApi>;

--- a/frontend/src/Modules/Converter/useConverterApi.ts
+++ b/frontend/src/Modules/Converter/useConverterApi.ts
@@ -1,17 +1,18 @@
 "use client";
 import {useApi} from 'Api/useApi';
+import {useMemo} from 'react';
 import {IConvertResult, IFormat, IParameter} from 'types/converter';
 
 export const useConverterApi = () => {
     const {api} = useApi();
-    return {
+    return useMemo(() => ({
         listFormats: () => api.get<IFormat[]>('/api/v1/converter/formats/'),
         getRemaining: () => api.get<{ remaining: number }>('/api/v1/converter/remaining/'),
         listFormatVariants: (id: number) => api.get<IFormat[]>(`/api/v1/converter/formats/${id}/variants/`),
         listFormatParameters: (id: number) => api.get<IParameter[]>(`/api/v1/converter/formats/${id}/parameters/`),
         convert: (formData: FormData) => api.post<IConvertResult>('/api/v1/converter/convert/', formData),
         getDownloadLink: (id: number | string) => `/api/v1/converter/download/${id}/`,
-    };
+    }), [api]);
 };
 
 export type UseConverterApi = ReturnType<typeof useConverterApi>;

--- a/frontend/src/Modules/Core/useCoreApi.ts
+++ b/frontend/src/Modules/Core/useCoreApi.ts
@@ -1,11 +1,12 @@
 import {useApi} from 'Api/useApi';
+import {useMemo} from 'react';
 
 export const useCoreApi = () => {
     const {api} = useApi();
-    return {
+    return useMemo(() => ({
         setLang: (lang: string) => api.post('/api/v1/user/set-lang/', {lang}, undefined, true),
         getBackendConfig: () => api.get('/api/v1/backend/config/'),
-    };
+    }), [api]);
 };
 
 export type UseCoreApi = ReturnType<typeof useCoreApi>;

--- a/frontend/src/Modules/FileHost/useFileHostApi.ts
+++ b/frontend/src/Modules/FileHost/useFileHostApi.ts
@@ -1,10 +1,11 @@
 import {useApi} from 'Api/useApi';
+import {useMemo} from 'react';
 import type {AxiosRequestConfig} from 'axios';
 import type {FolderContent} from './storageCache';
 
 export const useFileHostApi = () => {
     const {api} = useApi();
-    return {
+    return useMemo(() => ({
         toggleFavorite: (file_id: number) => api.post('/api/v1/filehost/files/toggle_favorite/', {file_id}),
         listAccess: (file_id: number) => api.get(`/api/v1/filehost/access/list/?file_id=${file_id}`),
         grantAccess: (payload: any) => api.post('/api/v1/filehost/access/grant/', payload),
@@ -26,7 +27,7 @@ export const useFileHostApi = () => {
         moveItem: (item_id: number, new_folder_id: number | null) => api.post('/api/v1/filehost/item/move/', {item_id, new_folder_id}),
         renameItem: (item_id: number, new_name: string) => api.post('/api/v1/filehost/item/rename/', {item_id, new_name}),
         getFolder: (id: number) => api.post('/api/v1/filehost/folder/', {id}),
-    };
+    }), [api]);
 };
 
 export type UseFileHostApi = ReturnType<typeof useFileHostApi>;

--- a/frontend/src/Modules/Order/useOrderApi.ts
+++ b/frontend/src/Modules/Order/useOrderApi.ts
@@ -1,8 +1,9 @@
 import {useApi} from 'Api/useApi';
+import {useMemo} from 'react';
 
 export const useOrderApi = () => {
     const {api} = useApi();
-    return {
+    return useMemo(() => ({
         getUserBalance: () => api.get('/api/v1/user/balance/'),
         getLatestBalanceProduct: () => api.get('/api/v1/balance/product/latest/'),
         createOrder: (payload: unknown) => api.post('/api/v1/orders/create/', payload),
@@ -17,7 +18,7 @@ export const useOrderApi = () => {
         deleteOrder: (id: number | string) => api.post(`/api/v1/orders/${id}/delete/`),
         resendPaymentNotification: (id: number | string) =>
             api.post(`/api/v1/orders/${id}/resend_payment_notification/`),
-    };
+    }), [api]);
 };
 
 export type UseOrderApi = ReturnType<typeof useOrderApi>;

--- a/frontend/src/Modules/Software/SoftwareDetail.tsx
+++ b/frontend/src/Modules/Software/SoftwareDetail.tsx
@@ -24,7 +24,11 @@ import useMediaQuery from '@mui/material/useMediaQuery';
 import Collapse from '@mui/material/Collapse';
 import Head from "Core/components/Head";
 
-const SoftwareDetail: React.FC = () => {
+interface SoftwareDetailProps {
+    initialSoftware?: ISoftware;
+}
+
+const SoftwareDetail: React.FC<SoftwareDetailProps> = ({initialSoftware}) => {
     const {id} = useParams();
     const {isAuthenticated} = useAuth();
     const {plt} = useTheme();
@@ -32,8 +36,8 @@ const SoftwareDetail: React.FC = () => {
     const navigate = useNavigate();
     const {t} = useTranslation();
 
-    const [software, setSoftware] = useState<ISoftware | null>(null);
-    const [loading, setLoading] = useState(true);
+    const [software, setSoftware] = useState<ISoftware | null>(initialSoftware ?? null);
+    const [loading, setLoading] = useState(!initialSoftware);
     const [animate, setAnimate] = useState(false);          // ← NEW
     const [isLogModalOpen, setIsLogModalOpen] = useState(false);
 
@@ -46,18 +50,19 @@ const SoftwareDetail: React.FC = () => {
 
     /* ---------- загрузка Software ---------- */
     useEffect(() => {
-        setLoading(true);
-        setAnimate(false);
-        if (!id) {
+        const softwareId = initialSoftware?.id ?? id;
+        if (!software && softwareId) {
+            setLoading(true);
+            setAnimate(false);
+            getSoftware(softwareId as any)
+                .then(data => setSoftware(data))
+                .catch(() => Message.error(t('software_load_error')))
+                .finally(() => setLoading(false));
+        } else if (!softwareId) {
             Message.error(t('software_id_not_provided'));
             setLoading(false);
-            return;
         }
-        getSoftware(id as any)
-            .then(data => setSoftware(data))
-            .catch(() => Message.error(t('software_load_error')))
-            .finally(() => setLoading(false));
-    }, [id, getSoftware, t]);
+    }, [initialSoftware, id, software, getSoftware, t]);
 
     /* ---------- старт анимации контента после загрузки ---------- */
     useEffect(() => {

--- a/frontend/src/Modules/Software/Softwares.tsx
+++ b/frontend/src/Modules/Software/Softwares.tsx
@@ -11,9 +11,13 @@ import {useTranslation} from 'react-i18next';
 import Collapse from '@mui/material/Collapse';
 import {useSoftwareApi} from './useSoftwareApi';
 
-const Softwares: React.FC = () => {
-    const [softwares, setSoftwares] = useState<ISoftware[]>([]);
-    const [loading, setLoading] = useState(true);
+interface SoftwaresProps {
+    initialSoftwares?: ISoftware[];
+}
+
+const Softwares: React.FC<SoftwaresProps> = ({initialSoftwares = []}) => {
+    const [softwares, setSoftwares] = useState<ISoftware[]>(initialSoftwares);
+    const [loading, setLoading] = useState(initialSoftwares.length === 0);
     const [animate, setAnimate] = useState(false);
     const navigate = useNavigate();
     const {plt} = useTheme();
@@ -21,16 +25,21 @@ const Softwares: React.FC = () => {
     const {t} = useTranslation();
 
     useEffect(() => {
-        setLoading(true);
-        setAnimate(false);
-        listSoftware()
-            .then(data => setSoftwares(data))
-            .finally(() => setLoading(false));
-    }, [listSoftware]);
+        if (initialSoftwares.length === 0) {
+            setLoading(true);
+            setAnimate(false);
+            listSoftware()
+                .then(data => setSoftwares(data))
+                .finally(() => setLoading(false));
+        } else {
+            setLoading(false);
+        }
+    }, [initialSoftwares.length, listSoftware]);
 
     useEffect(() => {
         if (!loading) {
-            setTimeout(() => setAnimate(true), 50)
+            const t = setTimeout(() => setAnimate(true), 50);
+            return () => clearTimeout(t);
         }
     }, [loading]);
 

--- a/frontend/src/Modules/Software/useSoftwareApi.ts
+++ b/frontend/src/Modules/Software/useSoftwareApi.ts
@@ -1,8 +1,9 @@
 import {useApi} from 'Api/useApi';
+import {useMemo} from 'react';
 
 export const useSoftwareApi = () => {
     const {api} = useApi();
-    return {
+    return useMemo(() => ({
         listLicenses: () => api.get('/api/v1/software/licenses/'),
         listSoftware: () => api.get('/api/v1/software/'),
         getSoftware: (id: number | string) => api.get(`/api/v1/software/${id}/`),
@@ -12,7 +13,7 @@ export const useSoftwareApi = () => {
         deleteWirelessMacro: (id: number | string) => api.delete(`/api/v1/wireless-macros/${id}/`),
         updateWirelessMacro: (id: number | string, payload: unknown) => api.put(`/api/v1/wireless-macros/${id}/`, payload),
         createWirelessMacro: (payload: unknown) => api.post('/api/v1/wireless-macros/', payload),
-    };
+    }), [api]);
 };
 
 export type UseSoftwareApi = ReturnType<typeof useSoftwareApi>;

--- a/frontend/src/Modules/Theme/useThemeApi.ts
+++ b/frontend/src/Modules/Theme/useThemeApi.ts
@@ -1,10 +1,11 @@
 import {useApi} from 'Api/useApi';
+import {useMemo} from 'react';
 
 export const useThemeApi = () => {
     const {api} = useApi();
-    return {
+    return useMemo(() => ({
         getThemes: () => api.get('/api/v1/themes/'),
-    };
+    }), [api]);
 };
 
 export type UseThemeApi = ReturnType<typeof useThemeApi>;

--- a/frontend/src/Modules/User/useUserApi.ts
+++ b/frontend/src/Modules/User/useUserApi.ts
@@ -1,14 +1,15 @@
 import {useApi} from 'Api/useApi';
+import {useMemo} from 'react';
 
 export const useUserApi = () => {
     const {api} = useApi();
-    return {
+    return useMemo(() => ({
         updateAvatar: (formData: FormData) =>
             api.patch('/api/v1/user/update/avatar/', formData, {
                 headers: {'Content-Type': 'multipart/form-data'},
             }),
         updateInfo: (payload: unknown) => api.patch('/api/v1/user/update/', payload),
-    };
+    }), [api]);
 };
 
 export type UseUserApi = ReturnType<typeof useUserApi>;

--- a/frontend/src/Modules/xLMine/useXLMineApi.ts
+++ b/frontend/src/Modules/xLMine/useXLMineApi.ts
@@ -1,9 +1,10 @@
 import {useApi} from 'Api/useApi';
+import {useMemo} from 'react';
 
 export const useXLMineApi = () => {
     const {api} = useApi();
 
-    return {
+    return useMemo(() => ({
         // Launcher endpoints
         getLaunchers: () => api.get('/api/v1/xlmine/launcher/'),
         createLauncher: (formData: FormData) =>
@@ -39,7 +40,7 @@ export const useXLMineApi = () => {
         // Donate
         getLatestDonateProduct: () => api.get('/api/v1/xlmine/donate/product/latest/'),
         createOrder: (payload: unknown) => api.post('/api/v1/orders/create/', payload),
-    };
+    }), [api]);
 };
 
 export type UseXLMineApi = ReturnType<typeof useXLMineApi>;

--- a/frontend/src/app/LayoutClient.tsx
+++ b/frontend/src/app/LayoutClient.tsx
@@ -11,6 +11,7 @@ import {useTheme} from "Theme/ThemeContext";
 import {useNavigation} from "Core/components/Header/HeaderProvider";
 import {useSelector} from "react-redux";
 import {RootState} from "Redux/store";
+import useMediaQuery from "@mui/material/useMediaQuery";
 
 const BackgroundFlicker = dynamic(() => import("Core/BackgroundFlicker"), {ssr: false});
 
@@ -18,7 +19,7 @@ export default function LayoutClient({children}: { children: React.ReactNode }) 
     const isHeaderVisible = useSelector((state: RootState) => state.visibility.isHeaderVisible);
     const {plt} = useTheme();
     const {headerNavHeight, mainRef} = useNavigation();
-    const isGt1000 = typeof window !== 'undefined' && window.innerWidth > 1000;
+    const isGt1000 = useMediaQuery('(min-width:1000px)');
     const isBackgroundFlickerEnabled = useSelector((state: RootState) => state.visibility.isBackgroundFlickerEnabled);
 
     return (

--- a/frontend/src/app/softwares/SoftwaresPageClient.tsx
+++ b/frontend/src/app/softwares/SoftwaresPageClient.tsx
@@ -3,11 +3,16 @@
 
 import Softwares from "../../Modules/Software/Softwares";
 import {FC} from "wide-containers";
+import {ISoftware} from "Software/Types/Software";
 
-export default function SoftwaresPageClient() {
+interface SoftwaresPageClientProps {
+    softwares: ISoftware[];
+}
+
+export default function SoftwaresPageClient({softwares}: SoftwaresPageClientProps) {
     return (
         <FC g={2} p={2} mx={"auto"} maxW={800}>
-            <Softwares/>
+            <Softwares initialSoftwares={softwares}/>
         </FC>
     );
 }

--- a/frontend/src/app/softwares/[id]/SoftwareDetailPageClient.tsx
+++ b/frontend/src/app/softwares/[id]/SoftwareDetailPageClient.tsx
@@ -2,25 +2,17 @@
 "use client";
 
 import {FC} from "wide-containers";
-import {useParams} from "next/navigation";
 import SoftwareDetail from "../../../Modules/Software/SoftwareDetail";
-import Providers from "../../../providers";
+import {ISoftware} from "Software/Types/Software";
 
-export default function SoftwareDetailPageClient() {
-    const params = useParams();
-    const id = params?.id;
-    console.log("SoftwareDetailPageClient useParams id =", id);
+interface SoftwareDetailPageClientProps {
+    software: ISoftware;
+}
 
-    if (!id) {
-        // защита на случай, если id всё ещё не прочитался
-        return <p>Software ID not specified</p>;
-    }
-
+export default function SoftwareDetailPageClient({software}: SoftwareDetailPageClientProps) {
     return (
-        <Providers>
-            <FC g={2} p={2} mx={"auto"} maxW={700}>
-                <SoftwareDetail/>
-            </FC>
-        </Providers>
+        <FC g={2} p={2} mx={"auto"} maxW={700}>
+            <SoftwareDetail initialSoftware={software}/>
+        </FC>
     );
 }

--- a/frontend/src/app/softwares/[id]/page.tsx
+++ b/frontend/src/app/softwares/[id]/page.tsx
@@ -1,20 +1,33 @@
 // app/softwares/[id]/page.tsx
 import type {Metadata} from "next";
 import SoftwareDetailPageClient from "./SoftwareDetailPageClient";
+import {API_BASE_URL} from "Api/axiosConfig";
+import {ISoftware} from "Software/Types/Software";
+import {cookies} from "next/headers";
 
 interface PageProps {
-    params: Promise<{ id: string }>;
+    params: { id: string };
 }
 
 export async function generateMetadata({params}: PageProps): Promise<Metadata> {
-    const {id} = await params;
+    const {id} = params;
     return {
         title: `Software ${id} - XLARTAS`,
         description: `Details about software ${id} on XLARTAS platform`,
     };
 }
 
-export default function SoftwareDetailPage() {
-    // просто рендерим клиентский, без пропсов
-    return <SoftwareDetailPageClient/>;
+export const revalidate = 60;
+
+export default async function SoftwareDetailPage({params}: PageProps) {
+    const cookieStore = cookies();
+    const token = cookieStore.get('access')?.value;
+    const headers: Record<string, string> = {};
+    if (token) headers['Authorization'] = `Bearer ${token}`;
+    const res = await fetch(`${API_BASE_URL}/api/v1/software/${params.id}/`, {
+        headers,
+        next: {revalidate: 60},
+    });
+    const software: ISoftware = await res.json();
+    return <SoftwareDetailPageClient software={software}/>;
 }

--- a/frontend/src/app/softwares/page.tsx
+++ b/frontend/src/app/softwares/page.tsx
@@ -1,12 +1,26 @@
 // app/softwares/page.tsx
 import type {Metadata} from "next";
 import SoftwaresPageClient from "./SoftwaresPageClient";
+import {API_BASE_URL} from "Api/axiosConfig";
+import {ISoftware} from "Software/Types/Software";
+import {cookies} from "next/headers";
 
 export const metadata: Metadata = {
     title: "Softwares - XLARTAS",
     description: "Explore available software on XLARTAS platform",
 };
 
-export default function SoftwaresPage() {
-    return <SoftwaresPageClient/>;
+export const revalidate = 60;
+
+export default async function SoftwaresPage() {
+    const cookieStore = cookies();
+    const token = cookieStore.get('access')?.value;
+    const headers: Record<string, string> = {};
+    if (token) headers['Authorization'] = `Bearer ${token}`;
+    const res = await fetch(`${API_BASE_URL}/api/v1/software/`, {
+        headers,
+        next: {revalidate: 60},
+    });
+    const softwares: ISoftware[] = await res.json();
+    return <SoftwaresPageClient softwares={softwares}/>;
 }


### PR DESCRIPTION
## Summary
- memoize API hooks and centralize axios config
- server-side render software listing and details
- replace direct `window.innerWidth` access with `useMediaQuery`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next: not found)*
- `npm install --no-audit --no-fund` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68964d34e6088330895c3bc93171c91d