### PR TITLE
Ensure trailing slash on frontend API requests

### DIFF
--- a/frontend/src/Modules/Api/useApi.ts
+++ b/frontend/src/Modules/Api/useApi.ts
@@ -109,6 +109,12 @@ export const useApi = () => {
             if (csrfToken) {
                 (cfg.headers as any)['X-CSRFToken'] = csrfToken;
             }
+            if (cfg.url && cfg.url.startsWith('/')) {
+                const [path, query] = cfg.url.split('?');
+                if (!path.endsWith('/')) {
+                    cfg.url = path + '/' + (query ? '?' + query : '');
+                }
+            }
             (cfg as any)._ts = performance.now();
             logReq(cfg.method, cfg.url, cfg.data);
             return cfg;


### PR DESCRIPTION
## Summary
- append trailing slash to relative API requests to avoid backend redirect

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689698d69fa0833085422f7eb8a45d32